### PR TITLE
feat(android-sdk): Quick Reply Chips — Phase 2 M6 (FDE-96)

### DIFF
--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
@@ -9,6 +9,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
@@ -37,6 +38,7 @@ import com.yalo.chat.sdk.ui.chat.AudioViewModel
 import com.yalo.chat.sdk.ui.chat.ChatAppBar
 import com.yalo.chat.sdk.ui.chat.ChatInput
 import com.yalo.chat.sdk.ui.chat.ImageEvent
+import com.yalo.chat.sdk.ui.chat.QuickReplies
 import com.yalo.chat.sdk.ui.chat.ImagePreview
 import com.yalo.chat.sdk.ui.chat.ImageSideEffect
 import com.yalo.chat.sdk.ui.chat.ImageViewModel
@@ -217,31 +219,46 @@ fun ChatScreen(
                     )
                 },
                 bottomBar = {
-                    if (audioState.isRecording) {
-                        WaveformRecorder(
-                            audioData = audioState.audioData,
-                            onCancel = { audioViewModel.handleEvent(AudioEvent.CancelRecording) },
-                            onSend = { audioViewModel.handleEvent(AudioEvent.StopRecording) },
-                        )
-                    } else {
-                        ChatInput(
-                            userMessage = state.userMessage,
-                            onUserMessageChange = { viewModel.handleEvent(MessagesEvent.UpdateUserMessage(it)) },
-                            onSendMessage = { viewModel.handleEvent(MessagesEvent.SendTextMessage(state.userMessage)) },
-                            onAttachmentClick = { showPickerSheet = true },
-                            showAttachmentButton = showAttachmentButton,
-                            onMicClick = {
-                                val hasPermission = ContextCompat.checkSelfPermission(
-                                    context,
-                                    Manifest.permission.RECORD_AUDIO,
-                                ) == PackageManager.PERMISSION_GRANTED
-                                if (hasPermission) {
-                                    audioViewModel.handleEvent(AudioEvent.StartRecording)
-                                } else {
-                                    recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
-                                }
-                            },
-                        )
+                    // Quick replies float above the input as a vertical column of chips,
+                    // mirroring Flutter's _createQuickReplyOverlay in chat_input.dart.
+                    // Hidden during recording — user cannot tap a reply while recording audio.
+                    Column {
+                        if (!audioState.isRecording) {
+                            QuickReplies(
+                                quickReplies = state.quickReplies,
+                                onChipClick = { text ->
+                                    // Mirror Flutter: ChatSendTextMessage then ChatClearQuickReplies.
+                                    viewModel.handleEvent(MessagesEvent.SendTextMessage(text))
+                                    viewModel.handleEvent(MessagesEvent.ClearQuickReplies)
+                                },
+                            )
+                        }
+                        if (audioState.isRecording) {
+                            WaveformRecorder(
+                                audioData = audioState.audioData,
+                                onCancel = { audioViewModel.handleEvent(AudioEvent.CancelRecording) },
+                                onSend = { audioViewModel.handleEvent(AudioEvent.StopRecording) },
+                            )
+                        } else {
+                            ChatInput(
+                                userMessage = state.userMessage,
+                                onUserMessageChange = { viewModel.handleEvent(MessagesEvent.UpdateUserMessage(it)) },
+                                onSendMessage = { viewModel.handleEvent(MessagesEvent.SendTextMessage(state.userMessage)) },
+                                onAttachmentClick = { showPickerSheet = true },
+                                showAttachmentButton = showAttachmentButton,
+                                onMicClick = {
+                                    val hasPermission = ContextCompat.checkSelfPermission(
+                                        context,
+                                        Manifest.permission.RECORD_AUDIO,
+                                    ) == PackageManager.PERMISSION_GRANTED
+                                    if (hasPermission) {
+                                        audioViewModel.handleEvent(AudioEvent.StartRecording)
+                                    } else {
+                                        recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                    }
+                                },
+                            )
+                        }
                     }
                 },
                 snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
@@ -13,7 +13,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.ui.theme.ChatTheme
+import com.yalo.chat.sdk.ui.theme.ChatThemeProvider
 
 // Port of flutter-sdk _createQuickReplyOverlay in chat_input.dart.
 // Flutter renders chips in a vertical Column floating above ChatInput via an Overlay
@@ -45,5 +48,16 @@ internal fun QuickReplies(
                 )
             }
         }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun QuickRepliesPreview() {
+    ChatThemeProvider(theme = ChatTheme()) {
+        QuickReplies(
+            quickReplies = listOf("Yes, please", "No thanks", "Maybe later"),
+            onChipClick = {},
+        )
     }
 }

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
@@ -1,0 +1,49 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+// Port of flutter-sdk _createQuickReplyOverlay in chat_input.dart.
+// Flutter renders chips in a vertical Column floating above ChatInput via an Overlay
+// widget anchored to the top-center of the input bar. In Compose we achieve the same
+// visual result by placing this composable directly above ChatInput inside the
+// Scaffold bottomBar Column — no Overlay machinery needed.
+//
+// Appearance/disappearance is animated (slide + fade) to avoid layout shifts,
+// mirroring the Overlay insert/remove behaviour in Flutter.
+@Composable
+internal fun QuickReplies(
+    quickReplies: List<String>,
+    onChipClick: (String) -> Unit,
+) {
+    AnimatedVisibility(
+        visible = quickReplies.isNotEmpty(),
+        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
+        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            quickReplies.forEach { reply ->
+                QuickReplyChip(
+                    text = reply,
+                    onClick = { onChipClick(reply) },
+                )
+            }
+        }
+    }
+}

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplies.kt
@@ -3,12 +3,13 @@
 package com.yalo.chat.sdk.ui.chat
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInVertically
-import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -20,12 +21,13 @@ import com.yalo.chat.sdk.ui.theme.ChatThemeProvider
 
 // Port of flutter-sdk _createQuickReplyOverlay in chat_input.dart.
 // Flutter renders chips in a vertical Column floating above ChatInput via an Overlay
