### PR TITLE
feat(android-sdk): M5 – Basic Chat UI – Phase 1 Complete (FDE-26)

### DIFF
--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -15,7 +15,14 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        YaloChat.init(YaloChatConfig())
+        YaloChat.init(
+            YaloChatConfig(
+                name = "Yalo Chat",
+                flowKey = "demo-flow-key",
+                authToken = "demo-auth-token",
+                userToken = "demo-user-token",
+            )
+        )
         setContent {
             ChatScreen()
         }

--- a/android-sdk/gradle/libs.versions.toml
+++ b/android-sdk/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }
+compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core" }
 
 # Activity
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.compose.ui.tooling.preview)
     implementation(libs.compose.material3)
     implementation(libs.compose.foundation)
+    implementation(libs.compose.material.icons.core)
     debugImplementation(libs.compose.ui.tooling)
 
     // Lifecycle / ViewModel

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -24,8 +24,12 @@ object YaloChat {
         val chatRepo = FakeChatMessageRepository(FakeYaloMessageRepository.SEED_MESSAGES)
         _viewModelFactory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
-            override fun <T : ViewModel> create(modelClass: Class<T>): T =
-                MessagesViewModel(yaloRepo, chatRepo) as T
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                require(modelClass.isAssignableFrom(MessagesViewModel::class.java)) {
+                    "Unsupported ViewModel class: $modelClass"
+                }
+                return MessagesViewModel(yaloRepo, chatRepo) as T
+            }
         }
     }
 

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -2,11 +2,33 @@
 
 package com.yalo.chat.sdk
 
-// Port of flutter-sdk YaloChat entry point — stub for Phase 1.
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
+import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.ui.chat.MessagesViewModel
+
+// Port of flutter-sdk YaloChat entry point.
 // Phase 2 wires real repos (Ktor networking, SQLDelight persistence) here.
 object YaloChat {
 
+    private var _config: YaloChatConfig? = null
+    private var _viewModelFactory: ViewModelProvider.Factory? = null
+
+    val config: YaloChatConfig
+        get() = _config ?: error("YaloChat.init() must be called before accessing config")
+
     fun init(config: YaloChatConfig) {
-        // No-op stub — real initialization added in Phase 2 (FDE-27, FDE-28).
+        _config = config
+        val yaloRepo = FakeYaloMessageRepository()
+        val chatRepo = FakeChatMessageRepository(FakeYaloMessageRepository.SEED_MESSAGES)
+        _viewModelFactory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T =
+                MessagesViewModel(yaloRepo, chatRepo) as T
+        }
     }
+
+    fun getViewModelFactory(): ViewModelProvider.Factory =
+        _viewModelFactory ?: error("YaloChat.init() must be called before rendering ChatScreen")
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChatConfig.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChatConfig.kt
@@ -2,8 +2,11 @@
 
 package com.yalo.chat.sdk
 
-// Port of flutter-sdk YaloChatConfig — placeholder for Phase 1.
-// Real fields (apiBaseUrl, authToken, userToken, flowKey, theme) added in Phase 2.
+// Port of flutter-sdk YaloChatConfig.
+// Phase 2 will add apiBaseUrl, theme, and other settings.
 data class YaloChatConfig(
-    val placeholder: Unit = Unit,
+    val name: String,
+    val flowKey: String,
+    val authToken: String,
+    val userToken: String,
 )

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
@@ -11,10 +11,12 @@ import kotlinx.coroutines.flow.asStateFlow
 
 // Phase 1 stub — in-memory list with StateFlow for reactive observation.
 // Replaced in Phase 2 by ChatMessageRepositoryLocal (SQLDelight, FDE-55).
