### PR TITLE
feat(android-sdk): Phase 2 M1 — Networking Layer (FDE-27)

### DIFF
--- a/android-sdk/app/build.gradle.kts
+++ b/android-sdk/app/build.gradle.kts
@@ -17,7 +17,13 @@ val localProps = Properties().also { props ->
     if (file.exists()) props.load(file.inputStream())
 }
 
-fun localProp(key: String) = localProps.getProperty(key, "")
+fun localProp(key: String): String {
+    val value = localProps.getProperty(key, "")
+    if (value.isEmpty()) {
+        logger.warn("WARNING: local.properties is missing '$key'. Copy local.properties.example → local.properties and fill in the values. The demo app will fail at runtime.")
+    }
+    return value
+}
 
 android {
     namespace = "com.yalo.chat.demo"

--- a/android-sdk/app/build.gradle.kts
+++ b/android-sdk/app/build.gradle.kts
@@ -1,5 +1,7 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -7,6 +9,15 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
+
+// Read demo credentials from local.properties (never committed to git).
+// Copy local.properties.example → local.properties and fill in the values.
+val localProps = Properties().also { props ->
+    val file = rootProject.file("local.properties")
+    if (file.exists()) props.load(file.inputStream())
+}
+
+fun localProp(key: String) = localProps.getProperty(key, "")
 
 android {
     namespace = "com.yalo.chat.demo"
@@ -18,6 +29,11 @@ android {
         targetSdk = 35
         versionCode = 1
         versionName = "1.0"
+
+        buildConfigField("String", "YALO_API_BASE_URL", "\"${localProp("yalo.apiBaseUrl")}\"")
+        buildConfigField("String", "YALO_FLOW_KEY",    "\"${localProp("yalo.flowKey")}\"")
+        buildConfigField("String", "YALO_AUTH_TOKEN",  "\"${localProp("yalo.authToken")}\"")
+        buildConfigField("String", "YALO_USER_TOKEN",  "\"${localProp("yalo.userToken")}\"")
     }
 
     compileOptions {
@@ -27,6 +43,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 }
 

--- a/android-sdk/app/src/main/AndroidManifest.xml
+++ b/android-sdk/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <!-- Copyright (c) Yalochat, Inc. All rights reserved. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".DemoApplication"
         android:label="Yalo Chat Demo"

--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -21,6 +21,7 @@ class MainActivity : ComponentActivity() {
                 flowKey = "demo-flow-key",
                 authToken = "demo-auth-token",
                 userToken = "demo-user-token",
+                apiBaseUrl = "https://your-yalo-api-base-url", // TODO: replace with real URL
             )
         )
         setContent {

--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -18,10 +18,10 @@ class MainActivity : ComponentActivity() {
         YaloChat.init(
             YaloChatConfig(
                 name = "Yalo Chat",
-                flowKey = "demo-flow-key",
-                authToken = "demo-auth-token",
-                userToken = "demo-user-token",
-                apiBaseUrl = "https://your-yalo-api-base-url", // TODO: replace with real URL
+                flowKey = BuildConfig.YALO_FLOW_KEY,
+                authToken = BuildConfig.YALO_AUTH_TOKEN,
+                userToken = BuildConfig.YALO_USER_TOKEN,
+                apiBaseUrl = BuildConfig.YALO_API_BASE_URL,
             )
         )
         setContent {

--- a/android-sdk/gradle/libs.versions.toml
+++ b/android-sdk/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref =
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-android = { group = "io.ktor", name = "ktor-client-android", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 

--- a/android-sdk/gradle/libs.versions.toml
+++ b/android-sdk/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "8.7.3"
+kotlinxDatetime = "0.6.1"
 activityCompose = "1.10.1"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.27"
@@ -39,10 +40,14 @@ ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref =
 ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref = "ktor" }
 
 # kotlinx.serialization
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
+
+# kotlinx.datetime — KMP-compatible date/time (replaces java.util.Date / SimpleDateFormat)
+kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 
 # SQLDelight
 sqldelight-android-driver = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }

--- a/android-sdk/local.properties.example
+++ b/android-sdk/local.properties.example
@@ -1,0 +1,11 @@
+# Android SDK location (set automatically by Android Studio)
+sdk.dir=/path/to/Android/sdk
+
+# ── Yalo demo credentials ──────────────────────────────────────────────────────
+# Copy this file to local.properties and fill in the values.
+# local.properties is gitignored — credentials will never be committed.
+
+yalo.apiBaseUrl=https://your-yalo-api-base-url
+yalo.flowKey=your-flow-key
+yalo.authToken=your-auth-token
+yalo.userToken=your-user-token

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -24,6 +24,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     lint {
@@ -70,9 +71,13 @@ dependencies {
     implementation(libs.ktor.client.cio)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.logging)
 
     // kotlinx.serialization
     implementation(libs.kotlinx.serialization.json)
+
+    // kotlinx.datetime — KMP-compatible (replaces java.text.SimpleDateFormat)
+    implementation(libs.kotlinx.datetime)
 
     // SQLDelight — KMP-ready persistence (no Room)
     implementation(libs.sqldelight.android.driver)

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -66,12 +66,16 @@ dependencies {
     // Coroutines
     implementation(libs.coroutines.android)
 
-    // Ktor — KMP-ready HTTP client (no OkHttp)
+    // Ktor — HTTP client
+    // ktor-client-android uses Android's system HTTP stack (proper DNS resolution).
+    // ktor-client-cio kept for tests (MockEngine is engine-agnostic).
+    // When splitting to KMP: move ktor-client-android to androidMain, add Darwin for iosMain.
     implementation(libs.ktor.client.core)
-    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.android)
     implementation(libs.ktor.client.content.negotiation)
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.logging)
+    testImplementation(libs.ktor.client.cio)
 
     // kotlinx.serialization
     implementation(libs.kotlinx.serialization.json)

--- a/android-sdk/sdk/consumer-proguard-rules.pro
+++ b/android-sdk/sdk/consumer-proguard-rules.pro
@@ -14,11 +14,12 @@
 -keepclassmembers class kotlinx.serialization.json.** {
     *** Companion;
 }
-# Keep generated serializers ($$serializer companion objects)
--keepclasseswithmembers class **$$serializer { *; }
-# Keep all @Serializable classes and their companions
--keep @kotlinx.serialization.Serializable class * { *; }
--keepclassmembers @kotlinx.serialization.Serializable class * {
+# Keep generated serializers for SDK-owned @Serializable classes only.
+# Scoped to com.yalo.chat.sdk.** to avoid keeping unrelated @Serializable classes
+# in the consuming app's binary.
+-keepclasseswithmembers class com.yalo.chat.sdk.**$$serializer { *; }
+-keep @kotlinx.serialization.Serializable class com.yalo.chat.sdk.** { *; }
+-keepclassmembers @kotlinx.serialization.Serializable class com.yalo.chat.sdk.** {
     *** Companion;
     *** INSTANCE;
     kotlinx.serialization.KSerializer serializer(...);

--- a/android-sdk/sdk/consumer-proguard-rules.pro
+++ b/android-sdk/sdk/consumer-proguard-rules.pro
@@ -1,12 +1,7 @@
-# Phase 2 M1 — Ktor + kotlinx.serialization rules (FDE-53).
+# Phase 2 M1 — kotlinx.serialization rules (FDE-53).
+# Ktor (ktor-client-android) ships its own consumer ProGuard rules via its AAR;
+# no blanket -keep io.ktor.** needed here — that would prevent shrinking.
 # SQLDelight rules will be added in Phase 2 M2.
-
-# ── Ktor ──────────────────────────────────────────────────────────────────────
--keep class io.ktor.** { *; }
--keepclassmembers class io.ktor.** { *; }
--dontwarn io.ktor.**
-# Ktor CIO engine uses Netty internally on Android
--dontwarn io.netty.**
 
 # ── kotlinx.serialization ─────────────────────────────────────────────────────
 -keepattributes *Annotation*, InnerClasses

--- a/android-sdk/sdk/consumer-proguard-rules.pro
+++ b/android-sdk/sdk/consumer-proguard-rules.pro
@@ -1,2 +1,25 @@
-# Placeholder — will be populated in Phase 2 M5 (FDE-53)
-# Ktor, SQLDelight, and kotlinx.serialization rules will be added here.
+# Phase 2 M1 — Ktor + kotlinx.serialization rules (FDE-53).
+# SQLDelight rules will be added in Phase 2 M2.
+
+# ── Ktor ──────────────────────────────────────────────────────────────────────
+-keep class io.ktor.** { *; }
+-keepclassmembers class io.ktor.** { *; }
+-dontwarn io.ktor.**
+# Ktor CIO engine uses Netty internally on Android
+-dontwarn io.netty.**
+
+# ── kotlinx.serialization ─────────────────────────────────────────────────────
+-keepattributes *Annotation*, InnerClasses
+-dontnote kotlinx.serialization.AnnotationsKt
+-keepclassmembers class kotlinx.serialization.json.** {
+    *** Companion;
+}
+# Keep generated serializers ($$serializer companion objects)
+-keepclasseswithmembers class **$$serializer { *; }
+# Keep all @Serializable classes and their companions
+-keep @kotlinx.serialization.Serializable class * { *; }
+-keepclassmembers @kotlinx.serialization.Serializable class * {
+    *** Companion;
+    *** INSTANCE;
+    kotlinx.serialization.KSerializer serializer(...);
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -9,6 +9,7 @@ import com.yalo.chat.sdk.data.remote.buildHttpClient
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryRemote
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
+import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 
 // Port of flutter-sdk YaloChat entry point.
@@ -18,13 +19,17 @@ object YaloChat {
 
     private var _config: YaloChatConfig? = null
     private var _viewModelFactory: ViewModelProvider.Factory? = null
+    private var _httpClient: HttpClient? = null
 
     val config: YaloChatConfig
         get() = _config ?: error("YaloChat.init() must be called before accessing config")
 
     fun init(config: YaloChatConfig) {
+        // Close any previously created client before replacing it (idempotent re-init).
+        _httpClient?.close()
         _config = config
         val httpClient = buildHttpClient(Android.create(), debug = BuildConfig.DEBUG)
+        _httpClient = httpClient
         val apiService = YaloChatApiService(
             apiBaseUrl = config.apiBaseUrl,
             authToken = config.authToken,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -5,9 +5,11 @@ package com.yalo.chat.sdk
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.data.remote.buildHttpClient
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryRemote
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
+import io.ktor.client.engine.android.Android
 
 // Port of flutter-sdk YaloChat entry point.
 // Phase 2 M1: wires real Ktor networking via YaloMessageRepositoryRemote.
@@ -22,11 +24,13 @@ object YaloChat {
 
     fun init(config: YaloChatConfig) {
         _config = config
+        val httpClient = buildHttpClient(Android.create(), debug = BuildConfig.DEBUG)
         val apiService = YaloChatApiService(
             apiBaseUrl = config.apiBaseUrl,
             authToken = config.authToken,
             userToken = config.userToken,
             flowKey = config.flowKey,
+            httpClient = httpClient,
         )
         val yaloRepo = YaloMessageRepositoryRemote(apiService)
         // Phase 2 M2 will replace FakeChatMessageRepository with ChatMessageRepositoryLocal (SQLDelight).

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -4,12 +4,14 @@ package com.yalo.chat.sdk
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.yalo.chat.sdk.data.remote.YaloChatApiService
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
-import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryRemote
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
 
 // Port of flutter-sdk YaloChat entry point.
-// Phase 2 wires real repos (Ktor networking, SQLDelight persistence) here.
+// Phase 2 M1: wires real Ktor networking via YaloMessageRepositoryRemote.
+// Phase 2 M2: will replace FakeChatMessageRepository with SQLDelight persistence.
 object YaloChat {
 
     private var _config: YaloChatConfig? = null
@@ -20,8 +22,15 @@ object YaloChat {
 
     fun init(config: YaloChatConfig) {
         _config = config
-        val yaloRepo = FakeYaloMessageRepository()
-        val chatRepo = FakeChatMessageRepository(FakeYaloMessageRepository.SEED_MESSAGES)
+        val apiService = YaloChatApiService(
+            apiBaseUrl = config.apiBaseUrl,
+            authToken = config.authToken,
+            userToken = config.userToken,
+            flowKey = config.flowKey,
+        )
+        val yaloRepo = YaloMessageRepositoryRemote(apiService)
+        // Phase 2 M2 will replace FakeChatMessageRepository with ChatMessageRepositoryLocal (SQLDelight).
+        val chatRepo = FakeChatMessageRepository()
         _viewModelFactory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChatConfig.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChatConfig.kt
@@ -3,10 +3,12 @@
 package com.yalo.chat.sdk
 
 // Port of flutter-sdk YaloChatConfig.
-// Phase 2 will add apiBaseUrl, theme, and other settings.
+// Phase 2 M1 adds apiBaseUrl — required for real Ktor networking.
+// Phase 2 M5 will add theme and other polish settings.
 data class YaloChatConfig(
     val name: String,
     val flowKey: String,
     val authToken: String,
     val userToken: String,
+    val apiBaseUrl: String,
 )

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -82,6 +82,8 @@ fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, debug: Boole
                     override fun log(message: String) { println(message) }
                 }
                 level = io.ktor.client.plugins.logging.LogLevel.ALL
+                // Redact the Bearer token so it never appears in Logcat.
+                sanitizeHeader { header -> header == io.ktor.http.HttpHeaders.Authorization }
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -20,6 +20,10 @@ import io.ktor.http.isSuccess
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
+private const val HEADER_USER_ID = "x-user-id"
+private const val HEADER_CHANNEL_ID = "x-channel-id"
+private const val HEADER_AUTHORIZATION = "Authorization"
+
 // Port of flutter-sdk YaloChatClient.
 // Ktor (CIO engine) replaces Dart's http package — same headers and endpoints.
 // All network errors are wrapped in Result.Error; no exceptions are thrown.
@@ -35,9 +39,9 @@ class YaloChatApiService(
     suspend fun sendTextMessage(request: YaloTextMessageRequest): Result<Unit> = try {
         val response = httpClient.post("$apiBaseUrl/inbound_messages") {
             contentType(ContentType.Application.Json)
-            header("x-user-id", userToken)
-            header("x-channel-id", flowKey)
-            header("Authorization", "Bearer $authToken")
+            header(HEADER_USER_ID, userToken)
+            header(HEADER_CHANNEL_ID, flowKey)
+            header(HEADER_AUTHORIZATION, "Bearer $authToken")
             setBody(request)
         }
         if (response.status.isSuccess()) Result.Ok(Unit)
@@ -50,9 +54,9 @@ class YaloChatApiService(
     suspend fun fetchMessages(since: Long): Result<List<YaloFetchMessagesResponse>> = try {
         val response = httpClient.get("$apiBaseUrl/messages") {
             parameter("since", since)
-            header("x-user-id", userToken)
-            header("x-channel-id", flowKey)
-            header("Authorization", "Bearer $authToken")
+            header(HEADER_USER_ID, userToken)
+            header(HEADER_CHANNEL_ID, flowKey)
+            header(HEADER_AUTHORIZATION, "Bearer $authToken")
         }
         if (response.status.isSuccess()) Result.Ok(response.body())
         else Result.Error(RuntimeException("HTTP ${response.status.value}: fetch failed"))

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -1,0 +1,68 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.remote
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
+import com.yalo.chat.sdk.data.remote.model.YaloTextMessageRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+
+// Port of flutter-sdk YaloChatClient.
+// Ktor (CIO engine) replaces Dart's http package — same headers and endpoints.
+// All network errors are wrapped in Result.Error; no exceptions are thrown.
+class YaloChatApiService(
+    private val apiBaseUrl: String,
+    private val authToken: String,
+    private val userToken: String,
+    private val flowKey: String,
+    // Exposed as internal so tests can inject a MockEngine-backed client.
+    internal val httpClient: HttpClient = defaultClient(),
+) {
+    // POST /inbound_messages — send a text message to the Yalo backend.
+    suspend fun sendTextMessage(request: YaloTextMessageRequest): Result<Unit> = try {
+        val response = httpClient.post("$apiBaseUrl/inbound_messages") {
+            contentType(ContentType.Application.Json)
+            header("x-user-id", userToken)
+            header("x-channel-id", flowKey)
+            header("Authorization", "Bearer $authToken")
+            setBody(request)
+        }
+        if (response.status.isSuccess()) Result.Ok(Unit)
+        else Result.Error(RuntimeException("HTTP ${response.status.value}: send failed"))
+    } catch (e: Exception) {
+        Result.Error(e)
+    }
+
+    // GET /messages?since={timestamp} — fetch messages newer than the given Unix second timestamp.
+    suspend fun fetchMessages(since: Long): Result<List<YaloFetchMessagesResponse>> = try {
+        val response = httpClient.get("$apiBaseUrl/messages") {
+            parameter("since", since)
+            header("x-user-id", userToken)
+            header("x-channel-id", flowKey)
+            header("Authorization", "Bearer $authToken")
+        }
+        if (response.status.isSuccess()) Result.Ok(response.body())
+        else Result.Error(RuntimeException("HTTP ${response.status.value}: fetch failed"))
+    } catch (e: Exception) {
+        Result.Error(e)
+    }
+}
+
+private fun defaultClient() = HttpClient(CIO) {
+    install(ContentNegotiation) {
+        json(Json { ignoreUnknownKeys = true })
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -2,6 +2,7 @@
 
 package com.yalo.chat.sdk.data.remote
 
+import com.yalo.chat.sdk.BuildConfig
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import com.yalo.chat.sdk.data.remote.model.YaloTextMessageRequest
@@ -9,6 +10,9 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -27,6 +31,9 @@ private const val HEADER_AUTHORIZATION = "Authorization"
 // Port of flutter-sdk YaloChatClient.
 // Ktor (CIO engine) replaces Dart's http package — same headers and endpoints.
 // All network errors are wrapped in Result.Error; no exceptions are thrown.
+//
+// KMP note: CIO engine is JVM/Android only. When splitting to a KMP module the
+// engine will move to androidMain and a Darwin engine added for iosMain.
 class YaloChatApiService(
     private val apiBaseUrl: String,
     private val authToken: String,
@@ -65,8 +72,19 @@ class YaloChatApiService(
     }
 }
 
+// KMP note: Logging uses println() which works on all Kotlin targets.
+// When the module is split, the CIO engine + Logging installation can move to
+// androidMain/iosMain and each target can use its own native logger.
 private fun defaultClient() = HttpClient(CIO) {
     install(ContentNegotiation) {
         json(Json { ignoreUnknownKeys = true })
+    }
+    if (BuildConfig.DEBUG) {
+        install(Logging) {
+            logger = object : Logger {
+                override fun log(message: String) { println(message) }
+            }
+            level = LogLevel.ALL
+        }
     }
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -2,17 +2,12 @@
 
 package com.yalo.chat.sdk.data.remote
 
-import com.yalo.chat.sdk.BuildConfig
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import com.yalo.chat.sdk.data.remote.model.YaloTextMessageRequest
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.client.plugins.logging.LogLevel
-import io.ktor.client.plugins.logging.Logger
-import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.get
 import io.ktor.client.request.header
 import io.ktor.client.request.parameter
@@ -29,18 +24,20 @@ private const val HEADER_CHANNEL_ID = "x-channel-id"
 private const val HEADER_AUTHORIZATION = "Authorization"
 
 // Port of flutter-sdk YaloChatClient.
-// Ktor (CIO engine) replaces Dart's http package — same headers and endpoints.
+// Ktor replaces Dart's http package — same headers and endpoints.
 // All network errors are wrapped in Result.Error; no exceptions are thrown.
 //
-// KMP note: CIO engine is JVM/Android only. When splitting to a KMP module the
-// engine will move to androidMain and a Darwin engine added for iosMain.
+// KMP note: the HttpClient (with its platform engine) is provided by the caller —
+// YaloChat.kt on Android passes an Android-engine client, tests pass a MockEngine client.
+// When splitting to KMP: YaloChat.kt moves to androidMain and provides the Android engine;
+// an iosMain counterpart provides the Darwin engine.
 class YaloChatApiService(
     private val apiBaseUrl: String,
     private val authToken: String,
     private val userToken: String,
     private val flowKey: String,
-    // Exposed as internal so tests can inject a MockEngine-backed client.
-    internal val httpClient: HttpClient = defaultClient(),
+    // Provided by the platform (YaloChat.kt on Android, tests via MockEngine).
+    internal val httpClient: HttpClient,
 ) {
     // POST /inbound_messages — send a text message to the Yalo backend.
     suspend fun sendTextMessage(request: YaloTextMessageRequest): Result<Unit> = try {
@@ -72,19 +69,19 @@ class YaloChatApiService(
     }
 }
 
-// KMP note: Logging uses println() which works on all Kotlin targets.
-// When the module is split, the CIO engine + Logging installation can move to
-// androidMain/iosMain and each target can use its own native logger.
-private fun defaultClient() = HttpClient(CIO) {
-    install(ContentNegotiation) {
-        json(Json { ignoreUnknownKeys = true })
-    }
-    if (BuildConfig.DEBUG) {
-        install(Logging) {
-            logger = object : Logger {
-                override fun log(message: String) { println(message) }
+// Builds a configured HttpClient with ContentNegotiation (JSON) and optional debug logging.
+// Called from YaloChat.kt with the platform engine (Android/Darwin/etc.).
+fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, debug: Boolean): HttpClient =
+    HttpClient(engine) {
+        install(ContentNegotiation) {
+            json(Json { ignoreUnknownKeys = true })
+        }
+        if (debug) {
+            install(io.ktor.client.plugins.logging.Logging) {
+                logger = object : io.ktor.client.plugins.logging.Logger {
+                    override fun log(message: String) { println(message) }
+                }
+                level = io.ktor.client.plugins.logging.LogLevel.ALL
             }
-            level = LogLevel.ALL
         }
     }
-}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -1,0 +1,23 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.remote.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+// Port of flutter-sdk YaloFetchMessagesResponse + YaloMessage.
+// snake_case server fields are mapped via @SerialName.
+@Serializable
+data class YaloFetchMessagesResponse(
+    val id: String,
+    val message: YaloMessageDto,
+    val date: String,
+    @SerialName("user_id") val userId: String,
+    val status: String,
+)
+
+@Serializable
+data class YaloMessageDto(
+    val text: String,
+    val role: String,
+)

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloTextMessageRequest.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloTextMessageRequest.kt
@@ -1,0 +1,22 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.remote.model
+
+import kotlinx.serialization.Serializable
+
+// Port of flutter-sdk YaloTextMessageRequest + YaloTextMessage.
+// The outer wrapper carries the epoch-second timestamp of the send request;
+// the inner content carries the message payload.
+@Serializable
+data class YaloTextMessageRequest(
+    val timestamp: Long,
+    val content: YaloTextMessage,
+)
+
+@Serializable
+data class YaloTextMessage(
+    val timestamp: Long,
+    val text: String,
+    val status: String,
+    val role: String,
+)

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
@@ -8,6 +8,8 @@ import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 
 // Phase 1 stub — returns hardcoded messages covering all MessageType variants
 // (Text, Image, Voice, Product, ProductCarousel, Promotion, QuickReply, Unknown).
@@ -19,6 +21,9 @@ class FakeYaloMessageRepository : YaloMessageRepository {
 
     override suspend fun fetchMessages(since: Long): Result<List<ChatMessage>> =
         Result.Ok(SEED_MESSAGES)
+
+    // No-op: Phase 1 has no remote polling — the fake repo provides seed data only.
+    override fun pollIncomingMessages(): Flow<ChatMessage> = emptyFlow()
 
     companion object {
         val SEED_MESSAGES: List<ChatMessage> = listOf(

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
@@ -8,6 +8,11 @@ package com.yalo.chat.sdk.data.repository.remote
 // Thread-safe via @Synchronized on each accessor.
 class SimpleCache<K, V>(private val capacity: Int) {
 
+    init {
+        require(capacity > 0) { "capacity must be > 0, was $capacity" }
+    }
+
+
     // accessOrder = true → LinkedHashMap maintains LRU order; removeEldestEntry
     // evicts when size exceeds capacity, keeping memory bounded.
     private val map: LinkedHashMap<K, V> = object : LinkedHashMap<K, V>(

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
@@ -1,0 +1,26 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.repository.remote
+
+// Bounded LRU cache used by YaloMessageRepositoryRemote to deduplicate inbound
+// messages within the polling lookback window.
+// Mirrors the ecache SimpleCache used in the Flutter SDK (capacity = 500).
+// Thread-safe via @Synchronized on each accessor.
+class SimpleCache<K, V>(private val capacity: Int) {
+
+    // accessOrder = true → LinkedHashMap maintains LRU order; removeEldestEntry
+    // evicts when size exceeds capacity, keeping memory bounded.
+    private val map: LinkedHashMap<K, V> = object : LinkedHashMap<K, V>(
+        (capacity * 1.34f + 1).toInt(), 0.75f, /* accessOrder = */ true,
+    ) {
+        override fun removeEldestEntry(eldest: Map.Entry<K, V>): Boolean = size > capacity
+    }
+
+    @Synchronized
+    fun get(key: K): V? = map[key]
+
+    @Synchronized
+    fun set(key: K, value: V) {
+        map[key] = value
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -64,9 +64,9 @@ class YaloMessageRepositoryRemote(
 
     // Continuous polling flow — emits each new inbound ChatMessage as it arrives.
     // Uses the LRU cache so the same message (identified by wiId) is never emitted twice.
-    // Network errors are re-thrown so the caller's retryWhen can restart the flow after
-    // a delay — this is what gives the "automatic restart on network recovery" behavior.
-    // Mirrors flutter-sdk YaloMessageRepositoryRemote._startPolling().
+    // Network errors are logged and swallowed — the loop continues on the next tick,
+    // mirroring flutter-sdk YaloMessageRepositoryRemote._startPolling() which logs
+    // the error and falls through to Future.delayed without breaking the loop.
     override fun pollIncomingMessages(): Flow<ChatMessage> = flow {
         while (true) {
             val since = System.currentTimeMillis() / 1000 - lookbackSecs
@@ -74,8 +74,7 @@ class YaloMessageRepositoryRemote(
                 is Result.Ok -> result.result
                     .mapNotNull { it.toChatMessage(deduplicate = true) }
                     .forEach { emit(it) }
-                // Re-throw so retryWhen in the ViewModel can catch and restart the flow.
-                is Result.Error -> throw result.error
+                is Result.Error -> Unit // swallow, loop continues — mirrors Flutter SDK
             }
             delay(pollingIntervalMs)
         }
@@ -129,9 +128,11 @@ private val threadLocalFormatters: ThreadLocal<List<SimpleDateFormat>> =
 
 // Converts ±HH:MM (or ±HH:MM:SS) offsets to ±HHMM (or ±HHMMSS) so they are
 // compatible with the 'Z' SimpleDateFormat pattern on all supported API levels.
+// Compiled once as a top-level val to avoid per-call Regex allocation.
+private val ISO_OFFSET_PATTERN = Regex("([+-]\\d{2}):(\\d{2})(?::(\\d{2}))?\$")
+
 private fun normalizeIso8601Offset(input: String): String {
-    val offsetPattern = Regex("([+-]\\d{2}):(\\d{2})(?::(\\d{2}))?\$")
-    return input.replace(offsetPattern) { match ->
+    return input.replace(ISO_OFFSET_PATTERN) { match ->
         val (hours, minutes) = match.destructured
         val seconds = match.groupValues[3]
         if (seconds.isNotEmpty()) "$hours$minutes$seconds" else "$hours$minutes"

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -1,0 +1,117 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.repository.remote
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
+import com.yalo.chat.sdk.data.remote.model.YaloTextMessage
+import com.yalo.chat.sdk.data.remote.model.YaloTextMessageRequest
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+// Port of flutter-sdk YaloMessageRepositoryRemote.
+// Polling: 1s interval, 5s lookback window, LRU deduplication cache (capacity 500).
+// All network errors are wrapped in Result.Error; nothing is thrown.
+// Phase 2 M1 only maps text messages — other types are detected in a future milestone.
+class YaloMessageRepositoryRemote(
+    private val apiService: YaloChatApiService,
+    // Exposed as internal so tests can override the interval without waiting.
+    internal val pollingIntervalMs: Long = 1_000L,
+    private val lookbackSecs: Long = 5L,
+) : YaloMessageRepository {
+
+    private val cache = SimpleCache<String, Boolean>(capacity = 500)
+
+    // Sends a text message to the Yalo backend.
+    // Non-text types are unsupported until Phase 2 M3/M4 add image/audio sending.
+    override suspend fun sendMessage(message: ChatMessage): Result<Unit> {
+        if (message.type != MessageType.Text) {
+            return Result.Error(
+                UnsupportedOperationException("Only text messages are supported in Phase 2 M1")
+            )
+        }
+        val nowSecs = System.currentTimeMillis() / 1000
+        val request = YaloTextMessageRequest(
+            timestamp = nowSecs,
+            content = YaloTextMessage(
+                timestamp = message.timestamp / 1000,
+                text = message.content,
+                status = message.status.value,
+                role = message.role.value,
+            ),
+        )
+        return apiService.sendTextMessage(request)
+    }
+
+    // Single-shot fetch — returns all messages newer than the given Unix second timestamp.
+    // The cache is NOT applied here so callers get the full list.
+    override suspend fun fetchMessages(since: Long): Result<List<ChatMessage>> =
+        when (val result = apiService.fetchMessages(since)) {
+            is Result.Ok -> Result.Ok(result.result.mapNotNull { it.toChatMessage(deduplicate = false) })
+            is Result.Error -> Result.Error(result.error)
+        }
+
+    // Continuous polling flow — emits each new inbound ChatMessage as it arrives.
+    // Uses the LRU cache so the same message (identified by wiId) is never emitted twice.
+    // Network errors are swallowed so the flow stays alive; the caller should apply
+    // retryWhen for automatic restart on persistent failure.
+    // Mirrors flutter-sdk YaloMessageRepositoryRemote._startPolling().
+    override fun pollIncomingMessages(): Flow<ChatMessage> = flow {
+        while (true) {
+            val since = System.currentTimeMillis() / 1000 - lookbackSecs
+            when (val result = apiService.fetchMessages(since)) {
+                is Result.Ok -> result.result
+                    .mapNotNull { it.toChatMessage(deduplicate = true) }
+                    .forEach { emit(it) }
+                is Result.Error -> Unit // swallow; caller applies retryWhen
+            }
+            delay(pollingIntervalMs)
+        }
+    }
+
+    private fun YaloFetchMessagesResponse.toChatMessage(deduplicate: Boolean): ChatMessage? {
+        if (deduplicate && cache.get(id) != null) return null
+        if (deduplicate) cache.set(id, true)
+        return ChatMessage(
+            wiId = id,
+            role = MessageRole.fromString(message.role),
+            type = MessageType.Text, // Phase 2 M1: only text detected
+            status = MessageStatus.DELIVERED,
+            content = message.text,
+            timestamp = parseIso8601(date),
+        )
+    }
+}
+
+// SimpleDateFormat is used instead of java.time.Instant to support API 21+
+// without requiring core library desugaring.
+private val ISO_FORMATS = listOf(
+    "yyyy-MM-dd'T'HH:mm:ss.SSSX",
+    "yyyy-MM-dd'T'HH:mm:ssX",
+    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+)
+
+private fun parseIso8601(date: String): Long {
+    for (fmt in ISO_FORMATS) {
+        try {
+            return SimpleDateFormat(fmt, Locale.US)
+                .apply { timeZone = TimeZone.getTimeZone("UTC") }
+                .parse(date)
+                ?.time ?: continue
+        } catch (_: Exception) {
+            continue
+        }
+    }
+    return System.currentTimeMillis()
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -21,7 +21,8 @@ import java.util.TimeZone
 
 // Port of flutter-sdk YaloMessageRepositoryRemote.
 // Polling: 1s interval, 5s lookback window, LRU deduplication cache (capacity 500).
-// All network errors are wrapped in Result.Error; nothing is thrown.
+// Network errors in the polling flow are re-thrown so retryWhen in the ViewModel
+// can restart it after a delay, mirroring the flutter-sdk polling restart behavior.
 // Phase 2 M1 only maps text messages — other types are detected in a future milestone.
 class YaloMessageRepositoryRemote(
     private val apiService: YaloChatApiService,
@@ -63,8 +64,8 @@ class YaloMessageRepositoryRemote(
 
     // Continuous polling flow — emits each new inbound ChatMessage as it arrives.
     // Uses the LRU cache so the same message (identified by wiId) is never emitted twice.
-    // Network errors are swallowed so the flow stays alive; the caller should apply
-    // retryWhen for automatic restart on persistent failure.
+    // Network errors are re-thrown so the caller's retryWhen can restart the flow after
+    // a delay — this is what gives the "automatic restart on network recovery" behavior.
     // Mirrors flutter-sdk YaloMessageRepositoryRemote._startPolling().
     override fun pollIncomingMessages(): Flow<ChatMessage> = flow {
         while (true) {
@@ -73,7 +74,8 @@ class YaloMessageRepositoryRemote(
                 is Result.Ok -> result.result
                     .mapNotNull { it.toChatMessage(deduplicate = true) }
                     .forEach { emit(it) }
-                is Result.Error -> Unit // swallow; caller applies retryWhen
+                // Re-throw so retryWhen in the ViewModel can catch and restart the flow.
+                is Result.Error -> throw result.error
             }
             delay(pollingIntervalMs)
         }
@@ -93,22 +95,54 @@ class YaloMessageRepositoryRemote(
     }
 }
 
+// ── ISO 8601 date parsing ─────────────────────────────────────────────────────
 // SimpleDateFormat is used instead of java.time.Instant to support API 21+
-// without requiring core library desugaring.
+// without core library desugaring.
+//
+// The 'X' timezone specifier is only available on API 24+, so 'Z' is used
+// instead (supported from API 1). ISO 8601 offsets use ±HH:MM but 'Z' expects
+// ±HHMM, so normalizeIso8601Offset strips the colon before parsing.
+//
+// ThreadLocal caches one SimpleDateFormat per format per thread — avoids
+// per-call allocation and is safe since SimpleDateFormat is not thread-safe.
+
+private const val UTC = "UTC"
+
+private data class Iso8601Format(val pattern: String, val normalizeOffset: Boolean)
+
 private val ISO_FORMATS = listOf(
-    "yyyy-MM-dd'T'HH:mm:ss.SSSX",
-    "yyyy-MM-dd'T'HH:mm:ssX",
-    "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss.SSSZ", normalizeOffset = true),
+    Iso8601Format("yyyy-MM-dd'T'HH:mm:ssZ",      normalizeOffset = true),
+    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", normalizeOffset = false),
+    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss'Z'",     normalizeOffset = false),
 )
 
+private val threadLocalFormatters: ThreadLocal<List<SimpleDateFormat>> =
+    ThreadLocal.withInitial {
+        ISO_FORMATS.map { fmt ->
+            SimpleDateFormat(fmt.pattern, Locale.US).apply {
+                timeZone = TimeZone.getTimeZone(UTC)
+            }
+        }
+    }
+
+// Converts ±HH:MM (or ±HH:MM:SS) offsets to ±HHMM (or ±HHMMSS) so they are
+// compatible with the 'Z' SimpleDateFormat pattern on all supported API levels.
+private fun normalizeIso8601Offset(input: String): String {
+    val offsetPattern = Regex("([+-]\\d{2}):(\\d{2})(?::(\\d{2}))?\$")
+    return input.replace(offsetPattern) { match ->
+        val (hours, minutes) = match.destructured
+        val seconds = match.groupValues[3]
+        if (seconds.isNotEmpty()) "$hours$minutes$seconds" else "$hours$minutes"
+    }
+}
+
 private fun parseIso8601(date: String): Long {
-    for (fmt in ISO_FORMATS) {
+    val formatters = threadLocalFormatters.get()!!
+    for ((index, fmt) in ISO_FORMATS.withIndex()) {
         try {
-            return SimpleDateFormat(fmt, Locale.US)
-                .apply { timeZone = TimeZone.getTimeZone("UTC") }
-                .parse(date)
-                ?.time ?: continue
+            val candidate = if (fmt.normalizeOffset) normalizeIso8601Offset(date) else date
+            return formatters[index].parse(candidate)?.time ?: continue
         } catch (_: Exception) {
             continue
         }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -15,15 +15,17 @@ import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.TimeZone
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 // Port of flutter-sdk YaloMessageRepositoryRemote.
 // Polling: 1s interval, 5s lookback window, LRU deduplication cache (capacity 500).
-// Network errors in the polling flow are re-thrown so retryWhen in the ViewModel
-// can restart it after a delay, mirroring the flutter-sdk polling restart behavior.
+// Network errors in the polling flow are swallowed and the loop continues — mirrors
+// flutter-sdk _startPolling() which logs the error and falls through to Future.delayed.
 // Phase 2 M1 only maps text messages — other types are detected in a future milestone.
+//
+// KMP note: all platform-specific imports (java.text.*, java.util.*) have been replaced
+// with kotlinx-datetime so this file is ready for a commonMain source set.
 class YaloMessageRepositoryRemote(
     private val apiService: YaloChatApiService,
     // Exposed as internal so tests can override the interval without waiting.
@@ -41,7 +43,7 @@ class YaloMessageRepositoryRemote(
                 UnsupportedOperationException("Only text messages are supported in Phase 2 M1")
             )
         }
-        val nowSecs = System.currentTimeMillis() / 1000
+        val nowSecs = Clock.System.now().epochSeconds
         val request = YaloTextMessageRequest(
             timestamp = nowSecs,
             content = YaloTextMessage(
@@ -69,7 +71,7 @@ class YaloMessageRepositoryRemote(
     // the error and falls through to Future.delayed without breaking the loop.
     override fun pollIncomingMessages(): Flow<ChatMessage> = flow {
         while (true) {
-            val since = System.currentTimeMillis() / 1000 - lookbackSecs
+            val since = Clock.System.now().epochSeconds - lookbackSecs
             when (val result = apiService.fetchMessages(since)) {
                 is Result.Ok -> result.result
                     .mapNotNull { it.toChatMessage(deduplicate = true) }
@@ -95,59 +97,13 @@ class YaloMessageRepositoryRemote(
 }
 
 // ── ISO 8601 date parsing ─────────────────────────────────────────────────────
-// SimpleDateFormat is used instead of java.time.Instant to support API 21+
-// without core library desugaring.
-//
-// The 'X' timezone specifier is only available on API 24+, so 'Z' is used
-// instead (supported from API 1). ISO 8601 offsets use ±HH:MM but 'Z' expects
-// ±HHMM, so normalizeIso8601Offset strips the colon before parsing.
-//
-// ThreadLocal caches one SimpleDateFormat per format per thread — avoids
-// per-call allocation and is safe since SimpleDateFormat is not thread-safe.
+// kotlinx-datetime's Instant.parse() handles all standard ISO 8601 variants
+// (with/without millis, Z suffix, ±HH:MM offsets) and is fully KMP-compatible —
+// no java.text.SimpleDateFormat, ThreadLocal, or TimeZone needed.
 
-private const val UTC = "UTC"
-
-private data class Iso8601Format(val pattern: String, val normalizeOffset: Boolean)
-
-private val ISO_FORMATS = listOf(
-    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss.SSSZ", normalizeOffset = true),
-    Iso8601Format("yyyy-MM-dd'T'HH:mm:ssZ",      normalizeOffset = true),
-    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", normalizeOffset = false),
-    Iso8601Format("yyyy-MM-dd'T'HH:mm:ss'Z'",     normalizeOffset = false),
-)
-
-// ThreadLocal.withInitial() requires API 26; anonymous subclass works from API 1.
-private val threadLocalFormatters: ThreadLocal<List<SimpleDateFormat>> =
-    object : ThreadLocal<List<SimpleDateFormat>>() {
-        override fun initialValue() = ISO_FORMATS.map { fmt ->
-            SimpleDateFormat(fmt.pattern, Locale.US).apply {
-                timeZone = TimeZone.getTimeZone(UTC)
-            }
-        }
+private fun parseIso8601(date: String): Long =
+    try {
+        Instant.parse(date).toEpochMilliseconds()
+    } catch (_: Exception) {
+        Clock.System.now().toEpochMilliseconds()
     }
-
-// Converts ±HH:MM (or ±HH:MM:SS) offsets to ±HHMM (or ±HHMMSS) so they are
-// compatible with the 'Z' SimpleDateFormat pattern on all supported API levels.
-// Compiled once as a top-level val to avoid per-call Regex allocation.
-private val ISO_OFFSET_PATTERN = Regex("([+-]\\d{2}):(\\d{2})(?::(\\d{2}))?\$")
-
-private fun normalizeIso8601Offset(input: String): String {
-    return input.replace(ISO_OFFSET_PATTERN) { match ->
-        val (hours, minutes) = match.destructured
-        val seconds = match.groupValues[3]
-        if (seconds.isNotEmpty()) "$hours$minutes$seconds" else "$hours$minutes"
-    }
-}
-
-private fun parseIso8601(date: String): Long {
-    val formatters = threadLocalFormatters.get()!!
-    for ((index, fmt) in ISO_FORMATS.withIndex()) {
-        try {
-            val candidate = if (fmt.normalizeOffset) normalizeIso8601Offset(date) else date
-            return formatters[index].parse(candidate)?.time ?: continue
-        } catch (_: Exception) {
-            continue
-        }
-    }
-    return System.currentTimeMillis()
-}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -117,9 +117,10 @@ private val ISO_FORMATS = listOf(
     Iso8601Format("yyyy-MM-dd'T'HH:mm:ss'Z'",     normalizeOffset = false),
 )
 
+// ThreadLocal.withInitial() requires API 26; anonymous subclass works from API 1.
 private val threadLocalFormatters: ThreadLocal<List<SimpleDateFormat>> =
-    ThreadLocal.withInitial {
-        ISO_FORMATS.map { fmt ->
+    object : ThreadLocal<List<SimpleDateFormat>>() {
+        override fun initialValue() = ISO_FORMATS.map { fmt ->
             SimpleDateFormat(fmt.pattern, Locale.US).apply {
                 timeZone = TimeZone.getTimeZone(UTC)
             }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/model/MessageRole.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/model/MessageRole.kt
@@ -9,6 +9,6 @@ enum class MessageRole(val value: String) {
     AGENT("AGENT");
 
     companion object {
-        fun fromString(value: String): MessageRole = entries.firstOrNull { it.value == value } ?: USER
+        fun fromString(value: String): MessageRole = entries.firstOrNull { it.value == value } ?: AGENT
     }
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
@@ -4,6 +4,7 @@ package com.yalo.chat.sdk.domain.repository
 
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.domain.model.ChatMessage
+import kotlinx.coroutines.flow.Flow
 
 // Port of flutter-sdk/lib/src/data/repositories/yalo_message_repository.dart
 // Phase 1: implemented by FakeYaloMessageRepository (in-memory hardcoded messages).
@@ -11,4 +12,9 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 interface YaloMessageRepository {
     suspend fun sendMessage(message: ChatMessage): Result<Unit>
     suspend fun fetchMessages(since: Long): Result<List<ChatMessage>>
+
+    // Phase 2: continuous polling flow — emits new inbound messages from the server.
+    // FakeYaloMessageRepository returns emptyFlow() (no-op for Phase 1 tests).
+    // YaloMessageRepositoryRemote uses a 1s polling loop with a 5s lookback window.
+    fun pollIncomingMessages(): Flow<ChatMessage>
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -14,6 +14,7 @@ import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -73,31 +74,35 @@ class MessagesViewModel(
         // the brief window where two collectors could be active after cancel+launch.
         if (subscriptionJob?.isActive == true) return
         subscriptionJob = viewModelScope.launch {
-            // 1. Observe local store — drives all UI updates.
-            launch {
-                chatMessageRepository.observeMessages().collect { messages ->
-                    _state.update {
-                        it.copy(
-                            messages = messages,
-                            quickReplies = messages.extractQuickReplies(),
-                        )
-                    }
-                }
-            }
-            // 2. Poll remote for new inbound messages; insert into local store so
-            //    the observer above picks them up automatically.
-            //    Errors are swallowed inside pollIncomingMessages(), mirroring
-            //    flutter-sdk YaloMessageRepositoryRemote._startPolling().
-            launch {
-                yaloMessageRepository.pollIncomingMessages()
-                    .collect { message ->
-                        // Mirror Flutter _handleMessagesSubscription: on insert error the
-                        // message is dropped and the chat is marked as failed to receive.
-                        when (chatMessageRepository.insertMessage(message)) {
-                            is Result.Ok -> Unit
-                            is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
+            // supervisorScope isolates the two child coroutines: an unexpected failure in
+            // one (e.g., an unhandled throw from a Flow collect) does not cancel the other.
+            supervisorScope {
+                // 1. Observe local store — drives all UI updates.
+                launch {
+                    chatMessageRepository.observeMessages().collect { messages ->
+                        _state.update {
+                            it.copy(
+                                messages = messages,
+                                quickReplies = messages.extractQuickReplies(),
+                            )
                         }
                     }
+                }
+                // 2. Poll remote for new inbound messages; insert into local store so
+                //    the observer above picks them up automatically.
+                //    Errors are swallowed inside pollIncomingMessages(), mirroring
+                //    flutter-sdk YaloMessageRepositoryRemote._startPolling().
+                launch {
+                    yaloMessageRepository.pollIncomingMessages()
+                        .collect { message ->
+                            // Mirror Flutter _handleMessagesSubscription: on insert error the
+                            // message is dropped and the chat is marked as failed to receive.
+                            when (chatMessageRepository.insertMessage(message)) {
+                                is Result.Ok -> Unit
+                                is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
+                            }
+                        }
+                }
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -13,9 +13,11 @@ import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -73,13 +75,25 @@ class MessagesViewModel(
         // the brief window where two collectors could be active after cancel+launch.
         if (subscriptionJob?.isActive == true) return
         subscriptionJob = viewModelScope.launch {
-            chatMessageRepository.observeMessages().collect { messages ->
-                _state.update {
-                    it.copy(
-                        messages = messages,
-                        quickReplies = messages.extractQuickReplies(),
-                    )
+            // 1. Observe local store — drives all UI updates.
+            launch {
+                chatMessageRepository.observeMessages().collect { messages ->
+                    _state.update {
+                        it.copy(
+                            messages = messages,
+                            quickReplies = messages.extractQuickReplies(),
+                        )
+                    }
                 }
+            }
+            // 2. Poll remote for new inbound messages; insert into local store so
+            //    the observer above picks them up automatically.
+            //    retryWhen restarts the polling flow on any network error (mirrors
+            //    flutter-sdk YaloMessageRepositoryRemote polling behavior).
+            launch {
+                yaloMessageRepository.pollIncomingMessages()
+                    .retryWhen { _, _ -> delay(1_000); true }
+                    .collect { message -> chatMessageRepository.insertMessage(message) }
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -13,11 +13,9 @@ import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -88,12 +86,18 @@ class MessagesViewModel(
             }
             // 2. Poll remote for new inbound messages; insert into local store so
             //    the observer above picks them up automatically.
-            //    retryWhen restarts the polling flow on any network error (mirrors
-            //    flutter-sdk YaloMessageRepositoryRemote polling behavior).
+            //    Errors are swallowed inside pollIncomingMessages(), mirroring
+            //    flutter-sdk YaloMessageRepositoryRemote._startPolling().
             launch {
                 yaloMessageRepository.pollIncomingMessages()
-                    .retryWhen { _, _ -> delay(1_000); true }
-                    .collect { message -> chatMessageRepository.insertMessage(message) }
+                    .collect { message ->
+                        // Mirror Flutter _handleMessagesSubscription: on insert error the
+                        // message is dropped and the chat is marked as failed to receive.
+                        when (chatMessageRepository.insertMessage(message)) {
+                            is Result.Ok -> Unit
+                            is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
+                        }
+                    }
             }
         }
     }
@@ -112,15 +116,9 @@ class MessagesViewModel(
             when (chatMessageRepository.insertMessage(optimistic)) {
                 is Result.Ok -> {
                     _state.update { it.copy(userMessage = "") }
-                    when (yaloMessageRepository.sendMessage(optimistic)) {
-                        is Result.Ok -> Unit
-                        // Send failure: mark the individual message as ERROR.
-                        // chatStatus is not changed to Failure here — a send error is message-level,
-                        // not a fatal chat-level failure (mirrors Flutter SDK MessagesBloc behavior).
-                        is Result.Error -> chatMessageRepository.updateMessage(
-                            optimistic.copy(status = MessageStatus.ERROR)
-                        )
-                    }
+                    // Fire-and-forget — mirrors Flutter SDK MessagesBloc._handleSendTextMessage
+                    // which calls _yaloMessageRepository.sendMessage() without awaiting.
+                    launch { yaloMessageRepository.sendMessage(optimistic) }
                 }
                 is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
             }

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiServiceTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiServiceTest.kt
@@ -1,0 +1,136 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.remote
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
+import com.yalo.chat.sdk.data.remote.model.YaloTextMessage
+import com.yalo.chat.sdk.data.remote.model.YaloTextMessageRequest
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class YaloChatApiServiceTest {
+
+    private fun apiService(handler: io.ktor.client.engine.mock.MockRequestHandler): YaloChatApiService {
+        val engine = MockEngine(handler)
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        return YaloChatApiService(
+            apiBaseUrl = "https://api.test",
+            authToken = "auth-token",
+            userToken = "user-token",
+            flowKey = "flow-key",
+            httpClient = client,
+        )
+    }
+
+    private val testRequest = YaloTextMessageRequest(
+        timestamp = 1_000L,
+        content = YaloTextMessage(timestamp = 900L, text = "hello", status = "SENT", role = "USER"),
+    )
+
+    // ── sendTextMessage ────────────────────────────────────────────────────────
+
+    @Test
+    fun `sendTextMessage returns Ok on HTTP 200`() = runTest {
+        val service = apiService {
+            respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        assertIs<Result.Ok<Unit>>(service.sendTextMessage(testRequest))
+    }
+
+    @Test
+    fun `sendTextMessage returns Error on HTTP 500`() = runTest {
+        val service = apiService {
+            respondError(HttpStatusCode.InternalServerError)
+        }
+        val result = service.sendTextMessage(testRequest)
+        assertIs<Result.Error<Unit>>(result)
+        assertTrue(result.error.message?.contains("500") == true)
+    }
+
+    @Test
+    fun `sendTextMessage returns Error on network exception`() = runTest {
+        val service = apiService { throw RuntimeException("no network") }
+        assertIs<Result.Error<Unit>>(service.sendTextMessage(testRequest))
+    }
+
+    @Test
+    fun `sendTextMessage sends correct auth headers`() = runTest {
+        var capturedHeaders: io.ktor.http.Headers? = null
+        val service = apiService { request ->
+            capturedHeaders = request.headers
+            respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        service.sendTextMessage(testRequest)
+        assertEquals("Bearer auth-token", capturedHeaders?.get("Authorization"))
+        assertEquals("user-token", capturedHeaders?.get("x-user-id"))
+        assertEquals("flow-key", capturedHeaders?.get("x-channel-id"))
+    }
+
+    // ── fetchMessages ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `fetchMessages returns Ok with parsed list on HTTP 200`() = runTest {
+        val body = """
+            [{"id":"msg-1","message":{"text":"Hi","role":"AGENT"},"date":"2024-01-01T00:00:00Z","user_id":"u1","status":"DELIVERED"}]
+        """.trimIndent()
+        val service = apiService {
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val result = service.fetchMessages(since = 1_000L)
+        assertIs<Result.Ok<List<YaloFetchMessagesResponse>>>(result)
+        assertEquals(1, result.result.size)
+        assertEquals("msg-1", result.result.first().id)
+        assertEquals("Hi", result.result.first().message.text)
+    }
+
+    @Test
+    fun `fetchMessages returns empty list when server returns empty array`() = runTest {
+        val service = apiService {
+            respond("[]", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val result = service.fetchMessages(since = 0L)
+        assertIs<Result.Ok<List<YaloFetchMessagesResponse>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `fetchMessages returns Error on HTTP 401`() = runTest {
+        val service = apiService { respondError(HttpStatusCode.Unauthorized) }
+        val result = service.fetchMessages(since = 0L)
+        assertIs<Result.Error<*>>(result)
+        assertTrue(result.error.message?.contains("401") == true)
+    }
+
+    @Test
+    fun `fetchMessages returns Error on network exception`() = runTest {
+        val service = apiService { throw RuntimeException("timeout") }
+        assertIs<Result.Error<*>>(service.fetchMessages(since = 0L))
+    }
+
+    @Test
+    fun `fetchMessages sends since as query parameter`() = runTest {
+        var capturedUrl: io.ktor.http.Url? = null
+        val service = apiService { request ->
+            capturedUrl = request.url
+            respond("[]", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        service.fetchMessages(since = 12345L)
+        assertEquals("12345", capturedUrl?.parameters?.get("since"))
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCacheTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCacheTest.kt
@@ -1,0 +1,51 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.repository.remote
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SimpleCacheTest {
+
+    @Test
+    fun `get returns null for absent key`() {
+        val cache = SimpleCache<String, Boolean>(capacity = 10)
+        assertNull(cache.get("missing"))
+    }
+
+    @Test
+    fun `set and get round-trip`() {
+        val cache = SimpleCache<String, Boolean>(capacity = 10)
+        cache.set("id-1", true)
+        assertEquals(true, cache.get("id-1"))
+    }
+
+    @Test
+    fun `capacity eviction removes eldest entry`() {
+        val cache = SimpleCache<Int, Int>(capacity = 3)
+        cache.set(1, 1)
+        cache.set(2, 2)
+        cache.set(3, 3)
+        // Access key 1 to make it "recently used" — key 2 becomes the eldest
+        cache.get(1)
+        // Insert a 4th entry, which exceeds capacity → eldest (key 2) is evicted
+        cache.set(4, 4)
+        assertNull(cache.get(2))
+        assertEquals(1, cache.get(1))
+        assertEquals(3, cache.get(3))
+        assertEquals(4, cache.get(4))
+    }
+
+    @Test
+    fun `overwriting an existing key does not grow beyond capacity`() {
+        val cache = SimpleCache<Int, Int>(capacity = 2)
+        cache.set(1, 1)
+        cache.set(2, 2)
+        cache.set(1, 99) // overwrite, not a new entry
+        cache.set(3, 3) // should evict key 2 (eldest)
+        assertNull(cache.get(2))
+        assertEquals(99, cache.get(1))
+        assertEquals(3, cache.get(3))
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -17,7 +17,6 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -131,28 +130,9 @@ class YaloMessageRepositoryRemoteTest {
     }
 
     @Test
-    fun `pollIncomingMessages throws on network error so retryWhen can restart it`() = runTest {
-        val engine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
-        val client = HttpClient(engine) {
-            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
-        }
-        val apiService = YaloChatApiService(
-            apiBaseUrl = "https://api.test", authToken = "a", userToken = "u", flowKey = "f",
-            httpClient = client,
-        )
-        val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
-        // The flow should throw so the caller's retryWhen can restart it.
-        var threw = false
-        try {
-            repo.pollIncomingMessages().take(1).toList()
-        } catch (_: Exception) {
-            threw = true
-        }
-        assertTrue(threw)
-    }
-
-    @Test
-    fun `pollIncomingMessages resumes after error when retryWhen is applied`() = runTest {
+    fun `pollIncomingMessages continues polling after network error`() = runTest {
+        // Mirrors Flutter _startPolling(): on error the loop continues without restarting.
+        // First call returns 500, second call returns a message — take(1) collects it.
         var callIndex = 0
         val engine = MockEngine {
             callIndex++
@@ -171,10 +151,7 @@ class YaloMessageRepositoryRemoteTest {
             httpClient = client,
         )
         val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
-        // retryWhen restarts after the first error; second poll succeeds
-        val messages = repo.pollIncomingMessages()
-            .retryWhen { _, _ -> true }
-            .take(1).toList()
+        val messages = repo.pollIncomingMessages().take(1).toList()
         assertEquals(1, messages.size)
         assertEquals("After error", messages.first().content)
     }

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -1,0 +1,170 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.repository.remote
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class YaloMessageRepositoryRemoteTest {
+
+    private fun buildRepo(responses: List<String>): YaloMessageRepositoryRemote {
+        var callIndex = 0
+        val engine = MockEngine {
+            val body = if (callIndex < responses.size) responses[callIndex++] else "[]"
+            respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        val apiService = YaloChatApiService(
+            apiBaseUrl = "https://api.test",
+            authToken = "auth",
+            userToken = "user",
+            flowKey = "flow",
+            httpClient = client,
+        )
+        return YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
+    }
+
+    private fun messageJson(id: String, text: String, role: String = "AGENT") =
+        """[{"id":"$id","message":{"text":"$text","role":"$role"},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"DELIVERED"}]"""
+
+    // ── sendMessage ────────────────────────────────────────────────────────────
+
+    @Test
+    fun `sendMessage text returns Ok when api succeeds`() = runTest {
+        val repo = buildRepo(listOf("{}"))
+        val message = ChatMessage(
+            role = MessageRole.USER, type = MessageType.Text,
+            status = MessageStatus.SENT, content = "hello",
+        )
+        assertIs<Result.Ok<Unit>>(repo.sendMessage(message))
+    }
+
+    @Test
+    fun `sendMessage non-text type returns Error`() = runTest {
+        val repo = buildRepo(emptyList())
+        val message = ChatMessage(
+            role = MessageRole.USER, type = MessageType.Image,
+            status = MessageStatus.SENT, content = "",
+        )
+        assertIs<Result.Error<Unit>>(repo.sendMessage(message))
+    }
+
+    // ── fetchMessages ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `fetchMessages maps response to ChatMessage`() = runTest {
+        val repo = buildRepo(listOf(messageJson("id-1", "Hello from server", "AGENT")))
+        val result = repo.fetchMessages(since = 0L)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(1, result.result.size)
+        assertEquals("Hello from server", result.result.first().content)
+        assertEquals(MessageRole.AGENT, result.result.first().role)
+        assertEquals(MessageType.Text, result.result.first().type)
+    }
+
+    @Test
+    fun `fetchMessages returns empty list when server returns empty array`() = runTest {
+        val repo = buildRepo(listOf("[]"))
+        val result = repo.fetchMessages(since = 0L)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(0, result.result.size)
+    }
+
+    @Test
+    fun `fetchMessages does not deduplicate — same message returned on each call`() = runTest {
+        val repo = buildRepo(listOf(messageJson("id-1", "Hi"), messageJson("id-1", "Hi")))
+        val first = repo.fetchMessages(since = 0L)
+        val second = repo.fetchMessages(since = 0L)
+        assertIs<Result.Ok<List<ChatMessage>>>(first)
+        assertIs<Result.Ok<List<ChatMessage>>>(second)
+        assertEquals(1, first.result.size)
+        assertEquals(1, second.result.size)
+    }
+
+    // ── pollIncomingMessages ───────────────────────────────────────────────────
+
+    @Test
+    fun `pollIncomingMessages emits messages from first poll`() = runTest {
+        val repo = buildRepo(listOf(messageJson("id-1", "Hi"), "[]"))
+        val messages = repo.pollIncomingMessages().take(1).toList()
+        assertEquals(1, messages.size)
+        assertEquals("Hi", messages.first().content)
+    }
+
+    @Test
+    fun `pollIncomingMessages deduplicates — same wiId is emitted only once`() = runTest {
+        // First poll: id-1 only. Second poll: id-1 (dup) + id-2 (new).
+        val bothMessages = """[
+            {"id":"id-1","message":{"text":"First","role":"AGENT"},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"DELIVERED"},
+            {"id":"id-2","message":{"text":"Second","role":"AGENT"},"date":"2024-01-01T12:00:01Z","user_id":"u1","status":"DELIVERED"}
+        ]"""
+        val repo = buildRepo(listOf(messageJson("id-1", "First"), bothMessages))
+        // take(2): id-1 from poll 1, id-2 from poll 2; id-1 is suppressed by the cache
+        val messages = repo.pollIncomingMessages().take(2).toList()
+        assertEquals(2, messages.size)
+        assertEquals("First", messages[0].content)
+        assertEquals("Second", messages[1].content)
+    }
+
+    @Test
+    fun `pollIncomingMessages swallows network error and continues on next tick`() = runTest {
+        var callIndex = 0
+        val engine = MockEngine {
+            callIndex++
+            if (callIndex == 1) respondError(HttpStatusCode.InternalServerError)
+            else respond(
+                messageJson("id-1", "After error"),
+                HttpStatusCode.OK,
+                headersOf(HttpHeaders.ContentType, "application/json"),
+            )
+        }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        val apiService = YaloChatApiService(
+            apiBaseUrl = "https://api.test", authToken = "a", userToken = "u", flowKey = "f",
+            httpClient = client,
+        )
+        val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
+        // First poll errors; second poll succeeds — we should still receive the message
+        val messages = repo.pollIncomingMessages().take(1).toList()
+        assertEquals(1, messages.size)
+        assertEquals("After error", messages.first().content)
+    }
+
+    @Test
+    fun `pollIncomingMessages sets MessageRole from server role field`() = runTest {
+        val repo = buildRepo(listOf(messageJson("id-1", "Hey", "USER"), "[]"))
+        val messages = repo.pollIncomingMessages().take(1).toList()
+        assertEquals(MessageRole.USER, messages.first().role)
+    }
+
+    @Test
+    fun `pollIncomingMessages status is always DELIVERED`() = runTest {
+        val repo = buildRepo(listOf(messageJson("id-1", "msg"), "[]"))
+        val messages = repo.pollIncomingMessages().take(1).toList()
+        assertEquals(MessageStatus.DELIVERED, messages.first().status)
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -17,6 +17,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -24,6 +25,7 @@ import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class YaloMessageRepositoryRemoteTest {
 
@@ -129,7 +131,28 @@ class YaloMessageRepositoryRemoteTest {
     }
 
     @Test
-    fun `pollIncomingMessages swallows network error and continues on next tick`() = runTest {
+    fun `pollIncomingMessages throws on network error so retryWhen can restart it`() = runTest {
+        val engine = MockEngine { respondError(HttpStatusCode.InternalServerError) }
+        val client = HttpClient(engine) {
+            install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+        val apiService = YaloChatApiService(
+            apiBaseUrl = "https://api.test", authToken = "a", userToken = "u", flowKey = "f",
+            httpClient = client,
+        )
+        val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
+        // The flow should throw so the caller's retryWhen can restart it.
+        var threw = false
+        try {
+            repo.pollIncomingMessages().take(1).toList()
+        } catch (_: Exception) {
+            threw = true
+        }
+        assertTrue(threw)
+    }
+
+    @Test
+    fun `pollIncomingMessages resumes after error when retryWhen is applied`() = runTest {
         var callIndex = 0
         val engine = MockEngine {
             callIndex++
@@ -148,8 +171,10 @@ class YaloMessageRepositoryRemoteTest {
             httpClient = client,
         )
         val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
-        // First poll errors; second poll succeeds — we should still receive the message
-        val messages = repo.pollIncomingMessages().take(1).toList()
+        // retryWhen restarts after the first error; second poll succeeds
+        val messages = repo.pollIncomingMessages()
+            .retryWhen { _, _ -> true }
+            .take(1).toList()
         assertEquals(1, messages.size)
         assertEquals("After error", messages.first().content)
     }

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/domain/model/MessageTypeTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/domain/model/MessageTypeTest.kt
@@ -34,9 +34,10 @@ class MessageTypeTest {
     }
 
     @Test
-    fun `MessageRole fromString returns USER for unknown value`() {
-        assertEquals(MessageRole.USER, MessageRole.fromString("unknown"))
-        assertEquals(MessageRole.USER, MessageRole.fromString(""))
+    fun `MessageRole fromString returns AGENT for unknown value`() {
+        // Mirrors Flutter SDK: orElse: () => MessageRole.assistant (AGENT)
+        assertEquals(MessageRole.AGENT, MessageRole.fromString("unknown"))
+        assertEquals(MessageRole.AGENT, MessageRole.fromString(""))
     }
 
     @Test

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -15,7 +15,6 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -114,23 +114,6 @@ class MessagesViewModelTest {
         assertEquals("hello", result.result.first().content)
     }
 
-    @Test
-    fun `SendTextMessage on send error marks message as ERROR`() = runTest {
-        val chatRepo = FakeChatMessageRepository()
-        val failingSendRepo = object : YaloMessageRepository {
-            override suspend fun sendMessage(message: ChatMessage) =
-                Result.Error<Unit>(RuntimeException("send failed"))
-            override suspend fun fetchMessages(since: Long) =
-                Result.Ok(emptyList<ChatMessage>())
-            override fun pollIncomingMessages() = emptyFlow<ChatMessage>()
-        }
-        val vm = viewModel(yaloRepo = failingSendRepo, chatRepo = chatRepo)
-        vm.handleEvent(MessagesEvent.SendTextMessage("hello"))
-        val result = chatRepo.getMessages(null, 10)
-        assertIs<Result.Ok<List<ChatMessage>>>(result)
-        assertEquals(MessageStatus.ERROR, result.result.first().status)
-    }
-
     // ── ClearMessages ─────────────────────────────────────────────────────────
 
     @Test
@@ -247,6 +230,9 @@ class MessagesViewModelTest {
         }
         val vm = MessagesViewModel(pollingYaloRepo, chatRepo)
         vm.handleEvent(MessagesEvent.SubscribeToMessages)
+        // advanceUntilIdle() drains all coroutines launched by SubscribeToMessages
+        // (pollIncomingMessages collector + observeMessages collector) before asserting.
+        testScheduler.advanceUntilIdle()
         assertEquals(1, vm.state.value.messages.size)
         assertEquals("from server", vm.state.value.messages.first().content)
         vm.viewModelScope.cancel()

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -15,6 +15,8 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -120,6 +122,7 @@ class MessagesViewModelTest {
                 Result.Error<Unit>(RuntimeException("send failed"))
             override suspend fun fetchMessages(since: Long) =
                 Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages() = emptyFlow<ChatMessage>()
         }
         val vm = viewModel(yaloRepo = failingSendRepo, chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SendTextMessage("hello"))
@@ -224,6 +227,28 @@ class MessagesViewModelTest {
                 quickReplies = listOf("Option A", "Option B"))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
+        vm.viewModelScope.cancel()
+    }
+
+    // ── Phase 2 — Remote polling ───────────────────────────────────────────────
+
+    @Test
+    fun `SubscribeToMessages inserts polled remote messages into state`() = runTest {
+        val chatRepo = FakeChatMessageRepository()
+        val pollingYaloRepo = object : YaloMessageRepository {
+            override suspend fun sendMessage(message: ChatMessage) = Result.Ok(Unit)
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages() = flowOf(
+                ChatMessage(
+                    role = MessageRole.AGENT, type = MessageType.Text,
+                    status = MessageStatus.DELIVERED, content = "from server",
+                )
+            )
+        }
+        val vm = MessagesViewModel(pollingYaloRepo, chatRepo)
+        vm.handleEvent(MessagesEvent.SubscribeToMessages)
+        assertEquals(1, vm.state.value.messages.size)
+        assertEquals("from server", vm.state.value.messages.first().content)
         vm.viewModelScope.cancel()
     }
 }


### PR DESCRIPTION
## Phase 2 — M1: Networking Layer

Ports \`flutter-sdk/YaloChatClient\` + \`YaloMessageRepositoryRemote\` to Kotlin/Ktor. This is the first Phase 2 PR — all previous PRs (#29, #39, #40) were Phase 1.

## What's in this PR

- **\`YaloChatApiService\`**: Ktor CIO HTTP client wrapping \`POST /inbound_messages\` and \`GET /messages?since=\`. Same headers as Flutter SDK (\`x-user-id\`, \`x-channel-id\`, \`Authorization: Bearer\`). All network errors return \`Result.Error\` — nothing throws.
- **\`YaloTextMessageRequest\` / \`YaloFetchMessagesResponse\`**: \`@Serializable\` models ported from Flutter SDK's \`YaloTextMessageRequest\` + \`YaloFetchMessagesResponse\`.
- **\`YaloMessageRepositoryRemote\`**: 1s polling loop via \`Flow + delay()\`, 5s lookback window. Deduplicates messages by \`wiId\` using \`SimpleCache\`. Network errors are swallowed and the loop continues — mirroring Flutter SDK \`_startPolling()\` which logs the error and falls through to \`Future.delayed\` without breaking the loop.
- **\`SimpleCache\`**: Bounded LRU cache (capacity 500) backed by \`LinkedHashMap(accessOrder=true)\`. Mirrors \`ecache.SimpleCache\` from Flutter SDK.
- **\`YaloMessageRepository\`**: Added \`pollIncomingMessages(): Flow<ChatMessage>\` to the interface. \`FakeYaloMessageRepository\` returns \`emptyFlow()\` — all Phase 1 tests unaffected.
- **\`MessagesViewModel.subscribeToMessages\`**: Launches two coroutines — one for local \`observeMessages()\` (existing) and one that collects \`pollIncomingMessages()\` and inserts into the local store. Insert errors set \`ChatStatus.Failure\`, mirroring Flutter SDK \`_handleMessagesSubscription\` \`onError\` behavior. \`sendMessage\` is fire-and-forget (not awaited), mirroring Flutter SDK \`_handleSendTextMessage\`.
- **\`MessageRole.fromString\` fallback**: Unknown roles fall back to \`AGENT\`, matching Flutter SDK \`orElse: () => MessageRole.assistant\`.
- **\`YaloChatConfig\`**: Added required \`apiBaseUrl\` field.
- **\`YaloChat.init\`**: Wires \`YaloChatApiService\` → \`YaloMessageRepositoryRemote\`. \`FakeChatMessageRepository\` remains until Phase 2 M2 (SQLDelight).
- **\`consumer-proguard-rules.pro\`**: Ktor R8 rules added. kotlinx.serialization keeps scoped to \`com.yalo.chat.sdk.**\` to avoid bloating consuming apps.

## Tests

24 new tests across 3 new test files:
- \`YaloChatApiServiceTest\` (9 tests) — send/fetch success, HTTP errors, network exceptions, header assertions, query params
- \`SimpleCacheTest\` (4 tests) — get/set, LRU eviction, overwrite behavior
- \`YaloMessageRepositoryRemoteTest\` (11 tests) — send, fetch, polling, deduplication, continues-after-error
- \`MessagesViewModelTest\` (+1 test) — \`SubscribeToMessages\` collects polled remote messages into state

All 83 tests pass.

## Test plan

- [ ] All unit tests pass: \`./gradlew :sdk:testDebugUnitTest\`
- [ ] Demo app builds: \`./gradlew :app:assembleDebug\`
- [ ] Set \`apiBaseUrl\` to a real Yalo backend URL in \`MainActivity\` and verify text messages send/receive end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)