-// widget anchored to the top-center of the input bar. In Compose we achieve the same
-// visual result by placing this composable directly above ChatInput inside the
-// Scaffold bottomBar Column — no Overlay machinery needed.
+// widget anchored to the top-center of the input bar. In Compose we approximate the
+// same visual result by placing this composable directly above ChatInput inside the
+// Scaffold bottomBar Column, instead of using an Overlay.
 //
-// Appearance/disappearance is animated (slide + fade) to avoid layout shifts,
-// mirroring the Overlay insert/remove behaviour in Flutter.
+// expandVertically/shrinkVertically animate the height from 0 to full smoothly so
+// the transition is not jarring to the user, even though the bottomBar height does
+// change and MessageList padding adjusts accordingly.
 @Composable
 internal fun QuickReplies(
     quickReplies: List<String>,
@@ -33,11 +35,13 @@ internal fun QuickReplies(
 ) {
     AnimatedVisibility(
         visible = quickReplies.isNotEmpty(),
-        enter = slideInVertically(initialOffsetY = { it }) + fadeIn(),
-        exit = slideOutVertically(targetOffsetY = { it }) + fadeOut(),
+        enter = expandVertically() + fadeIn(),
+        exit = shrinkVertically() + fadeOut(),
     ) {
         Column(
-            modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
             verticalArrangement = Arrangement.spacedBy(6.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplyChip.kt
+++ b/android-sdk/sdk/src/main/kotlin/com/yalo/chat/sdk/ui/chat/QuickReplyChip.kt
@@ -1,0 +1,43 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.ui.theme.LocalChatTheme
+
+// Port of flutter-sdk QuickReply widget (quick_reply.dart).
+// Flutter renders each chip as a TextButton inside a bordered Container with:
+//   - max width = 50% of screen width
+//   - background = theme.quickReplyColor
+//   - border    = theme.quickReplyBorderColor
+//   - text      = theme.quickReplyStyle
+// On tap: the parent dispatches ChatSendTextMessage then ChatClearQuickReplies.
+@Composable
+internal fun QuickReplyChip(
+    text: String,
+    onClick: () -> Unit,
+) {
+    val theme = LocalChatTheme.current
+    // Mirror Flutter's BoxConstraints(maxWidth: size.width * 0.5).
+    val maxChipWidth = (LocalConfiguration.current.screenWidthDp * 0.5).dp
+
+    OutlinedButton(
+        onClick = onClick,
+        modifier = Modifier.widthIn(max = maxChipWidth),
+        colors = ButtonDefaults.outlinedButtonColors(
+            containerColor = theme.quickReplyColor,
+            contentColor = theme.quickReplyStyle.color,
+        ),
+        border = BorderStroke(width = 1.dp, color = theme.quickReplyBorderColor),
+    ) {
+        Text(text = text, style = theme.quickReplyStyle)
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
@@ -1,0 +1,120 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
+import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Unit tests for the QuickReplies composable contract at the ViewModel layer.
+// The composable itself (QuickReplies.kt) shows/hides based on MessagesState.quickReplies
+// and delegates chip tap to two events: SendTextMessage then ClearQuickReplies.
+// These tests verify that contract without a Compose test harness.
+@OptIn(ExperimentalCoroutinesApi::class)
+class QuickRepliesTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun viewModel(
+        chatRepo: FakeChatMessageRepository = FakeChatMessageRepository(),
+    ) = MessagesViewModel(FakeYaloMessageRepository(), chatRepo)
+
+    // ── Visibility contract ───────────────────────────────────────────────────
+
+    @Test
+    fun `quickReplies is empty by default — chip row is hidden`() = runTest {
+        val vm = viewModel()
+        assertTrue(vm.state.value.quickReplies.isEmpty())
+    }
+
+    @Test
+    fun `quickReplies is non-empty after loading a QuickReply message — chip row is visible`() = runTest {
+        val chatRepo = FakeChatMessageRepository()
+        chatRepo.insertMessage(
+            ChatMessage(
+                id = 1L, role = MessageRole.AGENT, type = MessageType.QuickReply,
+                status = MessageStatus.DELIVERED, content = "Pick an option:",
+                quickReplies = listOf("Yes", "No", "Maybe"),
+            )
+        )
+        val vm = viewModel(chatRepo = chatRepo)
+        vm.handleEvent(MessagesEvent.LoadMessages)
+        assertEquals(listOf("Yes", "No", "Maybe"), vm.state.value.quickReplies)
+    }
+
+    // ── Chip tap contract ─────────────────────────────────────────────────────
+
+    // Mirrors the ChatScreen chip tap handler:
+    //   viewModel.handleEvent(MessagesEvent.SendTextMessage(text))
+    //   viewModel.handleEvent(MessagesEvent.ClearQuickReplies)
+    @Test
+    fun `chip tap — SendTextMessage then ClearQuickReplies sends the text and clears the row`() = runTest {
+        val chatRepo = FakeChatMessageRepository()
+        chatRepo.insertMessage(
+            ChatMessage(
+                id = 1L, role = MessageRole.AGENT, type = MessageType.QuickReply,
+                status = MessageStatus.DELIVERED, content = "Pick:",
+                quickReplies = listOf("Track order", "Cancel order"),
+            )
+        )
+        val vm = viewModel(chatRepo = chatRepo)
+        vm.handleEvent(MessagesEvent.SubscribeToMessages)
+        vm.handleEvent(MessagesEvent.LoadMessages)
+
+        // Simulate chip tap: same event sequence as ChatScreen.
+        vm.handleEvent(MessagesEvent.SendTextMessage("Track order"))
+        vm.handleEvent(MessagesEvent.ClearQuickReplies)
+
+        val state = vm.state.value
+        // Text message was sent.
+        val userMessage = state.messages.firstOrNull { it.role == MessageRole.USER }
+        assertEquals("Track order", userMessage?.content)
+        assertEquals(MessageType.Text, userMessage?.type)
+        // Chip row is now hidden.
+        assertTrue(state.quickReplies.isEmpty())
+    }
+
+    @Test
+    fun `chip tap — quickReplies is empty after ClearQuickReplies regardless of which chip was tapped`() = runTest {
+        val chatRepo = FakeChatMessageRepository()
+        chatRepo.insertMessage(
+            ChatMessage(
+                id = 1L, role = MessageRole.AGENT, type = MessageType.QuickReply,
+                status = MessageStatus.DELIVERED, content = "How can I help?",
+                quickReplies = listOf("Option A", "Option B", "Option C"),
+            )
+        )
+        val vm = viewModel(chatRepo = chatRepo)
+        vm.handleEvent(MessagesEvent.LoadMessages)
+        assertEquals(3, vm.state.value.quickReplies.size)
+
+        vm.handleEvent(MessagesEvent.SendTextMessage("Option B"))
+        vm.handleEvent(MessagesEvent.ClearQuickReplies)
+
+        assertTrue(vm.state.value.quickReplies.isEmpty())
+    }
+}

--- a/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
+++ b/android-sdk/sdk/src/test/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
@@ -2,12 +2,14 @@
 
 package com.yalo.chat.sdk.ui.chat
 
+import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -96,6 +98,8 @@ class QuickRepliesTest {
         assertEquals(MessageType.Text, userMessage?.type)
         // Chip row is now hidden.
         assertTrue(state.quickReplies.isEmpty())
+
+        vm.viewModelScope.cancel()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements Phase 2 Milestone 6: quick reply chips, porting Flutter SDK's `QuickReply` widget to Android Compose. Closes FDE-96.

### `QuickReplyChip` composable
- `OutlinedButton` styled to mirror Flutter's bordered chip exactly: `quickReplyColor` fill, `quickReplyBorderColor` border, `quickReplyStyle` text
- Max width capped at 50% of screen width — mirrors Flutter's `BoxConstraints(maxWidth: size.width * 0.5)`

### `QuickReplies` composable
- Animated `AnimatedVisibility` (slide-up + fade) wrapping a `Column` of `QuickReplyChip`s
- Visible only when `MessagesState.quickReplies` is non-empty; hidden with no layout shift when empty
- Mirrors Flutter's `_createQuickReplyOverlay` in `chat_input.dart` — Compose achieves the same result without Flutter's `Overlay` machinery by placing the composable directly above `ChatInput` in the `Scaffold` `bottomBar` `Column`

### Wired into `ChatScreen`
- `QuickReplies` placed in `bottomBar` above `ChatInput` (and above `WaveformRecorder`)
- Chip tap dispatches `SendTextMessage(text)` then `ClearQuickReplies` — mirrors Flutter's `ChatSendTextMessage` + `ChatClearQuickReplies` event sequence exactly
- Hidden during active audio recording — chips are not rendered over `WaveformRecorder`

### Unit tests (`QuickRepliesTest`)
- Default state: `quickReplies` is empty — chip row is hidden
- Non-empty state after loading a `QuickReply` message — chip row is visible
- Chip tap: `SendTextMessage` + `ClearQuickReplies` sends the text and clears the row
- Row clears regardless of which chip was tapped