-class FakeChatMessageRepository : ChatMessageRepository {
+class FakeChatMessageRepository(
+    initialMessages: List<ChatMessage> = emptyList(),
+) : ChatMessageRepository {
 
-    private val messages = mutableListOf<ChatMessage>()
-    private val _flow = MutableStateFlow<List<ChatMessage>>(emptyList())
+    private val messages = mutableListOf<ChatMessage>().apply { addAll(initialMessages) }
+    private val _flow = MutableStateFlow<List<ChatMessage>>(initialMessages)
 
     override suspend fun getMessages(cursor: Long?, limit: Int): Result<List<ChatMessage>> {
         val page = if (cursor == null) {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
@@ -16,7 +16,7 @@ class FakeChatMessageRepository(
 ) : ChatMessageRepository {
 
     private val messages = mutableListOf<ChatMessage>().apply { addAll(initialMessages) }
-    private val _flow = MutableStateFlow<List<ChatMessage>>(initialMessages)
+    private val _flow = MutableStateFlow<List<ChatMessage>>(initialMessages.toList())
 
     override suspend fun getMessages(cursor: Long?, limit: Int): Result<List<ChatMessage>> {
         val page = if (cursor == null) {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
@@ -2,11 +2,49 @@
 
 package com.yalo.chat.sdk.ui
 
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.yalo.chat.sdk.YaloChat
+import com.yalo.chat.sdk.ui.chat.ChatAppBar
+import com.yalo.chat.sdk.ui.chat.ChatInput
+import com.yalo.chat.sdk.ui.chat.MessageList
+import com.yalo.chat.sdk.ui.chat.MessagesEvent
+import com.yalo.chat.sdk.ui.chat.MessagesViewModel
 
-// Placeholder composable — full implementation in Milestone 5 (FDE-46).
+// Port of flutter-sdk Chat widget.
+// Scaffold mirrors Flutter's Scaffold: ChatAppBar (topBar), ChatInput (bottomBar),
+// MessageList (body) — LazyColumn with reverseLayout = true.
 @Composable
 fun ChatScreen() {
-    Text(text = "Chat SDK placeholder")
+    val viewModel: MessagesViewModel = viewModel(factory = YaloChat.getViewModelFactory())
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.handleEvent(MessagesEvent.LoadMessages)
+        viewModel.handleEvent(MessagesEvent.SubscribeToMessages)
+    }
+
+    Scaffold(
+        topBar = {
+            ChatAppBar(title = YaloChat.config.name)
+        },
+        bottomBar = {
+            ChatInput(
+                userMessage = state.userMessage,
+                onUserMessageChange = { viewModel.handleEvent(MessagesEvent.UpdateUserMessage(it)) },
+                onSendMessage = { viewModel.handleEvent(MessagesEvent.SendTextMessage(state.userMessage)) },
+            )
+        },
+    ) { paddingValues ->
+        MessageList(
+            messages = state.messages,
+            modifier = Modifier.padding(paddingValues),
+        )
+    }
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
@@ -1,0 +1,18 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+
+// Port of flutter-sdk ChatAppBar — Phase 1 shows name only (no icon/actions).
+// Phase 2 will add chatIconImage, shop/cart action buttons, and status text.
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatAppBar(title: String) {
+    TopAppBar(
+        title = { Text(text = title) },
+    )
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
@@ -1,0 +1,50 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+// Port of flutter-sdk ChatInput — Phase 1: text field + send button only.
+// Phase 2 will add attachment button, voice recorder, image preview, and quick replies.
+@Composable
+fun ChatInput(
+    userMessage: String,
+    onUserMessageChange: (String) -> Unit,
+    onSendMessage: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        TextField(
+            value = userMessage,
+            onValueChange = onUserMessageChange,
+            modifier = Modifier.weight(1f),
+            placeholder = { Text("Type a message…") },
+            singleLine = true,
+        )
+        IconButton(
+            onClick = onSendMessage,
+            enabled = userMessage.isNotBlank(),
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.Send,
+                contentDescription = "Send",
+            )
+        }
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -1,0 +1,59 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageType
+
+// Port of flutter-sdk Message + UserMessage + AssistantMessage.
+// Phase 1: text only; others rendered as "[type]" placeholder.
+// Phase 2 will add image, voice, product, productCarousel, promotion, quickReply widgets.
+@Composable
+fun MessageItem(message: ChatMessage) {
+    val isUser = message.role == MessageRole.USER
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 8.dp, vertical = 4.dp),
+        horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+    ) {
+        Surface(
+            shape = MaterialTheme.shapes.medium,
+            color = if (isUser) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.surfaceVariant,
+            modifier = Modifier.widthIn(max = 280.dp),
+        ) {
+            val textColor = if (isUser) MaterialTheme.colorScheme.onPrimary
+                            else MaterialTheme.colorScheme.onSurfaceVariant
+            Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
+                when (message.type) {
+                    MessageType.Text -> Text(
+                        text = message.content.orEmpty(),
+                        color = textColor,
+                    )
+                    MessageType.Unknown -> Text(
+                        text = "Unsupported message",
+                        color = textColor,
+                    )
+                    else -> Text(
+                        text = "[${message.type.value}]",
+                        color = textColor,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -41,7 +41,7 @@ fun MessageItem(message: ChatMessage) {
             Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                 when (message.type) {
                     MessageType.Text -> Text(
-                        text = message.content.orEmpty(),
+                        text = message.content,
                         color = textColor,
                     )
                     MessageType.Unknown -> Text(

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
@@ -1,0 +1,44 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.domain.model.ChatMessage
+
+// Port of flutter-sdk MessageList — reverse layout mirrors ListView.builder(reverse: true).
+// Items sorted newest-first so item[0] appears at the bottom of the reversed column.
+@Composable
+fun MessageList(
+    messages: List<ChatMessage>,
+    modifier: Modifier = Modifier,
+) {
+    if (messages.isEmpty()) {
+        Box(
+            modifier = modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(text = "No messages yet")
+        }
+        return
+    }
+    val sorted = messages.sortedByDescending { it.timestamp }
+    LazyColumn(
+        reverseLayout = true,
+        modifier = modifier
+            .fillMaxSize()
+            .padding(bottom = 4.dp),
+    ) {
+        items(items = sorted, key = { it.id ?: it.hashCode() }) { message ->
+            MessageItem(message = message)
+        }
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -30,14 +31,14 @@ fun MessageList(
         }
         return
     }
-    val sorted = messages.sortedByDescending { it.timestamp }
+    val sorted = remember(messages) { messages.sortedByDescending { it.timestamp } }
     LazyColumn(
         reverseLayout = true,
         modifier = modifier
             .fillMaxSize()
             .padding(bottom = 4.dp),
     ) {
-        items(items = sorted, key = { it.id ?: it.hashCode() }) { message ->
+        items(items = sorted, key = { it.id ?: it.wiId ?: it.timestamp }) { message ->
             MessageItem(message = message)
         }
     }


### PR DESCRIPTION
## Summary

- **YaloChatConfig** updated with real fields: `name`, `flowKey`, `authToken`, `userToken`
- **YaloChat.init()** wires fake repos via `ViewModelProvider.Factory` (no Hilt in `:sdk`); `getViewModelFactory()` throws a descriptive error if `init()` was not called
- **FakeChatMessageRepository** accepts `initialMessages` param — pre-seeded with `SEED_MESSAGES` so the demo shows messages on first launch
- **ChatScreen** — `Scaffold` wired to `MessagesViewModel` via `viewModel(factory = YaloChat.getViewModelFactory())`; `LaunchedEffect` triggers `LoadMessages` + `SubscribeToMessages`
- **ChatAppBar** — `TopAppBar` showing `YaloChat.config.name`
- **MessageList** — `LazyColumn(reverseLayout = true)`, messages sorted newest-first; mirrors Flutter's `ListView.builder(reverse: true)`; empty-state placeholder
- **MessageItem** — user messages right-aligned in primary bubble, agent messages left-aligned in surfaceVariant; `Text` renders content, `Unknown` renders "Unsupported message", others render `[type]` placeholder
- **ChatInput** — `TextField` + `IconButton` disabled when blank; all interaction via lambdas (no ViewModel reference inside)
- **MainActivity** — calls `YaloChat.init(YaloChatConfig(...))` with demo values

## Linear issues

- [FDE-26 – Basic Chat UI — Phase 1 Complete](https://linear.app/yalo/issue/FDE-26)
- [FDE-46 – Build ChatScreen, MessageList and MessageItem composables](https://linear.app/yalo/issue/FDE-46)
- [FDE-47 – Build ChatInput composable with defensive send guard](https://linear.app/yalo/issue/FDE-47)
- [FDE-48 – Implement YaloChat.init() manual DI entry point and wire ViewModel](https://linear.app/yalo/issue/FDE-48)

## Test plan

- [x] `./gradlew :sdk:testDebugUnitTest` — all tests pass
- [x] `./gradlew :app:assembleDebug` — demo app builds clean
- [x] Manual: install on emulator, confirm fake messages visible on launch
- [ ] Manual: user message appears right-aligned, agent left-aligned
- [ ] Manual: type text → Send button enables; clear → disables
- [ ] Manual: tap Send → message appears in list, input clears
- [ ] Manual: remove `YaloChat.init()` → descriptive error thrown (not NPE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)