### PR TITLE
feat(android-sdk): Phase 2 M2 — Local Storage (FDE-28)

### DIFF
--- a/android-sdk/app/build.gradle.kts
+++ b/android-sdk/app/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 // Copy local.properties.example → local.properties and fill in the values.
 val localProps = Properties().also { props ->
     val file = rootProject.file("local.properties")
-    if (file.exists()) props.load(file.inputStream())
+    if (file.exists()) file.inputStream().use { props.load(it) }
 }
 
 fun localProp(key: String): String {

--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -16,13 +16,14 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         YaloChat.init(
-            YaloChatConfig(
+            config = YaloChatConfig(
                 name = "Yalo Chat",
                 flowKey = BuildConfig.YALO_FLOW_KEY,
                 authToken = BuildConfig.YALO_AUTH_TOKEN,
                 userToken = BuildConfig.YALO_USER_TOKEN,
                 apiBaseUrl = BuildConfig.YALO_API_BASE_URL,
-            )
+            ),
+            context = this,
         )
         setContent {
             ChatScreen()

--- a/android-sdk/gradle/libs.versions.toml
+++ b/android-sdk/gradle/libs.versions.toml
@@ -53,7 +53,7 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 # SQLDelight
 sqldelight-android-driver = { group = "app.cash.sqldelight", name = "android-driver", version.ref = "sqldelight" }
 sqldelight-coroutines-extensions = { group = "app.cash.sqldelight", name = "coroutines-extensions", version.ref = "sqldelight" }
-sqldelight-jdbc-driver = { group = "app.cash.sqldelight", name = "jdbc-driver", version.ref = "sqldelight" }
+sqldelight-jdbc-driver = { group = "app.cash.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
 
 # Hilt (app only — never inside :sdk)
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -4,8 +4,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.ksp)
-    // SQLDelight plugin deferred to Phase 2 — no .sq files yet
-    // alias(libs.plugins.sqldelight)
+    alias(libs.plugins.sqldelight)
 }
 
 android {
@@ -44,8 +43,16 @@ kotlin {
     }
 }
 
-// SQLDelight schema and ChatDatabase configuration deferred to Phase 2 (FDE-54).
-// Will be added here once .sq files exist under src/main/sqldelight/.
+// Phase 2 M2 (FDE-54): SQLDelight schema for local message persistence.
+// Schema file: src/main/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+// KMP note: when splitting to KMP, add NativeSqliteDriver for iosMain here.
+sqldelight {
+    databases {
+        create("ChatDatabase") {
+            packageName.set("com.yalo.chat.sdk.database")
+        }
+    }
+}
 
 dependencies {
     // Compose BOM — all Compose artifact versions come from here

--- a/android-sdk/sdk/consumer-proguard-rules.pro
+++ b/android-sdk/sdk/consumer-proguard-rules.pro
@@ -5,8 +5,9 @@
 
 # ── SQLDelight ─────────────────────────────────────────────────────────────────
 # SQLDelight ships its own consumer ProGuard rules via its AAR.
-# Keep the generated ChatDatabase and query classes so R8 doesn't strip them.
--keep class com.yalo.chat.sdk.database.** { *; }
+# Keep the generated ChatDatabase entry point referenced by the SDK.
+# Narrowed from database.** to avoid preventing shrinking of all generated classes.
+-keep class com.yalo.chat.sdk.database.ChatDatabase { *; }
 
 # ── kotlinx.serialization ─────────────────────────────────────────────────────
 -keepattributes *Annotation*, InnerClasses

--- a/android-sdk/sdk/consumer-proguard-rules.pro
+++ b/android-sdk/sdk/consumer-proguard-rules.pro
@@ -1,7 +1,12 @@
 # Phase 2 M1 — kotlinx.serialization rules (FDE-53).
 # Ktor (ktor-client-android) ships its own consumer ProGuard rules via its AAR;
 # no blanket -keep io.ktor.** needed here — that would prevent shrinking.
-# SQLDelight rules will be added in Phase 2 M2.
+# Phase 2 M2 — SQLDelight rules (FDE-54).
+
+# ── SQLDelight ─────────────────────────────────────────────────────────────────
+# SQLDelight ships its own consumer ProGuard rules via its AAR.
+# Keep the generated ChatDatabase and query classes so R8 doesn't strip them.
+-keep class com.yalo.chat.sdk.database.** { *; }
 
 # ── kotlinx.serialization ─────────────────────────────────────────────────────
 -keepattributes *Annotation*, InnerClasses

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -5,6 +5,7 @@ package com.yalo.chat.sdk
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.yalo.chat.sdk.data.MessageSyncService
 import com.yalo.chat.sdk.data.local.LocalChatMessageRepository
@@ -16,10 +17,6 @@ import com.yalo.chat.sdk.database.ChatDatabase
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 // Port of flutter-sdk YaloChat entry point.
 // Phase 2 M2: wires SQLDelight persistence via LocalChatMessageRepository and
@@ -29,7 +26,7 @@ object YaloChat {
     private var _config: YaloChatConfig? = null
     private var _viewModelFactory: ViewModelProvider.Factory? = null
     private var _httpClient: HttpClient? = null
-    private var _sdkScope: CoroutineScope? = null
+    private var _driver: SqlDriver? = null
     private var _syncService: MessageSyncService? = null
 
     val config: YaloChatConfig
@@ -41,8 +38,8 @@ object YaloChat {
     fun init(config: YaloChatConfig, context: Context) {
         // Tear down any previous instance before re-initialising (idempotent re-init).
         _syncService?.stop()
-        _sdkScope?.cancel()
         _httpClient?.close()
+        _driver?.close()
 
         _config = config
 
@@ -59,17 +56,15 @@ object YaloChat {
         val yaloRepo = YaloMessageRepositoryRemote(apiService)
 
         val driver = AndroidSqliteDriver(ChatDatabase.Schema, context.applicationContext, "chat.db")
+        _driver = driver
         val db = createDatabase(driver)
         val localRepo = LocalChatMessageRepository(db.chatMessageQueries)
 
-        // SDK-owned scope: lives for the duration of the SDK session.
-        // SupervisorJob so MessageSyncService failure doesn't cancel the whole scope.
-        val sdkScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-        _sdkScope = sdkScope
-
+        // Sync service is started lazily by MessagesViewModel.subscribeToMessages() so that
+        // background polling only runs while the chat UI is active, not for the entire
+        // process lifetime. The ViewModel scope governs the polling lifecycle.
         val syncService = MessageSyncService(yaloRepo, localRepo)
         _syncService = syncService
-        syncService.start(sdkScope)
 
         _viewModelFactory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
@@ -77,7 +72,7 @@ object YaloChat {
                 require(modelClass.isAssignableFrom(MessagesViewModel::class.java)) {
                     "Unsupported ViewModel class: $modelClass"
                 }
-                return MessagesViewModel(yaloRepo, localRepo) as T
+                return MessagesViewModel(yaloRepo, localRepo, syncService) as T
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -2,34 +2,53 @@
 
 package com.yalo.chat.sdk
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import app.cash.sqldelight.driver.android.AndroidSqliteDriver
+import com.yalo.chat.sdk.data.MessageSyncService
+import com.yalo.chat.sdk.data.local.LocalChatMessageRepository
+import com.yalo.chat.sdk.data.local.createDatabase
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
 import com.yalo.chat.sdk.data.remote.buildHttpClient
-import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryRemote
+import com.yalo.chat.sdk.database.ChatDatabase
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 
 // Port of flutter-sdk YaloChat entry point.
-// Phase 2 M1: wires real Ktor networking via YaloMessageRepositoryRemote.
-// Phase 2 M2: will replace FakeChatMessageRepository with SQLDelight persistence.
+// Phase 2 M2: wires SQLDelight persistence via LocalChatMessageRepository and
+// MessageSyncService, replacing FakeChatMessageRepository.
 object YaloChat {
 
     private var _config: YaloChatConfig? = null
     private var _viewModelFactory: ViewModelProvider.Factory? = null
     private var _httpClient: HttpClient? = null
+    private var _sdkScope: CoroutineScope? = null
+    private var _syncService: MessageSyncService? = null
 
     val config: YaloChatConfig
         get() = _config ?: error("YaloChat.init() must be called before accessing config")
 
-    fun init(config: YaloChatConfig) {
-        // Close any previously created client before replacing it (idempotent re-init).
+    // context: needed to construct AndroidSqliteDriver for the local SQLite database.
+    // KMP note: when splitting to KMP, YaloChat.kt moves to androidMain; iosMain
+    // counterpart will provide NativeSqliteDriver without a Context.
+    fun init(config: YaloChatConfig, context: Context) {
+        // Tear down any previous instance before re-initialising (idempotent re-init).
+        _syncService?.stop()
+        _sdkScope?.cancel()
         _httpClient?.close()
+
         _config = config
+
         val httpClient = buildHttpClient(Android.create(), debug = BuildConfig.DEBUG)
         _httpClient = httpClient
+
         val apiService = YaloChatApiService(
             apiBaseUrl = config.apiBaseUrl,
             authToken = config.authToken,
@@ -38,15 +57,27 @@ object YaloChat {
             httpClient = httpClient,
         )
         val yaloRepo = YaloMessageRepositoryRemote(apiService)
-        // Phase 2 M2 will replace FakeChatMessageRepository with ChatMessageRepositoryLocal (SQLDelight).
-        val chatRepo = FakeChatMessageRepository()
+
+        val driver = AndroidSqliteDriver(ChatDatabase.Schema, context.applicationContext, "chat.db")
+        val db = createDatabase(driver)
+        val localRepo = LocalChatMessageRepository(db.chatMessageQueries)
+
+        // SDK-owned scope: lives for the duration of the SDK session.
+        // SupervisorJob so MessageSyncService failure doesn't cancel the whole scope.
+        val sdkScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        _sdkScope = sdkScope
+
+        val syncService = MessageSyncService(yaloRepo, localRepo)
+        _syncService = syncService
+        syncService.start(sdkScope)
+
         _viewModelFactory = object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel> create(modelClass: Class<T>): T {
                 require(modelClass.isAssignableFrom(MessagesViewModel::class.java)) {
                     "Unsupported ViewModel class: $modelClass"
                 }
-                return MessagesViewModel(yaloRepo, chatRepo) as T
+                return MessagesViewModel(yaloRepo, localRepo) as T
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/YaloChat.kt
@@ -63,7 +63,11 @@ object YaloChat {
         // Sync service is started lazily by MessagesViewModel.subscribeToMessages() so that
         // background polling only runs while the chat UI is active, not for the entire
         // process lifetime. The ViewModel scope governs the polling lifecycle.
-        val syncService = MessageSyncService(yaloRepo, localRepo)
+        val syncService = MessageSyncService(
+            yaloRepo = yaloRepo,
+            localRepo = localRepo,
+            onSyncError = { e -> android.util.Log.e("MessageSyncService", "insertMessages failed", e) },
+        )
         _syncService = syncService
 
         _viewModelFactory = object : ViewModelProvider.Factory {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
@@ -1,0 +1,45 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data
+
+import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
+import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+
+// Port of flutter-sdk YaloMessageRepositoryRemote._startPolling() + _handleMessagesSubscription().
+// Separates the remote polling concern from MessagesViewModel — the ViewModel only observes
+// the local store, while this service keeps the local store in sync with the server.
+//
+// Data flow:
+//   YaloMessageRepositoryRemote.pollIncomingMessages()
+//     → emit(batch) on each non-empty poll cycle
+//     → MessageSyncService inserts batch into LocalChatMessageRepository (single transaction)
+//     → LocalChatMessageRepository.observeMessages() emits updated list
+//     → MessagesViewModel updates UI
+//
+// FDE-56: Free of Android-specific imports (KMP-compatible).
+class MessageSyncService(
+    private val yaloRepo: YaloMessageRepository,
+    private val localRepo: ChatMessageRepository,
+) {
+    private var job: Job? = null
+
+    // Start polling. Idempotent — calling while already active is a no-op.
+    fun start(scope: CoroutineScope) {
+        if (job?.isActive == true) return
+        job = scope.launch {
+            yaloRepo.pollIncomingMessages().collect { batch ->
+                // Insert the whole poll batch in one SQLDelight transaction.
+                // Errors are ignored — polling continues on the next cycle.
+                localRepo.insertMessages(batch)
+            }
+        }
+    }
+
+    fun stop() {
+        job?.cancel()
+        job = null
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
@@ -21,9 +21,12 @@ import kotlinx.coroutines.launch
 //     → MessagesViewModel updates UI
 //
 // FDE-56: Free of Android-specific imports (KMP-compatible).
-class MessageSyncService(
+internal class MessageSyncService(
     private val yaloRepo: YaloMessageRepository,
     private val localRepo: ChatMessageRepository,
+    // Optional callback for insert failures — avoids println in library code.
+    // YaloChat wires this to android.util.Log; tests can pass a capturing lambda.
+    private val onSyncError: ((Throwable) -> Unit)? = null,
 ) {
     private var job: Job? = null
 
@@ -36,8 +39,7 @@ class MessageSyncService(
                 // Polling continues on the next cycle regardless of insert outcome.
                 val result = localRepo.insertMessages(batch)
                 if (result is Result.Error) {
-                    // Surface failures so SDK consumers can observe sync issues.
-                    println("MessageSyncService: insertMessages failed — ${result.error.message}")
+                    onSyncError?.invoke(result.error)
                 }
             }
         }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
@@ -2,6 +2,7 @@
 
 package com.yalo.chat.sdk.data
 
+import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import kotlinx.coroutines.CoroutineScope
@@ -32,8 +33,12 @@ class MessageSyncService(
         job = scope.launch {
             yaloRepo.pollIncomingMessages().collect { batch ->
                 // Insert the whole poll batch in one SQLDelight transaction.
-                // Errors are ignored — polling continues on the next cycle.
-                localRepo.insertMessages(batch)
+                // Polling continues on the next cycle regardless of insert outcome.
+                val result = localRepo.insertMessages(batch)
+                if (result is Result.Error) {
+                    // Surface failures so SDK consumers can observe sync issues.
+                    println("MessageSyncService: insertMessages failed — ${result.error.message}")
+                }
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/DatabaseFactory.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/DatabaseFactory.kt
@@ -11,4 +11,4 @@ import com.yalo.chat.sdk.database.ChatDatabase
 // JSON columns (amplitudes, products, quick_replies) are stored as TEXT and decoded
 // manually in LocalChatMessageRepository using kotlinx.serialization — no ColumnAdapters needed.
 // KMP note: when splitting to KMP, iosMain will provide NativeSqliteDriver.
-fun createDatabase(driver: SqlDriver): ChatDatabase = ChatDatabase(driver)
+internal fun createDatabase(driver: SqlDriver): ChatDatabase = ChatDatabase(driver)

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/DatabaseFactory.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/DatabaseFactory.kt
@@ -1,0 +1,14 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.local
+
+import app.cash.sqldelight.db.SqlDriver
+import com.yalo.chat.sdk.database.ChatDatabase
+
+// Factory: constructs ChatDatabase with the given platform SqlDriver.
+//   Android → AndroidSqliteDriver(ChatDatabase.Schema, context, "chat.db") — wired in YaloChat.kt
+//   Tests   → JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY) with ChatDatabase.Schema.create(driver)
+// JSON columns (amplitudes, products, quick_replies) are stored as TEXT and decoded
+// manually in LocalChatMessageRepository using kotlinx.serialization — no ColumnAdapters needed.
+// KMP note: when splitting to KMP, iosMain will provide NativeSqliteDriver.
+fun createDatabase(driver: SqlDriver): ChatDatabase = ChatDatabase(driver)

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -25,7 +25,7 @@ import kotlinx.serialization.json.Json
 // Port of flutter-sdk ChatMessageRepositoryLocal (Drift) — same schema, same query semantics.
 // Free of Android-specific imports: ChatMessageQueries is injected, ioDispatcher is injectable.
 // KMP note: when splitting to KMP, pass the appropriate CoroutineDispatcher from the platform.
-class LocalChatMessageRepository(
+internal class LocalChatMessageRepository(
     private val queries: ChatMessageQueries,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ChatMessageRepository {
@@ -46,8 +46,11 @@ class LocalChatMessageRepository(
         }
 
     // INSERT OR REPLACE a single message — used by MessagesViewModel for optimistic sends.
-    override suspend fun insertMessage(message: ChatMessage): Result<Unit> =
-        withContext(ioDispatcher) {
+    override suspend fun insertMessage(message: ChatMessage): Result<Unit> {
+        if (message.id == null) return Result.Error(
+            IllegalArgumentException("Cannot insert a message with null id")
+        )
+        return withContext(ioDispatcher) {
             try {
                 queries.insertOrReplace(message.toRow())
                 Result.Ok(Unit)
@@ -55,11 +58,16 @@ class LocalChatMessageRepository(
                 Result.Error(e)
             }
         }
+    }
 
     // Batch INSERT OR REPLACE in a single transaction — used by MessageSyncService.
     // Port of Flutter insertChatMessage called in a loop inside a Drift transaction.
-    override suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit> =
-        withContext(ioDispatcher) {
+    override suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit> {
+        val nullIdMessage = messages.firstOrNull { it.id == null }
+        if (nullIdMessage != null) return Result.Error(
+            IllegalArgumentException("Cannot insert a message with null id (content: ${nullIdMessage.content})")
+        )
+        return withContext(ioDispatcher) {
             try {
                 queries.transaction {
                     messages.forEach { queries.insertOrReplace(it.toRow()) }
@@ -69,6 +77,7 @@ class LocalChatMessageRepository(
                 Result.Error(e)
             }
         }
+    }
 
     // UPDATE an existing message (e.g., status change after server confirmation).
     override suspend fun updateMessage(message: ChatMessage): Result<Unit> =
@@ -111,7 +120,7 @@ class LocalChatMessageRepository(
     )
 
     private fun ChatMessage.toRow(): InsertOrReplaceParams = InsertOrReplaceParams(
-        id = id ?: error("ChatMessage.id must not be null when persisting"),
+        id = id!!, // null check already done in insertMessage/insertMessages/updateMessage
         wi_id = wiId,
         role = role.value,
         content = content,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -1,0 +1,183 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.local
+
+import app.cash.sqldelight.coroutines.asFlow
+import app.cash.sqldelight.coroutines.mapToList
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.database.ChatMessageQueries
+import com.yalo.chat.sdk.database.Chat_message
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.model.Product
+import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.builtins.ListSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+
+// Port of flutter-sdk ChatMessageRepositoryLocal (Drift) — same schema, same query semantics.
+// Free of Android-specific imports: ChatMessageQueries is injected, ioDispatcher is injectable.
+// KMP note: when splitting to KMP, pass the appropriate CoroutineDispatcher from the platform.
+class LocalChatMessageRepository(
+    private val queries: ChatMessageQueries,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ChatMessageRepository {
+
+    // GET first page (no cursor) or cursor page — mirrors Flutter getChatMessagePageDesc.
+    override suspend fun getMessages(cursor: Long?, limit: Int): Result<List<ChatMessage>> =
+        withContext(ioDispatcher) {
+            try {
+                val rows = if (cursor == null) {
+                    queries.selectFirstPage(limit.toLong()).executeAsList()
+                } else {
+                    queries.selectPageBefore(cursor, limit.toLong()).executeAsList()
+                }
+                Result.Ok(rows.map { it.toDomain() })
+            } catch (e: Exception) {
+                Result.Error(e)
+            }
+        }
+
+    // INSERT OR REPLACE a single message — used by MessagesViewModel for optimistic sends.
+    override suspend fun insertMessage(message: ChatMessage): Result<Unit> =
+        withContext(ioDispatcher) {
+            try {
+                queries.insertOrReplace(message.toRow())
+                Result.Ok(Unit)
+            } catch (e: Exception) {
+                Result.Error(e)
+            }
+        }
+
+    // Batch INSERT OR REPLACE in a single transaction — used by MessageSyncService.
+    // Port of Flutter insertChatMessage called in a loop inside a Drift transaction.
+    override suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit> =
+        withContext(ioDispatcher) {
+            try {
+                queries.transaction {
+                    messages.forEach { queries.insertOrReplace(it.toRow()) }
+                }
+                Result.Ok(Unit)
+            } catch (e: Exception) {
+                Result.Error(e)
+            }
+        }
+
+    // UPDATE an existing message (e.g., status change after server confirmation).
+    override suspend fun updateMessage(message: ChatMessage): Result<Unit> =
+        withContext(ioDispatcher) {
+            if (message.id == null) return@withContext Result.Error(
+                IllegalArgumentException("Cannot update a message with null id")
+            )
+            try {
+                queries.insertOrReplace(message.toRow())
+                Result.Ok(Unit)
+            } catch (e: Exception) {
+                Result.Error(e)
+            }
+        }
+
+    // Live observation: emits updated list whenever chat_message table changes.
+    // Port of Flutter stream returned by Drift's watchX.
+    // Uses SQLDelight coroutines-extensions asFlow + mapToList.
+    override fun observeMessages(): Flow<List<ChatMessage>> =
+        queries.observeConversation()
+            .asFlow()
+            .mapToList(ioDispatcher)
+            .map { rows -> rows.map { it.toDomain() } }
+
+    // ── Mappers ───────────────────────────────────────────────────────────────
+
+    private fun Chat_message.toDomain(): ChatMessage = ChatMessage(
+        id = id,
+        wiId = wi_id,
+        role = MessageRole.fromString(role),
+        type = MessageType.fromString(type),
+        status = MessageStatus.fromString(status),
+        content = content,
+        fileName = file_name,
+        amplitudes = amplitudes?.let { decodeDoubleList(it) } ?: emptyList(),
+        duration = duration,
+        products = products?.let { decodeProductList(it) } ?: emptyList(),
+        quickReplies = quick_replies?.let { decodeStringList(it) } ?: emptyList(),
+        timestamp = timestamp,
+    )
+
+    private fun ChatMessage.toRow(): InsertOrReplaceParams = InsertOrReplaceParams(
+        id = id ?: error("ChatMessage.id must not be null when persisting"),
+        wi_id = wiId,
+        role = role.value,
+        content = content,
+        type = type.value,
+        status = status.value,
+        file_name = fileName,
+        amplitudes = amplitudes.takeIf { it.isNotEmpty() }?.let { encodeDoubleList(it) },
+        duration = duration,
+        products = products.takeIf { it.isNotEmpty() }?.let { encodeProductList(it) },
+        quick_replies = quickReplies.takeIf { it.isNotEmpty() }?.let { encodeStringList(it) },
+        timestamp = timestamp,
+    )
+
+    // ── JSON helpers ──────────────────────────────────────────────────────────
+
+    private val doubleListSerializer = ListSerializer(Double.serializer())
+    private val productListSerializer = ListSerializer(Product.serializer())
+    private val stringListSerializer = ListSerializer(String.serializer())
+
+    private fun decodeDoubleList(json: String): List<Double> =
+        try { Json.decodeFromString(doubleListSerializer, json) } catch (_: Exception) { emptyList() }
+
+    private fun decodeProductList(json: String): List<Product> =
+        try { Json.decodeFromString(productListSerializer, json) } catch (_: Exception) { emptyList() }
+
+    private fun decodeStringList(json: String): List<String> =
+        try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { emptyList() }
+
+    private fun encodeDoubleList(list: List<Double>): String =
+        Json.encodeToString(doubleListSerializer, list)
+
+    private fun encodeProductList(list: List<Product>): String =
+        Json.encodeToString(productListSerializer, list)
+
+    private fun encodeStringList(list: List<String>): String =
+        Json.encodeToString(stringListSerializer, list)
+}
+
+// Struct to carry insertOrReplace parameters (avoids a long positional call site).
+private data class InsertOrReplaceParams(
+    val id: Long,
+    val wi_id: String?,
+    val role: String,
+    val content: String,
+    val type: String,
+    val status: String,
+    val file_name: String?,
+    val amplitudes: String?,
+    val duration: Long?,
+    val products: String?,
+    val quick_replies: String?,
+    val timestamp: Long,
+)
+
+private fun ChatMessageQueries.insertOrReplace(p: InsertOrReplaceParams) =
+    insertOrReplace(
+        id = p.id,
+        wi_id = p.wi_id,
+        role = p.role,
+        content = p.content,
+        type = p.type,
+        status = p.status,
+        file_name = p.file_name,
+        amplitudes = p.amplitudes,
+        duration = p.duration,
+        products = p.products,
+        quick_replies = p.quick_replies,
+        timestamp = p.timestamp,
+    )

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -31,7 +31,7 @@ private const val HEADER_AUTHORIZATION = "Authorization"
 // YaloChat.kt on Android passes an Android-engine client, tests pass a MockEngine client.
 // When splitting to KMP: YaloChat.kt moves to androidMain and provides the Android engine;
 // an iosMain counterpart provides the Darwin engine.
-class YaloChatApiService(
+internal class YaloChatApiService(
     private val apiBaseUrl: String,
     private val authToken: String,
     private val userToken: String,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -71,7 +71,8 @@ class YaloChatApiService(
 
 // Builds a configured HttpClient with ContentNegotiation (JSON) and optional debug logging.
 // Called from YaloChat.kt with the platform engine (Android/Darwin/etc.).
-fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, debug: Boolean): HttpClient =
+// internal: not part of the public SDK API surface.
+internal fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, debug: Boolean): HttpClient =
     HttpClient(engine) {
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
@@ -81,9 +82,14 @@ fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, debug: Boole
                 logger = object : io.ktor.client.plugins.logging.Logger {
                     override fun log(message: String) { println(message) }
                 }
-                level = io.ktor.client.plugins.logging.LogLevel.ALL
-                // Redact the Bearer token so it never appears in Logcat.
-                sanitizeHeader { header -> header == io.ktor.http.HttpHeaders.Authorization }
+                // HEADERS only — avoids logging request/response bodies in plaintext.
+                level = io.ktor.client.plugins.logging.LogLevel.HEADERS
+                // Redact sensitive headers so they never appear in Logcat.
+                sanitizeHeader { header ->
+                    header == io.ktor.http.HttpHeaders.Authorization ||
+                        header.equals(HEADER_USER_ID, ignoreCase = true) ||
+                        header.equals(HEADER_CHANNEL_ID, ignoreCase = true)
+                }
             }
         }
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 // Port of flutter-sdk YaloFetchMessagesResponse + YaloMessage.
 // snake_case server fields are mapped via @SerialName.
 @Serializable
-data class YaloFetchMessagesResponse(
+internal data class YaloFetchMessagesResponse(
     val id: String,
     val message: YaloMessageDto,
     val date: String,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloTextMessageRequest.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/remote/model/YaloTextMessageRequest.kt
@@ -8,13 +8,13 @@ import kotlinx.serialization.Serializable
 // The outer wrapper carries the epoch-second timestamp of the send request;
 // the inner content carries the message payload.
 @Serializable
-data class YaloTextMessageRequest(
+internal data class YaloTextMessageRequest(
     val timestamp: Long,
     val content: YaloTextMessage,
 )
 
 @Serializable
-data class YaloTextMessage(
+internal data class YaloTextMessage(
     val timestamp: Long,
     val text: String,
     val status: String,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
@@ -33,6 +33,12 @@ class FakeChatMessageRepository(
         return Result.Ok(Unit)
     }
 
+    override suspend fun insertMessages(messagesToInsert: List<ChatMessage>): Result<Unit> {
+        messages.addAll(messagesToInsert)
+        _flow.value = messages.toList()
+        return Result.Ok(Unit)
+    }
+
     override suspend fun updateMessage(message: ChatMessage): Result<Unit> {
         if (message.id == null) return Result.Error(IllegalArgumentException("Cannot update a message with null id"))
         val index = messages.indexOfFirst { it.id == message.id }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepository.kt
@@ -34,7 +34,19 @@ class FakeChatMessageRepository(
     }
 
     override suspend fun insertMessages(messagesToInsert: List<ChatMessage>): Result<Unit> {
-        messages.addAll(messagesToInsert)
+        // Mirror INSERT OR REPLACE semantics: replace existing entry by id when present.
+        val indexById = messages.withIndex()
+            .mapNotNull { (i, m) -> m.id?.let { it to i } }
+            .toMap(mutableMapOf())
+        messagesToInsert.forEach { message ->
+            val existingIndex = message.id?.let { indexById[it] }
+            if (existingIndex != null) {
+                messages[existingIndex] = message
+            } else {
+                messages.add(message)
+                message.id?.let { indexById[it] = messages.lastIndex }
+            }
+        }
         _flow.value = messages.toList()
         return Result.Ok(Unit)
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
@@ -23,7 +23,7 @@ class FakeYaloMessageRepository : YaloMessageRepository {
         Result.Ok(SEED_MESSAGES)
 
     // No-op: Phase 1 has no remote polling — the fake repo provides seed data only.
-    override fun pollIncomingMessages(): Flow<ChatMessage> = emptyFlow()
+    override fun pollIncomingMessages(): Flow<List<ChatMessage>> = emptyFlow()
 
     companion object {
         val SEED_MESSAGES: List<ChatMessage> = listOf(

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/SimpleCache.kt
@@ -6,7 +6,7 @@ package com.yalo.chat.sdk.data.repository.remote
 // messages within the polling lookback window.
 // Mirrors the ecache SimpleCache used in the Flutter SDK (capacity = 500).
 // Thread-safe via @Synchronized on each accessor.
-class SimpleCache<K, V>(private val capacity: Int) {
+internal class SimpleCache<K, V>(private val capacity: Int) {
 
     init {
         require(capacity > 0) { "capacity must be > 0, was $capacity" }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -85,13 +85,17 @@ class YaloMessageRepositoryRemote(
     private fun YaloFetchMessagesResponse.toChatMessage(deduplicate: Boolean): ChatMessage? {
         if (deduplicate && cache.get(id) != null) return null
         if (deduplicate) cache.set(id, true)
+        val ts = parseIso8601(date)
         return ChatMessage(
+            // Use the epoch-millis timestamp as the stable Long primary key.
+            // The server id (UUID string) is stored in wiId and drives deduplication via the cache.
+            id = if (ts != 0L) ts else id.hashCode().toLong(),
             wiId = id,
             role = MessageRole.fromString(message.role),
             type = MessageType.Text, // Phase 2 M1: only text detected
             status = MessageStatus.DELIVERED,
             content = message.text,
-            timestamp = parseIso8601(date),
+            timestamp = ts,
         )
     }
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -26,7 +26,7 @@ import kotlinx.datetime.Instant
 //
 // KMP note: all platform-specific imports (java.text.*, java.util.*) have been replaced
 // with kotlinx-datetime so this file is ready for a commonMain source set.
-class YaloMessageRepositoryRemote(
+internal class YaloMessageRepositoryRemote(
     private val apiService: YaloChatApiService,
     // Exposed as internal so tests can override the interval without waiting.
     internal val pollingIntervalMs: Long = 1_000L,
@@ -86,10 +86,14 @@ class YaloMessageRepositoryRemote(
         if (deduplicate && cache.get(id) != null) return null
         if (deduplicate) cache.set(id, true)
         val ts = parseIso8601(date)
+        // Build a collision-resistant Long primary key:
+        //   upper: second-precision epoch (handles server dates with no sub-second component)
+        //   lower: 0–999 from wiId hash, so messages in the same second get distinct ids.
+        // For ts == 0 (malformed date) the id is just the hash offset — sorts before real messages.
+        val hashOffset = ((id.hashCode() % 1000) + 1000) % 1000
+        val stableId = if (ts != 0L) (ts / 1000L) * 1000L + hashOffset else hashOffset.toLong()
         return ChatMessage(
-            // Use the epoch-millis timestamp as the stable Long primary key.
-            // The server id (UUID string) is stored in wiId and drives deduplication via the cache.
-            id = if (ts != 0L) ts else id.hashCode().toLong(),
+            id = stableId,
             wiId = id,
             role = MessageRole.fromString(message.role),
             type = MessageType.Text, // Phase 2 M1: only text detected

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -105,5 +105,7 @@ private fun parseIso8601(date: String): Long =
     try {
         Instant.parse(date).toEpochMilliseconds()
     } catch (_: Exception) {
-        Clock.System.now().toEpochMilliseconds()
+        // Fallback to 0 so malformed dates sort before all real messages
+        // rather than jumping to "now" and breaking chronological ordering.
+        0L
     }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -64,18 +64,18 @@ class YaloMessageRepositoryRemote(
             is Result.Error -> Result.Error(result.error)
         }
 
-    // Continuous polling flow — emits each new inbound ChatMessage as it arrives.
-    // Uses the LRU cache so the same message (identified by wiId) is never emitted twice.
-    // Network errors are logged and swallowed — the loop continues on the next tick,
-    // mirroring flutter-sdk YaloMessageRepositoryRemote._startPolling() which logs
-    // the error and falls through to Future.delayed without breaking the loop.
-    override fun pollIncomingMessages(): Flow<ChatMessage> = flow {
+    // Continuous polling flow — each emission is the de-duplicated batch of new messages
+    // from one poll cycle. Empty batches are suppressed so downstream only sees real data.
+    // Network errors are swallowed and the loop continues on the next tick, mirroring
+    // flutter-sdk YaloMessageRepositoryRemote._startPolling().
+    override fun pollIncomingMessages(): Flow<List<ChatMessage>> = flow {
         while (true) {
             val since = Clock.System.now().epochSeconds - lookbackSecs
             when (val result = apiService.fetchMessages(since)) {
-                is Result.Ok -> result.result
-                    .mapNotNull { it.toChatMessage(deduplicate = true) }
-                    .forEach { emit(it) }
+                is Result.Ok -> {
+                    val batch = result.result.mapNotNull { it.toChatMessage(deduplicate = true) }
+                    if (batch.isNotEmpty()) emit(batch)
+                }
                 is Result.Error -> Unit // swallow, loop continues — mirrors Flutter SDK
             }
             delay(pollingIntervalMs)

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/model/Product.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/model/Product.kt
@@ -2,8 +2,11 @@
 
 package com.yalo.chat.sdk.domain.model
 
+import kotlinx.serialization.Serializable
+
 // Port of flutter-sdk/lib/domain/models/product/product.dart
 // All fields mirror the Flutter model exactly, including unit/subunit handling.
+@Serializable
 data class Product(
     val sku: String,
     val name: String,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/ChatMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/ChatMessageRepository.kt
@@ -8,10 +8,12 @@ import kotlinx.coroutines.flow.Flow
 
 // Port of flutter-sdk/lib/src/data/repositories/chat_message_repository.dart
 // Phase 1: implemented by FakeChatMessageRepository (in-memory MutableList).
-// Phase 2: implemented by ChatMessageRepositoryLocal (SQLDelight).
+// Phase 2: implemented by LocalChatMessageRepository (SQLDelight).
 interface ChatMessageRepository {
     suspend fun getMessages(cursor: Long?, limit: Int): Result<List<ChatMessage>>
     suspend fun insertMessage(message: ChatMessage): Result<Unit>
+    // Batch upsert in a single DB transaction — used by MessageSyncService on each poll cycle.
+    suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit>
     suspend fun updateMessage(message: ChatMessage): Result<Unit>
     fun observeMessages(): Flow<List<ChatMessage>>
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
@@ -13,8 +13,9 @@ interface YaloMessageRepository {
     suspend fun sendMessage(message: ChatMessage): Result<Unit>
     suspend fun fetchMessages(since: Long): Result<List<ChatMessage>>
 
-    // Phase 2: continuous polling flow — emits new inbound messages from the server.
+    // Phase 2: continuous polling flow — each emission is the batch of new messages
+    // from one poll cycle. Empty batches are suppressed; only non-empty lists are emitted.
     // FakeYaloMessageRepository returns emptyFlow() (no-op for Phase 1 tests).
-    // YaloMessageRepositoryRemote uses a 1s polling loop with a 5s lookback window.
-    fun pollIncomingMessages(): Flow<ChatMessage>
+    // YaloMessageRepositoryRemote polls on a 1s interval with a 5s lookback window.
+    fun pollIncomingMessages(): Flow<List<ChatMessage>>
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.Composable
 // Phase 2 will add chatIconImage, shop/cart action buttons, and status text.
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ChatAppBar(title: String) {
+internal fun ChatAppBar(title: String) {
     TopAppBar(
         title = { Text(text = title) },
     )

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.unit.dp
 // Port of flutter-sdk ChatInput — Phase 1: text field + send button only.
 // Phase 2 will add attachment button, voice recorder, image preview, and quick replies.
 @Composable
-fun ChatInput(
+internal fun ChatInput(
     userMessage: String,
     onUserMessageChange: (String) -> Unit,
     onSendMessage: () -> Unit,

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -22,7 +22,7 @@ import com.yalo.chat.sdk.domain.model.MessageType
 // Phase 1: text only; others rendered as "[type]" placeholder.
 // Phase 2 will add image, voice, product, productCarousel, promotion, quickReply widgets.
 @Composable
-fun MessageItem(message: ChatMessage) {
+internal fun MessageItem(message: ChatMessage) {
     val isUser = message.role == MessageRole.USER
     Row(
         modifier = Modifier

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
@@ -18,7 +18,7 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 // Port of flutter-sdk MessageList — reverse layout mirrors ListView.builder(reverse: true).
 // Items sorted newest-first so item[0] appears at the bottom of the reversed column.
 @Composable
-fun MessageList(
+internal fun MessageList(
     messages: List<ChatMessage>,
     modifier: Modifier = Modifier,
 ) {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -5,6 +5,7 @@ package com.yalo.chat.sdk.ui.chat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.MessageSyncService
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -26,6 +27,8 @@ import kotlinx.coroutines.launch
 class MessagesViewModel(
     private val yaloMessageRepository: YaloMessageRepository,
     private val chatMessageRepository: ChatMessageRepository,
+    // null in tests — sync is driven externally (or not at all) in unit tests.
+    private val syncService: MessageSyncService? = null,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(MessagesState())
@@ -44,7 +47,10 @@ class MessagesViewModel(
             is MessagesEvent.SubscribeToMessages -> subscribeToMessages()
             is MessagesEvent.SendTextMessage -> sendTextMessage(event.text)
             is MessagesEvent.UpdateUserMessage -> _state.update { it.copy(userMessage = event.value) }
-            is MessagesEvent.ClearMessages -> _state.value = MessagesState()
+            is MessagesEvent.ClearMessages -> {
+                syncService?.stop()
+                _state.value = MessagesState()
+            }
             is MessagesEvent.ClearQuickReplies -> _state.update { it.copy(quickReplies = emptyList()) }
         }
     }
@@ -74,6 +80,9 @@ class MessagesViewModel(
     private fun subscribeToMessages() {
         // Return early if already collecting — makes this call idempotent.
         if (subscriptionJob?.isActive == true) return
+        // Start remote polling lazily so it only runs while the chat UI is active.
+        // Polling is scoped to viewModelScope and stops automatically when the ViewModel is cleared.
+        syncService?.start(viewModelScope)
         // Observe local store — MessageSyncService writes remote messages here,
         // so the UI always reads from a single source of truth (SQLDelight / fake repo).
         subscriptionJob = viewModelScope.launch {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -14,13 +14,15 @@ import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.supervisorScope
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 // Port of flutter-sdk/lib/src/ui/chat/view_models/messages/messages_bloc.dart
+// Phase 2 M2: subscribeToMessages() now only observes the local store.
+// Remote polling is handled by MessageSyncService (FDE-56), which writes incoming
+// server messages to SQLDelight so the observeMessages() flow picks them up.
 class MessagesViewModel(
     private val yaloMessageRepository: YaloMessageRepository,
     private val chatMessageRepository: ChatMessageRepository,
@@ -70,38 +72,17 @@ class MessagesViewModel(
     }
 
     private fun subscribeToMessages() {
-        // Return early if already collecting — makes this call idempotent without
-        // the brief window where two collectors could be active after cancel+launch.
+        // Return early if already collecting — makes this call idempotent.
         if (subscriptionJob?.isActive == true) return
+        // Observe local store — MessageSyncService writes remote messages here,
+        // so the UI always reads from a single source of truth (SQLDelight / fake repo).
         subscriptionJob = viewModelScope.launch {
-            // supervisorScope isolates the two child coroutines: an unexpected failure in
-            // one (e.g., an unhandled throw from a Flow collect) does not cancel the other.
-            supervisorScope {
-                // 1. Observe local store — drives all UI updates.
-                launch {
-                    chatMessageRepository.observeMessages().collect { messages ->
-                        _state.update {
-                            it.copy(
-                                messages = messages,
-                                quickReplies = messages.extractQuickReplies(),
-                            )
-                        }
-                    }
-                }
-                // 2. Poll remote for new inbound messages; insert into local store so
-                //    the observer above picks them up automatically.
-                //    Errors are swallowed inside pollIncomingMessages(), mirroring
-                //    flutter-sdk YaloMessageRepositoryRemote._startPolling().
-                launch {
-                    yaloMessageRepository.pollIncomingMessages()
-                        .collect { message ->
-                            // Mirror Flutter _handleMessagesSubscription: on insert error the
-                            // message is dropped and the chat is marked as failed to receive.
-                            when (chatMessageRepository.insertMessage(message)) {
-                                is Result.Ok -> Unit
-                                is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
-                            }
-                        }
+            chatMessageRepository.observeMessages().collect { messages ->
+                _state.update {
+                    it.copy(
+                        messages = messages,
+                        quickReplies = messages.extractQuickReplies(),
+                    )
                 }
             }
         }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -102,9 +102,14 @@ class MessagesViewModel(
             when (chatMessageRepository.insertMessage(optimistic)) {
                 is Result.Ok -> {
                     _state.update { it.copy(userMessage = "") }
-                    // Fire-and-forget — mirrors Flutter SDK MessagesBloc._handleSendTextMessage
-                    // which calls _yaloMessageRepository.sendMessage() without awaiting.
-                    launch { yaloMessageRepository.sendMessage(optimistic) }
+                    // Send to remote and update the optimistic message on failure.
+                    launch {
+                        if (yaloMessageRepository.sendMessage(optimistic) is Result.Error) {
+                            chatMessageRepository.updateMessage(
+                                optimistic.copy(status = MessageStatus.ERROR)
+                            )
+                        }
+                    }
                 }
                 is Result.Error -> _state.update { it.copy(chatStatus = ChatStatus.Failure) }
             }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -24,7 +24,7 @@ import kotlinx.coroutines.launch
 // Phase 2 M2: subscribeToMessages() now only observes the local store.
 // Remote polling is handled by MessageSyncService (FDE-56), which writes incoming
 // server messages to SQLDelight so the observeMessages() flow picks them up.
-class MessagesViewModel(
+internal class MessagesViewModel(
     private val yaloMessageRepository: YaloMessageRepository,
     private val chatMessageRepository: ChatMessageRepository,
     // null in tests — sync is driven externally (or not at all) in unit tests.
@@ -37,9 +37,12 @@ class MessagesViewModel(
     // Keeps the active subscription job so SubscribeToMessages is idempotent.
     private var subscriptionJob: Job? = null
 
-    // Decrementing counter for optimistic temp IDs — always negative so they
-    // never collide with real server IDs (which are positive).
-    private val tempIdSeq = AtomicLong(-1L)
+    // Incrementing counter seeded from current epoch-ms so optimistic temp IDs:
+    //  1. Never collide across sessions (different session → different starting time)
+    //  2. Sort at the bottom in ORDER BY id ASC (most recent, correct chat position)
+    // Server message IDs are also epoch-ms based, so optimistic and server messages
+    // interleave correctly by send time.
+    private val tempIdSeq = AtomicLong(System.currentTimeMillis())
 
     fun handleEvent(event: MessagesEvent) {
         when (event) {
@@ -100,7 +103,7 @@ class MessagesViewModel(
     private fun sendTextMessage(text: String) {
         if (text.isBlank()) return
         viewModelScope.launch {
-            val tempId = tempIdSeq.getAndDecrement()
+            val tempId = tempIdSeq.getAndIncrement()
             val optimistic = ChatMessage(
                 id = tempId,
                 role = MessageRole.USER,

--- a/android-sdk/sdk/src/main/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+++ b/android-sdk/sdk/src/main/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
@@ -1,0 +1,52 @@
+-- Copyright (c) Yalochat, Inc. All rights reserved.
+-- Port of flutter-sdk/lib/src/data/services/database/chat_message.drift
+-- Schema matches the Flutter Drift schema exactly (same column names and types).
+-- JSON columns (amplitudes, products, quick_replies) are stored as TEXT and decoded
+-- via ColumnAdapters in DatabaseFactory.kt using kotlinx.serialization.
+
+CREATE TABLE chat_message (
+    id              INTEGER NOT NULL PRIMARY KEY,
+    wi_id           TEXT,
+    role            TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    file_name       TEXT,
+    amplitudes      TEXT,
+    duration        INTEGER,
+    products        TEXT,
+    quick_replies   TEXT,
+    timestamp       INTEGER NOT NULL
+);
+
+-- Upsert by primary key — mirrors Flutter Drift insertOrReplace mode.
+insertOrReplace:
+INSERT OR REPLACE INTO chat_message (
+    id, wi_id, role, content, type, status,
+    file_name, amplitudes, duration, products, quick_replies, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+
+-- First page: most recent messages, ordered newest-first.
+-- Port of Flutter getMessagesFirstPage(limit).
+selectFirstPage:
+SELECT * FROM chat_message
+ORDER BY id DESC
+LIMIT :limit;
+
+-- Cursor page: messages with id < cursor, ordered newest-first.
+-- Port of Flutter getMessagesPage(cursor, limit).
+selectPageBefore:
+SELECT * FROM chat_message
+WHERE id < :cursor
+ORDER BY id DESC
+LIMIT :limit;
+
+-- Live query: all messages ordered oldest-first for chat display.
+-- Used by LocalChatMessageRepository.observeMessages() via .asFlow().mapToList().
+observeConversation:
+SELECT * FROM chat_message
+ORDER BY id ASC;
+
+-- Delete all messages (e.g., on logout / conversation reset).
+deleteConversation:
+DELETE FROM chat_message;

--- a/android-sdk/sdk/src/main/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+++ b/android-sdk/sdk/src/main/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
@@ -1,8 +1,8 @@
 -- Copyright (c) Yalochat, Inc. All rights reserved.
 -- Port of flutter-sdk/lib/src/data/services/database/chat_message.drift
 -- Schema matches the Flutter Drift schema exactly (same column names and types).
--- JSON columns (amplitudes, products, quick_replies) are stored as TEXT and decoded
--- via ColumnAdapters in DatabaseFactory.kt using kotlinx.serialization.
+-- JSON columns (amplitudes, products, quick_replies) are stored as TEXT and are
+-- encoded/decoded in the Kotlin repository layer (see LocalChatMessageRepository).
 
 CREATE TABLE chat_message (
     id              INTEGER NOT NULL PRIMARY KEY,

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
@@ -13,7 +13,6 @@ import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -22,8 +21,6 @@ import kotlin.test.assertIs
 // FDE-56: MessageSyncService tests.
 @OptIn(ExperimentalCoroutinesApi::class)
 class MessageSyncServiceTest {
-
-    private val dispatcher = UnconfinedTestDispatcher()
 
     private fun yaloRepo(vararg batches: List<ChatMessage>): YaloMessageRepository =
         object : YaloMessageRepository {

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
@@ -1,0 +1,115 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
+import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+// FDE-56: MessageSyncService tests.
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessageSyncServiceTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    private fun yaloRepo(vararg batches: List<ChatMessage>): YaloMessageRepository =
+        object : YaloMessageRepository {
+            override suspend fun sendMessage(message: ChatMessage) = Result.Ok(Unit)
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): Flow<List<ChatMessage>> = flowOf(*batches)
+        }
+
+    private fun msg(id: Long, content: String = "msg $id") = ChatMessage(
+        id = id,
+        role = MessageRole.AGENT,
+        type = MessageType.Text,
+        status = MessageStatus.DELIVERED,
+        content = content,
+    )
+
+    // ── core FDE-56 test: batch of 3 messages → insertMessages called ─────────
+
+    @Test
+    fun `mock remote returns 3 messages — all inserted into local repo`() = runTest {
+        val batch = listOf(msg(1L, "A"), msg(2L, "B"), msg(3L, "C"))
+        val localRepo = FakeChatMessageRepository()
+        val service = MessageSyncService(yaloRepo(batch), localRepo)
+
+        service.start(this)
+        testScheduler.advanceUntilIdle()
+
+        val result = localRepo.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(3, result.result.size)
+        assertEquals(setOf("A", "B", "C"), result.result.map { it.content }.toSet())
+    }
+
+    @Test
+    fun `multiple poll batches are all inserted`() = runTest {
+        val batch1 = listOf(msg(1L), msg(2L))
+        val batch2 = listOf(msg(3L), msg(4L))
+        val localRepo = FakeChatMessageRepository()
+        val service = MessageSyncService(yaloRepo(batch1, batch2), localRepo)
+
+        service.start(this)
+        testScheduler.advanceUntilIdle()
+
+        val result = localRepo.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(4, result.result.size)
+    }
+
+    @Test
+    fun `start is idempotent — calling twice does not duplicate messages`() = runTest {
+        val batch = listOf(msg(1L))
+        val localRepo = FakeChatMessageRepository()
+        val service = MessageSyncService(yaloRepo(batch), localRepo)
+
+        service.start(this)
+        service.start(this) // second call should be a no-op
+
+        testScheduler.advanceUntilIdle()
+
+        val result = localRepo.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(1, result.result.size)
+    }
+
+    @Test
+    fun `stop cancels polling`() = runTest {
+        // Repo that tracks whether insertMessages was called after stop
+        var insertCallCount = 0
+        val trackingRepo = object : ChatMessageRepository {
+            override suspend fun getMessages(cursor: Long?, limit: Int) = Result.Ok(emptyList<ChatMessage>())
+            override suspend fun insertMessage(message: ChatMessage) = Result.Ok(Unit)
+            override suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit> {
+                insertCallCount++
+                return Result.Ok(Unit)
+            }
+            override suspend fun updateMessage(message: ChatMessage) = Result.Ok(Unit)
+            override fun observeMessages() = kotlinx.coroutines.flow.MutableStateFlow(emptyList<ChatMessage>())
+        }
+        val batch = listOf(msg(1L))
+        val service = MessageSyncService(yaloRepo(batch), trackingRepo)
+
+        service.start(this)
+        service.stop()
+        testScheduler.advanceUntilIdle()
+
+        // After stop, no further inserts should happen from the cancelled flow
+        assertEquals(0, insertCallCount)
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/local/ChatMessageQueriesTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/local/ChatMessageQueriesTest.kt
@@ -1,0 +1,138 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.local
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.yalo.chat.sdk.database.ChatDatabase
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+// FDE-54: SQLDelight schema and query tests.
+// Uses JdbcSqliteDriver (in-memory) — no Android emulator required.
+class ChatMessageQueriesTest {
+
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var db: ChatDatabase
+
+    @BeforeTest
+    fun setup() {
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        ChatDatabase.Schema.create(driver)
+        db = createDatabase(driver)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        driver.close()
+    }
+
+    private fun insert(
+        id: Long,
+        role: String = "AGENT",
+        content: String = "hello",
+        type: String = "text",
+        status: String = "DELIVERED",
+        timestamp: Long = id * 1000L,
+        wiId: String? = null,
+    ) = db.chatMessageQueries.insertOrReplace(
+        id = id,
+        wi_id = wiId,
+        role = role,
+        content = content,
+        type = type,
+        status = status,
+        file_name = null,
+        amplitudes = null,
+        duration = null,
+        products = null,
+        quick_replies = null,
+        timestamp = timestamp,
+    )
+
+    // ── insertOrReplace + selectFirstPage ─────────────────────────────────────
+
+    @Test
+    fun `insertOrReplace then selectFirstPage returns correct row`() {
+        insert(id = 1L, content = "Hello")
+        val rows = db.chatMessageQueries.selectFirstPage(limit = 10).executeAsList()
+        assertEquals(1, rows.size)
+        assertEquals("Hello", rows.first().content)
+        assertEquals("AGENT", rows.first().role)
+    }
+
+    @Test
+    fun `insertOrReplace with same id overwrites previous entry`() {
+        insert(id = 1L, content = "Original")
+        insert(id = 1L, content = "Updated")
+        val rows = db.chatMessageQueries.selectFirstPage(limit = 10).executeAsList()
+        assertEquals(1, rows.size)
+        assertEquals("Updated", rows.first().content)
+    }
+
+    @Test
+    fun `selectFirstPage respects limit`() {
+        (1L..10L).forEach { insert(id = it) }
+        val rows = db.chatMessageQueries.selectFirstPage(limit = 3).executeAsList()
+        assertEquals(3, rows.size)
+    }
+
+    @Test
+    fun `selectFirstPage returns rows ordered newest-first`() {
+        insert(id = 1L, timestamp = 1000L)
+        insert(id = 2L, timestamp = 2000L)
+        insert(id = 3L, timestamp = 3000L)
+        val rows = db.chatMessageQueries.selectFirstPage(limit = 10).executeAsList()
+        assertEquals(listOf(3L, 2L, 1L), rows.map { it.id })
+    }
+
+    // ── selectPageBefore ──────────────────────────────────────────────────────
+
+    @Test
+    fun `selectPageBefore returns correct cursor-based page`() {
+        (1L..10L).forEach { insert(id = it) }
+        // cursor = 6: should return ids 5, 4, 3 (3 items before 6)
+        val rows = db.chatMessageQueries.selectPageBefore(cursor = 6L, limit = 3L).executeAsList()
+        assertEquals(listOf(5L, 4L, 3L), rows.map { it.id })
+    }
+
+    @Test
+    fun `selectPageBefore with cursor at start returns empty`() {
+        (1L..5L).forEach { insert(id = it) }
+        val rows = db.chatMessageQueries.selectPageBefore(cursor = 1L, limit = 10L).executeAsList()
+        assertEquals(0, rows.size)
+    }
+
+    // ── observeConversation ───────────────────────────────────────────────────
+
+    @Test
+    fun `observeConversation returns rows ordered oldest-first`() {
+        insert(id = 3L); insert(id = 1L); insert(id = 2L)
+        val rows = db.chatMessageQueries.observeConversation().executeAsList()
+        assertEquals(listOf(1L, 2L, 3L), rows.map { it.id })
+    }
+
+    // ── deleteConversation ────────────────────────────────────────────────────
+
+    @Test
+    fun `deleteConversation removes all rows`() {
+        (1L..5L).forEach { insert(id = it) }
+        db.chatMessageQueries.deleteConversation()
+        val rows = db.chatMessageQueries.selectFirstPage(limit = 100).executeAsList()
+        assertEquals(0, rows.size)
+    }
+
+    // ── nullable fields ───────────────────────────────────────────────────────
+
+    @Test
+    fun `nullable fields are stored and retrieved correctly`() {
+        insert(id = 1L, wiId = "wi-abc")
+        val row = db.chatMessageQueries.selectFirstPage(limit = 1).executeAsList().first()
+        assertEquals("wi-abc", row.wi_id)
+        assertNull(row.amplitudes)
+        assertNull(row.products)
+        assertNull(row.quick_replies)
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -1,0 +1,185 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.data.local
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.database.ChatDatabase
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.model.Product
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+// FDE-55: LocalChatMessageRepository tests.
+// Uses JdbcSqliteDriver (in-memory) — no Android emulator required.
+@OptIn(ExperimentalCoroutinesApi::class)
+class LocalChatMessageRepositoryTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var driver: JdbcSqliteDriver
+    private lateinit var repo: LocalChatMessageRepository
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        ChatDatabase.Schema.create(driver)
+        val db = createDatabase(driver)
+        repo = LocalChatMessageRepository(db.chatMessageQueries, ioDispatcher = dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+        driver.close()
+    }
+
+    private fun msg(id: Long, content: String = "msg $id", timestamp: Long = id * 1000L) =
+        ChatMessage(
+            id = id,
+            role = MessageRole.AGENT,
+            type = MessageType.Text,
+            status = MessageStatus.DELIVERED,
+            content = content,
+            timestamp = timestamp,
+        )
+
+    // ── insertMessage + getMessages ───────────────────────────────────────────
+
+    @Test
+    fun `insertMessage then getMessages returns message`() = runTest {
+        assertIs<Result.Ok<Unit>>(repo.insertMessage(msg(1L, "Hello")))
+        val result = repo.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(1, result.result.size)
+        assertEquals("Hello", result.result.first().content)
+    }
+
+    @Test
+    fun `getMessages first page returns most recent messages`() = runTest {
+        (1L..5L).forEach { repo.insertMessage(msg(it)) }
+        val result = repo.getMessages(cursor = null, limit = 3)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        // selectFirstPage orders newest-first; limit 3 returns ids 5, 4, 3
+        assertEquals(listOf(5L, 4L, 3L), result.result.map { it.id })
+    }
+
+    @Test
+    fun `getMessages cursor page returns correct window`() = runTest {
+        // Insert 50 messages, request page of 20 before id=31 → ids 30..11
+        (1L..50L).forEach { repo.insertMessage(msg(it)) }
+        val result = repo.getMessages(cursor = 31L, limit = 20)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(20, result.result.size)
+        assertEquals(30L, result.result.first().id)
+        assertEquals(11L, result.result.last().id)
+    }
+
+    // ── insertMessages (batch) ────────────────────────────────────────────────
+
+    @Test
+    fun `insertMessages inserts all messages in one call`() = runTest {
+        val batch = (1L..5L).map { msg(it) }
+        assertIs<Result.Ok<Unit>>(repo.insertMessages(batch))
+        val result = repo.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(5, result.result.size)
+    }
+
+    // ── observeMessages ───────────────────────────────────────────────────────
+
+    @Test
+    fun `observeMessages emits updated list after insert`() = runTest {
+        repo.insertMessage(msg(1L, "First"))
+        val messages = repo.observeMessages().first()
+        assertEquals(1, messages.size)
+        assertEquals("First", messages.first().content)
+    }
+
+    @Test
+    fun `observeMessages returns messages ordered oldest-first`() = runTest {
+        repo.insertMessage(msg(3L)); repo.insertMessage(msg(1L)); repo.insertMessage(msg(2L))
+        val messages = repo.observeMessages().first()
+        assertEquals(listOf(1L, 2L, 3L), messages.map { it.id })
+    }
+
+    // ── JSON columns round-trip ───────────────────────────────────────────────
+
+    @Test
+    fun `quickReplies round-trip through JSON column`() = runTest {
+        val message = ChatMessage(
+            id = 1L,
+            role = MessageRole.AGENT,
+            type = MessageType.QuickReply,
+            status = MessageStatus.DELIVERED,
+            content = "Pick one:",
+            quickReplies = listOf("Yes", "No", "Maybe"),
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(listOf("Yes", "No", "Maybe"), result.result.first().quickReplies)
+    }
+
+    @Test
+    fun `products round-trip through JSON column`() = runTest {
+        val product = Product(sku = "sku-1", name = "Widget", price = 9.99)
+        val message = ChatMessage(
+            id = 1L,
+            role = MessageRole.AGENT,
+            type = MessageType.Product,
+            status = MessageStatus.DELIVERED,
+            content = "",
+            products = listOf(product),
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val stored = result.result.first().products
+        assertEquals(1, stored.size)
+        assertEquals("sku-1", stored.first().sku)
+        assertEquals("Widget", stored.first().name)
+        assertEquals(9.99, stored.first().price)
+    }
+
+    @Test
+    fun `amplitudes round-trip through JSON column`() = runTest {
+        val message = ChatMessage(
+            id = 1L,
+            role = MessageRole.USER,
+            type = MessageType.Voice,
+            status = MessageStatus.SENT,
+            content = "",
+            amplitudes = listOf(0.1, 0.5, 0.9),
+            duration = 3000L,
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(listOf(0.1, 0.5, 0.9), result.result.first().amplitudes)
+    }
+
+    // ── updateMessage ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `updateMessage changes status of existing message`() = runTest {
+        repo.insertMessage(msg(1L))
+        repo.updateMessage(msg(1L).copy(status = MessageStatus.READ))
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(MessageStatus.READ, result.result.first().status)
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeChatMessageRepositoryTest.kt
@@ -89,6 +89,17 @@ class FakeChatMessageRepositoryTest {
     }
 
     @Test
+    fun `insertMessages inserts all messages and updates flow`() = runTest {
+        val r = repo()
+        r.insertMessages(listOf(message(1L, "A"), message(2L, "B"), message(3L, "C")))
+        val result = r.getMessages(cursor = null, limit = 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(3, result.result.size)
+        val emitted = r.observeMessages().first()
+        assertEquals(3, emitted.size)
+    }
+
+    @Test
     fun `observeMessages emits updated list after insertMessage`() = runTest {
         val r = repo()
         r.insertMessage(message(1L))

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -17,6 +17,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -105,34 +106,36 @@ class YaloMessageRepositoryRemoteTest {
     }
 
     // ── pollIncomingMessages ───────────────────────────────────────────────────
+    // Each emission is now a List<ChatMessage> (one poll cycle = one batch).
 
     @Test
-    fun `pollIncomingMessages emits messages from first poll`() = runTest {
+    fun `pollIncomingMessages emits batch from first poll`() = runTest {
         val repo = buildRepo(listOf(messageJson("id-1", "Hi"), "[]"))
-        val messages = repo.pollIncomingMessages().take(1).toList()
-        assertEquals(1, messages.size)
-        assertEquals("Hi", messages.first().content)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals("Hi", batch.first().content)
     }
 
     @Test
-    fun `pollIncomingMessages deduplicates — same wiId is emitted only once`() = runTest {
-        // First poll: id-1 only. Second poll: id-1 (dup) + id-2 (new).
+    fun `pollIncomingMessages deduplicates — same wiId emitted only once across batches`() = runTest {
+        // Poll 1: [id-1]. Poll 2: [id-1 (dup), id-2 (new)] → batch 2 = [id-2] only.
         val bothMessages = """[
             {"id":"id-1","message":{"text":"First","role":"AGENT"},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"DELIVERED"},
             {"id":"id-2","message":{"text":"Second","role":"AGENT"},"date":"2024-01-01T12:00:01Z","user_id":"u1","status":"DELIVERED"}
         ]"""
         val repo = buildRepo(listOf(messageJson("id-1", "First"), bothMessages))
-        // take(2): id-1 from poll 1, id-2 from poll 2; id-1 is suppressed by the cache
-        val messages = repo.pollIncomingMessages().take(2).toList()
-        assertEquals(2, messages.size)
-        assertEquals("First", messages[0].content)
-        assertEquals("Second", messages[1].content)
+        val batches = repo.pollIncomingMessages().take(2).toList()
+        assertEquals(2, batches.size)
+        assertEquals(1, batches[0].size)
+        assertEquals("First", batches[0].first().content)
+        assertEquals(1, batches[1].size)
+        assertEquals("Second", batches[1].first().content)
     }
 
     @Test
     fun `pollIncomingMessages continues polling after network error`() = runTest {
         // Mirrors Flutter _startPolling(): on error the loop continues without restarting.
-        // First call returns 500, second call returns a message — take(1) collects it.
+        // First call returns 500, second call returns a message — first() collects it.
         var callIndex = 0
         val engine = MockEngine {
             callIndex++
@@ -151,22 +154,32 @@ class YaloMessageRepositoryRemoteTest {
             httpClient = client,
         )
         val repo = YaloMessageRepositoryRemote(apiService, pollingIntervalMs = 0L)
-        val messages = repo.pollIncomingMessages().take(1).toList()
-        assertEquals(1, messages.size)
-        assertEquals("After error", messages.first().content)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals("After error", batch.first().content)
     }
 
     @Test
     fun `pollIncomingMessages sets MessageRole from server role field`() = runTest {
         val repo = buildRepo(listOf(messageJson("id-1", "Hey", "USER"), "[]"))
-        val messages = repo.pollIncomingMessages().take(1).toList()
-        assertEquals(MessageRole.USER, messages.first().role)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(MessageRole.USER, batch.first().role)
     }
 
     @Test
     fun `pollIncomingMessages status is always DELIVERED`() = runTest {
         val repo = buildRepo(listOf(messageJson("id-1", "msg"), "[]"))
-        val messages = repo.pollIncomingMessages().take(1).toList()
-        assertEquals(MessageStatus.DELIVERED, messages.first().status)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(MessageStatus.DELIVERED, batch.first().status)
+    }
+
+    @Test
+    fun `pollIncomingMessages suppresses empty poll cycles`() = runTest {
+        // First poll returns nothing, second returns a message → first() skips the empty cycle.
+        val repo = buildRepo(listOf("[]", messageJson("id-1", "Eventually")))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals("Eventually", batch.first().content)
+        assertTrue(batch.first().role == MessageRole.AGENT)
     }
 }

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -10,12 +10,10 @@ import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
-import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -45,7 +43,7 @@ class MessagesViewModelTest {
     }
 
     private fun viewModel(
-        yaloRepo: YaloMessageRepository = FakeYaloMessageRepository(),
+        yaloRepo: FakeYaloMessageRepository = FakeYaloMessageRepository(),
         chatRepo: FakeChatMessageRepository = FakeChatMessageRepository(),
     ) = MessagesViewModel(yaloRepo, chatRepo)
 
@@ -71,6 +69,7 @@ class MessagesViewModelTest {
             override suspend fun getMessages(cursor: Long?, limit: Int) =
                 Result.Error<List<ChatMessage>>(RuntimeException("db error"))
             override suspend fun insertMessage(message: ChatMessage) = Result.Ok(Unit)
+            override suspend fun insertMessages(messages: List<ChatMessage>) = Result.Ok(Unit)
             override suspend fun updateMessage(message: ChatMessage) = Result.Ok(Unit)
             override fun observeMessages(): Flow<List<ChatMessage>> = MutableStateFlow(emptyList())
         }
@@ -157,7 +156,7 @@ class MessagesViewModelTest {
     // ── SubscribeToMessages ───────────────────────────────────────────────────
 
     @Test
-    fun `SubscribeToMessages updates state when messages are inserted`() = runTest {
+    fun `SubscribeToMessages updates state when messages are inserted into local repo`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SubscribeToMessages)
@@ -209,31 +208,6 @@ class MessagesViewModelTest {
                 quickReplies = listOf("Option A", "Option B"))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
-        vm.viewModelScope.cancel()
-    }
-
-    // ── Phase 2 — Remote polling ───────────────────────────────────────────────
-
-    @Test
-    fun `SubscribeToMessages inserts polled remote messages into state`() = runTest {
-        val chatRepo = FakeChatMessageRepository()
-        val pollingYaloRepo = object : YaloMessageRepository {
-            override suspend fun sendMessage(message: ChatMessage) = Result.Ok(Unit)
-            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
-            override fun pollIncomingMessages() = flowOf(
-                ChatMessage(
-                    role = MessageRole.AGENT, type = MessageType.Text,
-                    status = MessageStatus.DELIVERED, content = "from server",
-                )
-            )
-        }
-        val vm = MessagesViewModel(pollingYaloRepo, chatRepo)
-        vm.handleEvent(MessagesEvent.SubscribeToMessages)
-        // advanceUntilIdle() drains all coroutines launched by SubscribeToMessages
-        // (pollIncomingMessages collector + observeMessages collector) before asserting.
-        testScheduler.advanceUntilIdle()
-        assertEquals(1, vm.state.value.messages.size)
-        assertEquals("from server", vm.state.value.messages.first().content)
         vm.viewModelScope.cancel()
     }
 }

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -43,7 +43,7 @@ class MessagesViewModelTest {
     }
 
     private fun viewModel(
-        yaloRepo: FakeYaloMessageRepository = FakeYaloMessageRepository(),
+        yaloRepo: com.yalo.chat.sdk.domain.repository.YaloMessageRepository = FakeYaloMessageRepository(),
         chatRepo: FakeChatMessageRepository = FakeChatMessageRepository(),
     ) = MessagesViewModel(yaloRepo, chatRepo)
 
@@ -122,7 +122,7 @@ class MessagesViewModelTest {
             override fun pollIncomingMessages(): kotlinx.coroutines.flow.Flow<List<ChatMessage>> =
                 kotlinx.coroutines.flow.emptyFlow()
         }
-        val vm = MessagesViewModel(failingYaloRepo, chatRepo)
+        val vm = viewModel(yaloRepo = failingYaloRepo, chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SendTextMessage("hello"))
         val result = chatRepo.getMessages(null, 10)
         assertIs<Result.Ok<List<ChatMessage>>>(result)

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -112,6 +112,23 @@ class MessagesViewModelTest {
         assertEquals("hello", result.result.first().content)
     }
 
+    @Test
+    fun `SendTextMessage marks optimistic message as ERROR when remote send fails`() = runTest {
+        val chatRepo = FakeChatMessageRepository()
+        val failingYaloRepo = object : com.yalo.chat.sdk.domain.repository.YaloMessageRepository {
+            override suspend fun sendMessage(message: ChatMessage) =
+                Result.Error<Unit>(RuntimeException("network error"))
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): kotlinx.coroutines.flow.Flow<List<ChatMessage>> =
+                kotlinx.coroutines.flow.emptyFlow()
+        }
+        val vm = MessagesViewModel(failingYaloRepo, chatRepo)
+        vm.handleEvent(MessagesEvent.SendTextMessage("hello"))
+        val result = chatRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(MessageStatus.ERROR, result.result.first().status)
+    }
+
     // ── ClearMessages ─────────────────────────────────────────────────────────
 
     @Test


### PR DESCRIPTION
## Summary

Implements Phase 2 Milestone 2: SQLDelight local persistence, replacing `FakeChatMessageRepository` with a real SQLite-backed implementation. Closes FDE-54, FDE-55, FDE-56.

### FDE-54 — SQLDelight schema + queries
- `ChatMessage.sq` mirrors the Flutter Drift schema exactly (same columns, same naming)
- Queries: `insertOrReplace`, `selectFirstPage`, `selectPageBefore` (cursor-based pagination), `observeConversation` (live Flow), `deleteConversation`
- SQLDelight Gradle plugin enabled; `sqldelight-jdbc-driver` alias corrected to use `sqlite-driver` artifact

### FDE-55 — `LocalChatMessageRepository`
- Implements `ChatMessageRepository` using generated `ChatMessageQueries`
- `observeMessages()` → `observeConversation().asFlow().mapToList()` (live SQLDelight flow)
- JSON columns (`amplitudes`, `products`, `quickReplies`) encoded/decoded with `kotlinx.serialization`
- Free of Android-specific imports; `ioDispatcher` injected for testability
- `Product.kt` annotated `@Serializable` for JSON column encoding
- `DatabaseFactory.kt`: `createDatabase(SqlDriver)` factory (Android → `AndroidSqliteDriver`, tests → `JdbcSqliteDriver`)

### FDE-56 — `MessageSyncService`
- Single responsibility: polls `YaloMessageRepositoryRemote`, inserts each batch into `LocalChatMessageRepository` in one SQLDelight transaction
- `pollIncomingMessages()` return type changed: `Flow<ChatMessage>` → `Flow<List<ChatMessage>>` (batch per cycle; empty cycles suppressed)
- `MessagesViewModel.subscribeToMessages()` simplified — only observes local store; polling fully delegated to `MessageSyncService`
- `YaloChat.init()` now accepts `Context`; creates `AndroidSqliteDriver`, wires `LocalChatMessageRepository` + `MessageSyncService`

## Follow-up: deferred Copilot comments from Phase 2 M1 + M2

This PR also addresses review comments that were deferred from the Phase 2 M1 PR (#41):

**From M1 (networking layer):**
- `buildHttpClient` marked `internal` (not public API surface)
- Debug logging changed from `LogLevel.ALL` → `LogLevel.HEADERS`; `x-user-id` and `x-channel-id` headers sanitized alongside `Authorization`
- `parseIso8601` fallback returns `0L` instead of `Clock.System.now()` so malformed dates sort before real messages
- `localProp()` InputStream closed via `.use {}` to prevent file handle leak
- `sendTextMessage` now updates the optimistic message to `MessageStatus.ERROR` on remote send failure (test added)

**From M2 (this PR's first review round):**
- Removed unused `dispatcher` field in `MessageSyncServiceTest`
- Fixed `ChatMessage.sq` comment (ColumnAdapters reference → repository layer)
- Narrowed consumer ProGuard rule from `database.**` to `ChatDatabase` only
- `FakeChatMessageRepository.insertMessages` now uses upsert semantics (replace by id) matching `INSERT OR REPLACE`
- `MessagesViewModelTest.viewModel()` helper accepts `YaloMessageRepository` interface instead of concrete fake
- `toChatMessage` in `YaloMessageRepositoryRemote` assigns a stable non-null Long id (epoch millis; fallback to `wiId.hashCode()`) so polled messages can be persisted
- `YaloChat` stores and closes `SqlDriver` on re-init to prevent file-descriptor leaks
- `MessageSyncService` started lazily in `subscribeToMessages()` — polling only runs while the chat UI is active; stopped on `ClearMessages`
- `MessageSyncService` logs `insertMessages` failures instead of silently ignoring them

## Test plan

- [x] `ChatMessageQueriesTest` — schema queries on in-memory `JdbcSqliteDriver` (no emulator)
- [x] `LocalChatMessageRepositoryTest` — pagination, JSON round-trip (quickReplies, products, amplitudes), live observation
- [x] `MessageSyncServiceTest` — batch of 3 messages inserted, multiple batches, idempotent start, stop cancels
- [x] All prior tests updated for `Flow<List<ChatMessage>>` API change
- [x] `SendTextMessage ERROR` test — verifies optimistic message status updated on remote failure
- [x] **107 tests pass** (0 failures, no emulator required)
- [x] `:sdk:lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)