### PR TITLE
chore(git): private assets submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# AI private assets (managed by chat-sdk-private-assets submodule)
+CLAUDE.md
+.claude/
+
 # Miscellaneous
 *.class
 *.log

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "private-assets"]
 	path = private-assets
-	url = ../chat-sdk-private-assets
+	url = https://github.com/yalochat/chat-sdk-private-assets.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ai-assets"]
+	path = ai-assets
+	url = ../chat-sdk-private-assets

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "ai-assets"]
-	path = ai-assets
+[submodule "private-assets"]
+	path = private-assets
 	url = ../chat-sdk-private-assets


### PR DESCRIPTION
This pull request introduces a new Git submodule to the repository. The submodule, named `private-assets`, is linked to an external repository and will allow the project to manage and update shared assets more efficiently.

Submodule addition:

* Added a new submodule configuration for `private-assets` in the `.gitmodules` file, pointing to the `../chat-sdk-private-assets` repository.
* Initialized the `private-assets` submodule at commit `76ca0ebf6a64c18a7038c725c568f6879290eba4`.