### PR TITLE
feat(android-sdk): Video, Buttons, and CTA message types (M10)

### DIFF
--- a/android-sdk/.gitignore
+++ b/android-sdk/.gitignore
@@ -6,6 +6,7 @@ build/
 .gradle/
 **/.gradle/
 **/build/
+.kotlin/
 
 # Android Studio
 .idea/

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -115,11 +115,12 @@ kotlin {
     // They are JVM/Android-only (protobuf-kotlin-lite has no Kotlin/Native support).
     sourceSets.getByName("androidMain") {
         kotlin.srcDir("../../proto/kotlin")
-        // Exclude Kotlin DSL wrappers that reference Java types not yet generated in
-        // SdkMessageOuterClass.java (added by proto beb3ca9 without regenerating the Java file).
-        // These types (MessageStatusRequest/Response, RegisterCommandsRequest) are not
-        // used by the Android SDK and their unresolved-type references cause
-        // "Overload resolution ambiguity" on timestampOrNull across all other proto files.
+        // Exclude all Kotlin DSL wrappers that reference Java types not present in the
+        // committed SdkMessageOuterClass.java. These wrappers were generated from the proto
+        // source but the corresponding Java outer class was not regenerated at the same time,
+        // leaving unresolved type references that produce "Overload resolution ambiguity"
+        // on timestampOrNull across all other proto files. The SDK does not use these
+        // wrappers directly; the raw Java accessors in SdkMessageOuterClass are sufficient.
         kotlin.filter.exclude(
             "**/AttachmentMessageResponseKt.kt",
             "**/CustomActionRequestKt.kt",

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -121,9 +121,17 @@ kotlin {
         // used by the Android SDK and their unresolved-type references cause
         // "Overload resolution ambiguity" on timestampOrNull across all other proto files.
         kotlin.filter.exclude(
+            "**/AttachmentMessageResponseKt.kt",
+            "**/CustomActionRequestKt.kt",
+            "**/CustomActionResponseKt.kt",
+            "**/ImageMessageResponseKt.kt",
+            "**/MessageReceiptResponseKt.kt",
             "**/MessageStatusRequestKt.kt",
             "**/MessageStatusResponseKt.kt",
             "**/RegisterCommandsRequestKt.kt",
+            "**/TextMessageResponseKt.kt",
+            "**/VideoMessageResponseKt.kt",
+            "**/VoiceNoteMessageResponseKt.kt",
         )
     }
 }

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -115,6 +115,16 @@ kotlin {
     // They are JVM/Android-only (protobuf-kotlin-lite has no Kotlin/Native support).
     sourceSets.getByName("androidMain") {
         kotlin.srcDir("../../proto/kotlin")
+        // Exclude Kotlin DSL wrappers that reference Java types not yet generated in
+        // SdkMessageOuterClass.java (added by proto beb3ca9 without regenerating the Java file).
+        // These types (MessageStatusRequest/Response, RegisterCommandsRequest) are not
+        // used by the Android SDK and their unresolved-type references cause
+        // "Overload resolution ambiguity" on timestampOrNull across all other proto files.
+        kotlin.filter.exclude(
+            "**/MessageStatusRequestKt.kt",
+            "**/MessageStatusResponseKt.kt",
+            "**/RegisterCommandsRequestKt.kt",
+        )
     }
 }
 

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
@@ -1,0 +1,69 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.ui.theme.LocalChatTheme
+
+// Port of flutter-sdk buttons_message.dart — ButtonsMessage widget.
+// Renders optional header + body text + outlined reply buttons inside the agent bubble.
+// Tapping a button fires SendTextMessage with the button label (same as a quick reply chip).
+@Composable
+internal fun ButtonsMessage(
+    message: ChatMessage,
+    onEvent: (MessagesEvent) -> Unit,
+) {
+    val theme = LocalChatTheme.current
+    val textStyle = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (!message.header.isNullOrEmpty()) {
+            Text(
+                text = message.header,
+                style = MaterialTheme.typography.titleSmall.merge(theme.assistantMessageTextStyle),
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        if (message.content.isNotEmpty()) {
+            Text(
+                text = message.content,
+                style = textStyle,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        if (!message.footer.isNullOrEmpty()) {
+            Text(
+                text = message.footer,
+                style = MaterialTheme.typography.bodySmall.merge(theme.assistantMessageTextStyle),
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+        message.buttons.forEach { label ->
+            OutlinedButton(
+                onClick = { onEvent(MessagesEvent.SendTextMessage(label)) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 6.dp),
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(1.dp, theme.actionIconColor),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = theme.actionIconColor,
+                ),
+            ) {
+                Text(text = label, style = textStyle)
+            }
+        }
+    }
+}

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
-// Port of flutter-sdk buttons_message.dart — ButtonsMessage widget.
 // Renders optional header + body text + optional footer + outlined reply buttons inside
 // the agent bubble. Tapping a button fires SendTextMessage with the label as content.
 @Composable

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
@@ -7,9 +7,9 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,35 +18,34 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Port of flutter-sdk buttons_message.dart — ButtonsMessage widget.
-// Renders optional header + body text + outlined reply buttons inside the agent bubble.
-// Tapping a button fires SendTextMessage with the button label (same as a quick reply chip).
+// Renders optional header + body text + optional footer + outlined reply buttons inside
+// the agent bubble. Tapping a button fires SendTextMessage with the label as content.
 @Composable
 internal fun ButtonsMessage(
     message: ChatMessage,
     onEvent: (MessagesEvent) -> Unit,
 ) {
     val theme = LocalChatTheme.current
-    val textStyle = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle)
 
     Column(modifier = Modifier.fillMaxWidth()) {
         if (!message.header.isNullOrEmpty()) {
             Text(
                 text = message.header,
-                style = MaterialTheme.typography.titleSmall.merge(theme.assistantMessageTextStyle),
+                style = MaterialTheme.typography.bodyMedium.merge(theme.messageHeaderStyle),
                 modifier = Modifier.padding(bottom = 4.dp),
             )
         }
         if (message.content.isNotEmpty()) {
             Text(
                 text = message.content,
-                style = textStyle,
+                style = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle),
                 modifier = Modifier.padding(bottom = 4.dp),
             )
         }
         if (!message.footer.isNullOrEmpty()) {
             Text(
                 text = message.footer,
-                style = MaterialTheme.typography.bodySmall.merge(theme.assistantMessageTextStyle),
+                style = MaterialTheme.typography.bodyMedium.merge(theme.messageFooterStyle),
                 modifier = Modifier.padding(bottom = 8.dp),
             )
         }
@@ -57,12 +56,16 @@ internal fun ButtonsMessage(
                     .fillMaxWidth()
                     .padding(top = 6.dp),
                 shape = RoundedCornerShape(8.dp),
-                border = BorderStroke(1.dp, theme.actionIconColor),
+                border = BorderStroke(1.dp, theme.buttonsMessageButtonBorderColor),
                 colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = theme.actionIconColor,
+                    containerColor = theme.buttonsMessageButtonColor,
+                    contentColor = theme.buttonsMessageButtonForegroundColor,
                 ),
             ) {
-                Text(text = label, style = textStyle)
+                Text(
+                    text = label,
+                    style = MaterialTheme.typography.bodyMedium.merge(theme.buttonsMessageButtonTextStyle),
+                )
             }
         }
     }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -59,7 +59,12 @@ internal fun CtaMessage(message: ChatMessage) {
                 onClick = {
                     val uri = Uri.parse(button.url)
                     if (uri.scheme == "https" || uri.scheme == "http") {
-                        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, uri)) }
+                        runCatching {
+                            context.startActivity(
+                                Intent(Intent.ACTION_VIEW, uri)
+                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                            )
+                        }
                     }
                 },
                 modifier = Modifier

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -57,8 +57,10 @@ internal fun CtaMessage(message: ChatMessage) {
         message.ctaButtons.forEach { button ->
             OutlinedButton(
                 onClick = {
-                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(button.url))
-                    context.startActivity(intent)
+                    val uri = Uri.parse(button.url)
+                    if (uri.scheme == "https" || uri.scheme == "http") {
+                        runCatching { context.startActivity(Intent(Intent.ACTION_VIEW, uri)) }
+                    }
                 },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,33 +25,33 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Port of flutter-sdk cta_message.dart — CtaMessage widget.
-// Renders optional header + body text + CTA buttons that open URLs in the browser.
-// Uses an Android Intent (ACTION_VIEW) — no url_launcher dependency needed.
+// Renders optional header + body text + optional footer + CTA buttons that open URLs.
+// Button layout mirrors Flutter: text on the left, arrow icon on the right.
+// URL opening uses Intent.ACTION_VIEW (equivalent to Flutter's url_launcher).
 @Composable
 internal fun CtaMessage(message: ChatMessage) {
     val theme = LocalChatTheme.current
     val context = LocalContext.current
-    val textStyle = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle)
 
     Column(modifier = Modifier.fillMaxWidth()) {
         if (!message.header.isNullOrEmpty()) {
             Text(
                 text = message.header,
-                style = MaterialTheme.typography.titleSmall.merge(theme.assistantMessageTextStyle),
+                style = MaterialTheme.typography.bodyMedium.merge(theme.messageHeaderStyle),
                 modifier = Modifier.padding(bottom = 4.dp),
             )
         }
         if (message.content.isNotEmpty()) {
             Text(
                 text = message.content,
-                style = textStyle,
+                style = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle),
                 modifier = Modifier.padding(bottom = 4.dp),
             )
         }
         if (!message.footer.isNullOrEmpty()) {
             Text(
                 text = message.footer,
-                style = MaterialTheme.typography.bodySmall.merge(theme.assistantMessageTextStyle),
+                style = MaterialTheme.typography.bodyMedium.merge(theme.messageFooterStyle),
                 modifier = Modifier.padding(bottom = 8.dp),
             )
         }
@@ -67,22 +65,25 @@ internal fun CtaMessage(message: ChatMessage) {
                     .fillMaxWidth()
                     .padding(top = 6.dp),
                 shape = RoundedCornerShape(8.dp),
-                border = BorderStroke(1.dp, theme.actionIconColor),
+                border = BorderStroke(1.dp, theme.ctaButtonBorderColor),
                 colors = ButtonDefaults.outlinedButtonColors(
-                    contentColor = theme.actionIconColor,
+                    containerColor = theme.ctaButtonColor,
+                    contentColor = theme.ctaButtonForegroundColor,
                 ),
             ) {
+                // Text left-aligned, arrow icon on the right — mirrors Flutter's OutlinedButton.icon
+                // which swaps icon/label slots to achieve this layout.
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(
                         text = button.text,
-                        style = textStyle,
+                        style = MaterialTheme.typography.bodyMedium.merge(theme.ctaButtonTextStyle),
                         modifier = Modifier.weight(1f),
                     )
                     Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        imageVector = theme.ctaArrowForwardIcon,
                         contentDescription = null,
                         modifier = Modifier.size(16.dp),
                     )

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -24,10 +24,9 @@ import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
-// Port of flutter-sdk cta_message.dart — CtaMessage widget.
 // Renders optional header + body text + optional footer + CTA buttons that open URLs.
-// Button layout mirrors Flutter: text on the left, arrow icon on the right.
-// URL opening uses Intent.ACTION_VIEW (equivalent to Flutter's url_launcher).
+// Button layout: text on the left, arrow icon on the right.
+// URL opening uses Intent.ACTION_VIEW.
 @Composable
 internal fun CtaMessage(message: ChatMessage) {
     val theme = LocalChatTheme.current
@@ -71,8 +70,7 @@ internal fun CtaMessage(message: ChatMessage) {
                     contentColor = theme.ctaButtonForegroundColor,
                 ),
             ) {
-                // Text left-aligned, arrow icon on the right — mirrors Flutter's OutlinedButton.icon
-                // which swaps icon/label slots to achieve this layout.
+                // Text left-aligned, arrow icon on the right.
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.fillMaxWidth(),

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -1,0 +1,93 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.ui.theme.LocalChatTheme
+
+// Port of flutter-sdk cta_message.dart — CtaMessage widget.
+// Renders optional header + body text + CTA buttons that open URLs in the browser.
+// Uses an Android Intent (ACTION_VIEW) — no url_launcher dependency needed.
+@Composable
+internal fun CtaMessage(message: ChatMessage) {
+    val theme = LocalChatTheme.current
+    val context = LocalContext.current
+    val textStyle = MaterialTheme.typography.bodyMedium.merge(theme.assistantMessageTextStyle)
+
+    Column(modifier = Modifier.fillMaxWidth()) {
+        if (!message.header.isNullOrEmpty()) {
+            Text(
+                text = message.header,
+                style = MaterialTheme.typography.titleSmall.merge(theme.assistantMessageTextStyle),
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        if (message.content.isNotEmpty()) {
+            Text(
+                text = message.content,
+                style = textStyle,
+                modifier = Modifier.padding(bottom = 4.dp),
+            )
+        }
+        if (!message.footer.isNullOrEmpty()) {
+            Text(
+                text = message.footer,
+                style = MaterialTheme.typography.bodySmall.merge(theme.assistantMessageTextStyle),
+                modifier = Modifier.padding(bottom = 8.dp),
+            )
+        }
+        message.ctaButtons.forEach { button ->
+            OutlinedButton(
+                onClick = {
+                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse(button.url))
+                    context.startActivity(intent)
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 6.dp),
+                shape = RoundedCornerShape(8.dp),
+                border = BorderStroke(1.dp, theme.actionIconColor),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    contentColor = theme.actionIconColor,
+                ),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    Text(
+                        text = button.text,
+                        style = textStyle,
+                        modifier = Modifier.weight(1f),
+                    )
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -57,9 +57,7 @@ internal fun MessageItem(
     val theme = LocalChatTheme.current
     val isUser = message.role == MessageRole.USER
 
-    // Product messages render their own card borders/backgrounds, so they bypass the bubble
-    // Surface. This mirrors Flutter's AssistantMessage which uses a padding Container rather
-    // than a colored bubble for product types.
+    // Product messages render their own card borders/backgrounds, so they bypass the bubble Surface.
     if (message.type == MessageType.Product || message.type == MessageType.ProductCarousel) {
         Row(
             modifier = Modifier
@@ -151,16 +149,10 @@ internal fun MessageItem(
     }
 }
 
-// Port of flutter-sdk video_message.dart — VideoMessage widget.
-//
-// Thumbnail: extracted from the local file using MediaMetadataRetriever (built-in Android,
-// no extra dependency). Falls back to a dark placeholder if extraction fails.
-//
+// Thumbnail: extracted from the local file using MediaMetadataRetriever.
+// Falls back to a dark placeholder if extraction fails.
 // Playback: tapping the thumbnail shows an in-process VideoView via AndroidView.
-// VideoView reads from the local file path directly (no FileProvider needed since
-// both the SDK and VideoView run in the same process and the file is private to the app).
-//
-// Caption: if message.content is non-empty it is shown below the video — mirrors Flutter.
+// Caption: shown below the video when message.content is non-empty.
 @Composable
 private fun VideoMessageItem(
     message: ChatMessage,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -2,9 +2,7 @@
 
 package com.yalo.chat.sdk.ui.chat
 
-import android.content.Intent
 import android.media.MediaMetadataRetriever
-import android.net.Uri
 import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -163,17 +161,18 @@ private fun VideoMessageItem(
 
     LaunchedEffect(message.fileName) {
         val path = message.fileName ?: return@LaunchedEffect
-        withContext(Dispatchers.IO) {
+        val bitmap = withContext(Dispatchers.IO) {
             val retriever = MediaMetadataRetriever()
             try {
                 retriever.setDataSource(path)
-                retriever.getFrameAtTime(0)?.asImageBitmap()?.let { thumbnail = it }
+                retriever.getFrameAtTime(0)?.asImageBitmap()
             } catch (_: Exception) {
-                // Extraction failed — thumbnail stays null; dark placeholder shown instead.
+                null
             } finally {
                 retriever.release()
             }
         }
+        bitmap?.let { thumbnail = it }
     }
 
     Column {

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -3,10 +3,15 @@
 package com.yalo.chat.sdk.ui.chat
 
 import android.content.Intent
+import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.widget.VideoView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -14,23 +19,32 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayCircle
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import coil3.compose.AsyncImage
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 internal fun MessageItem(
@@ -114,7 +128,10 @@ internal fun MessageItem(
                         onPlay = onPlayAudio,
                         onStop = onStopAudio,
                     )
-                    MessageType.Video -> VideoMessageItem(message = message)
+                    MessageType.Video -> VideoMessageItem(
+                        message = message,
+                        messageTextStyle = messageTextStyle,
+                    )
                     MessageType.Buttons -> ButtonsMessage(
                         message = message,
                         onEvent = onEvent,
@@ -134,41 +151,87 @@ internal fun MessageItem(
     }
 }
 
-// Inline video preview — shows a play icon overlay on the first frame.
-// Tapping opens the video with the system media player via an Intent.
-// Full in-app playback (like Flutter's video_player) would require Media3/ExoPlayer —
-// that dependency is out of scope here; the system player is a faithful minimum.
+// Port of flutter-sdk video_message.dart — VideoMessage widget.
+//
+// Thumbnail: extracted from the local file using MediaMetadataRetriever (built-in Android,
+// no extra dependency). Falls back to a dark placeholder if extraction fails.
+//
+// Playback: tapping the thumbnail shows an in-process VideoView via AndroidView.
+// VideoView reads from the local file path directly (no FileProvider needed since
+// both the SDK and VideoView run in the same process and the file is private to the app).
+//
+// Caption: if message.content is non-empty it is shown below the video — mirrors Flutter.
 @Composable
-private fun VideoMessageItem(message: ChatMessage) {
-    val context = LocalContext.current
-    Box(
-        modifier = Modifier
-            .size(200.dp)
-            .clickable {
-                message.fileName?.let { path ->
-                    val uri = Uri.parse(path)
-                    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
-                        setDataAndType(uri, message.mediaType ?: "video/mp4")
-                    }
-                    context.startActivity(intent)
+private fun VideoMessageItem(
+    message: ChatMessage,
+    messageTextStyle: androidx.compose.ui.text.TextStyle,
+) {
+    var thumbnail by remember { mutableStateOf<ImageBitmap?>(null) }
+    var showPlayer by remember { mutableStateOf(false) }
+
+    LaunchedEffect(message.fileName) {
+        val path = message.fileName ?: return@LaunchedEffect
+        withContext(Dispatchers.IO) {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(path)
+                retriever.getFrameAtTime(0)?.asImageBitmap()?.let { thumbnail = it }
+            } catch (_: Exception) {
+                // Extraction failed — thumbnail stays null; dark placeholder shown instead.
+            } finally {
+                retriever.release()
+            }
+        }
+    }
+
+    Column {
+        Box(
+            modifier = Modifier
+                .size(200.dp)
+                .clickable { showPlayer = !showPlayer },
+            contentAlignment = Alignment.Center,
+        ) {
+            if (showPlayer && message.fileName != null) {
+                // In-process VideoView — no FileProvider needed (same-process file access).
+                AndroidView(
+                    factory = { ctx ->
+                        VideoView(ctx).apply {
+                            setVideoPath(message.fileName)
+                            setOnPreparedListener { it.start() }
+                        }
+                    },
+                    modifier = Modifier.matchParentSize(),
+                )
+            } else {
+                if (thumbnail != null) {
+                    Image(
+                        bitmap = thumbnail!!,
+                        contentDescription = "Video thumbnail",
+                        contentScale = ContentScale.Crop,
+                        modifier = Modifier.matchParentSize(),
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .matchParentSize()
+                            .background(Color(0xFF1A1A1A)),
+                    )
                 }
-            },
-        contentAlignment = Alignment.Center,
-    ) {
-        // Use Coil to render the first frame as a thumbnail.
-        AsyncImage(
-            model = message.fileName,
-            contentDescription = "Video message",
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.matchParentSize(),
-            placeholder = ColorPainter(androidx.compose.ui.graphics.Color.Black),
-            error = ColorPainter(androidx.compose.ui.graphics.Color.Black),
-        )
-        Icon(
-            imageVector = Icons.Filled.PlayCircle,
-            contentDescription = "Play video",
-            modifier = Modifier.size(48.dp),
-            tint = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.85f),
-        )
+                androidx.compose.material3.Icon(
+                    imageVector = Icons.Filled.PlayCircle,
+                    contentDescription = "Play video",
+                    modifier = Modifier.size(48.dp),
+                    tint = Color.White.copy(alpha = 0.85f),
+                )
+            }
+        }
+        // Caption — mirrors Flutter's SelectableText below the video when content is non-empty.
+        if (message.content.isNotEmpty()) {
+            Text(
+                text = message.content,
+                style = messageTextStyle,
+                modifier = Modifier.padding(top = 4.dp),
+            )
+        }
     }
 }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -160,6 +160,8 @@ private fun VideoMessageItem(
     var showPlayer by remember { mutableStateOf(false) }
 
     LaunchedEffect(message.fileName) {
+        thumbnail = null
+        showPlayer = false
         val path = message.fileName ?: return@LaunchedEffect
         val bitmap = withContext(Dispatchers.IO) {
             val retriever = MediaMetadataRetriever()

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -2,6 +2,9 @@
 
 package com.yalo.chat.sdk.ui.chat
 
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
@@ -9,14 +12,19 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayCircle
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.yalo.chat.sdk.domain.model.ChatMessage
@@ -106,6 +114,12 @@ internal fun MessageItem(
                         onPlay = onPlayAudio,
                         onStop = onStopAudio,
                     )
+                    MessageType.Video -> VideoMessageItem(message = message)
+                    MessageType.Buttons -> ButtonsMessage(
+                        message = message,
+                        onEvent = onEvent,
+                    )
+                    MessageType.CTA -> CtaMessage(message = message)
                     MessageType.Unknown -> Text(
                         text = "Unsupported message",
                         style = messageTextStyle,
@@ -117,5 +131,44 @@ internal fun MessageItem(
                 }
             }
         }
+    }
+}
+
+// Inline video preview — shows a play icon overlay on the first frame.
+// Tapping opens the video with the system media player via an Intent.
+// Full in-app playback (like Flutter's video_player) would require Media3/ExoPlayer —
+// that dependency is out of scope here; the system player is a faithful minimum.
+@Composable
+private fun VideoMessageItem(message: ChatMessage) {
+    val context = LocalContext.current
+    Box(
+        modifier = Modifier
+            .size(200.dp)
+            .clickable {
+                message.fileName?.let { path ->
+                    val uri = Uri.parse(path)
+                    val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                        setDataAndType(uri, message.mediaType ?: "video/mp4")
+                    }
+                    context.startActivity(intent)
+                }
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        // Use Coil to render the first frame as a thumbnail.
+        AsyncImage(
+            model = message.fileName,
+            contentDescription = "Video message",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.matchParentSize(),
+            placeholder = ColorPainter(androidx.compose.ui.graphics.Color.Black),
+            error = ColorPainter(androidx.compose.ui.graphics.Color.Black),
+        )
+        Icon(
+            imageVector = Icons.Filled.PlayCircle,
+            contentDescription = "Play video",
+            modifier = Modifier.size(48.dp),
+            tint = androidx.compose.ui.graphics.Color.White.copy(alpha = 0.85f),
+        )
     }
 }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
@@ -86,14 +86,12 @@ data class ChatTheme(
     val quickReplyColor: Color = Color(0xFFF9FAFC),
     /** Border color of quick reply chip buttons. */
     val quickReplyBorderColor: Color = Color(0xFFE8E8E8),
-    // Buttons message — port of Flutter SdkColors.buttonsMessage* light defaults.
     /** Background of buttons in a ButtonsMessage bubble (transparent by default). */
     val buttonsMessageButtonColor: Color = Color(0x00000000),
     /** Border color of buttons in a ButtonsMessage bubble. */
     val buttonsMessageButtonBorderColor: Color = Color(0xFFDDE4EC),
     /** Foreground (text/icon) color of buttons in a ButtonsMessage bubble. */
     val buttonsMessageButtonForegroundColor: Color = Color(0xFF111111),
-    // CTA message — port of Flutter SdkColors.ctaButton* light defaults.
     /** Background of CTA buttons (transparent by default). */
     val ctaButtonColor: Color = Color(0x00000000),
     /** Border color of CTA buttons. */
@@ -107,7 +105,6 @@ data class ChatTheme(
     val hintTextStyle: TextStyle = TextStyle(color = Color(0xFFBEBEBE)),
     val timerTextStyle: TextStyle = TextStyle(color = Color(0xFF7C8086)),
     val quickReplyStyle: TextStyle = TextStyle(color = Color(0xFF000000)),
-    // Port of Flutter ChatTheme.messageHeaderStyle / messageFooterStyle.
     /** Bold header text shown above the body of a buttons or CTA message. */
     val messageHeaderStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontWeight = FontWeight.Bold),
     /** Subdued footer text shown below the body of a buttons or CTA message. */

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
@@ -5,6 +5,7 @@ package com.yalo.chat.sdk.ui.theme
 import androidx.compose.foundation.shape.CornerBasedShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
 import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AttachMoney
@@ -85,6 +86,20 @@ data class ChatTheme(
     val quickReplyColor: Color = Color(0xFFF9FAFC),
     /** Border color of quick reply chip buttons. */
     val quickReplyBorderColor: Color = Color(0xFFE8E8E8),
+    // Buttons message — port of Flutter SdkColors.buttonsMessage* light defaults.
+    /** Background of buttons in a ButtonsMessage bubble (transparent by default). */
+    val buttonsMessageButtonColor: Color = Color(0x00000000),
+    /** Border color of buttons in a ButtonsMessage bubble. */
+    val buttonsMessageButtonBorderColor: Color = Color(0xFFDDE4EC),
+    /** Foreground (text/icon) color of buttons in a ButtonsMessage bubble. */
+    val buttonsMessageButtonForegroundColor: Color = Color(0xFF111111),
+    // CTA message — port of Flutter SdkColors.ctaButton* light defaults.
+    /** Background of CTA buttons (transparent by default). */
+    val ctaButtonColor: Color = Color(0x00000000),
+    /** Border color of CTA buttons. */
+    val ctaButtonBorderColor: Color = Color(0xFFDDE4EC),
+    /** Foreground (text/icon) color of CTA buttons. */
+    val ctaButtonForegroundColor: Color = Color(0xFF111111),
     // ── Text styles ───────────────────────────────────────────────────────────
     val userMessageTextStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontSize = 16.sp),
     val assistantMessageTextStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontSize = 16.sp),
@@ -92,6 +107,15 @@ data class ChatTheme(
     val hintTextStyle: TextStyle = TextStyle(color = Color(0xFFBEBEBE)),
     val timerTextStyle: TextStyle = TextStyle(color = Color(0xFF7C8086)),
     val quickReplyStyle: TextStyle = TextStyle(color = Color(0xFF000000)),
+    // Port of Flutter ChatTheme.messageHeaderStyle / messageFooterStyle.
+    /** Bold header text shown above the body of a buttons or CTA message. */
+    val messageHeaderStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontWeight = FontWeight.Bold),
+    /** Subdued footer text shown below the body of a buttons or CTA message. */
+    val messageFooterStyle: TextStyle = TextStyle(color = Color(0xFF7C8086), fontSize = 12.sp),
+    /** Text style for labels inside CTA buttons. */
+    val ctaButtonTextStyle: TextStyle = TextStyle(color = Color(0xFF111111)),
+    /** Text style for labels inside ButtonsMessage buttons. */
+    val buttonsMessageButtonTextStyle: TextStyle = TextStyle(color = Color(0xFF111111)),
     val productTitleStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontSize = 16.sp, fontWeight = FontWeight.Bold),
     val productSubunitsStyle: TextStyle = TextStyle(color = Color(0xFF7C8086), fontSize = 12.sp),
     val productPriceStyle: TextStyle = TextStyle(color = Color(0xFF2207F1), fontWeight = FontWeight.Bold),
@@ -126,6 +150,8 @@ data class ChatTheme(
     val currencyIcon: ImageVector = Icons.Filled.AttachMoney,
     val addIcon: ImageVector = Icons.Filled.Add,
     val removeIcon: ImageVector = Icons.Filled.Remove,
+    /** Arrow icon rendered on CTA buttons — port of Flutter ChatTheme.ctaArrowForwardIcon. */
+    val ctaArrowForwardIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowForward,
 ) {
     companion object {
         /**

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/ChatMessageQueriesTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/ChatMessageQueriesTest.kt
@@ -51,6 +51,10 @@ class ChatMessageQueriesTest {
         media_type = null,
         products = null,
         quick_replies = null,
+        header_ = null,
+        footer = null,
+        buttons = null,
+        cta_buttons = null,
         timestamp = timestamp,
     )
 

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -169,7 +169,9 @@ class LocalChatMessageRepositoryTest {
         repo.insertMessage(message)
         val result = repo.getMessages(cursor = null, limit = 1)
         assertIs<Result.Ok<List<ChatMessage>>>(result)
-        assertEquals(listOf(0.1, 0.5, 0.9), result.result.first().amplitudes)
+        val stored = result.result.first()
+        assertEquals(listOf(0.1, 0.5, 0.9), stored.amplitudes)
+        assertEquals(3000L, stored.duration)
     }
 
     // ── updateMessage ─────────────────────────────────────────────────────────

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -9,6 +9,7 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.Product
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -181,5 +182,84 @@ class LocalChatMessageRepositoryTest {
         val result = repo.getMessages(cursor = null, limit = 1)
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         assertEquals(MessageStatus.READ, result.result.first().status)
+    }
+
+    // ── Buttons message round-trip ────────────────────────────────────────────
+
+    @Test
+    fun `buttons message round-trips header, footer and button labels through DB`() = runTest {
+        val message = ChatMessage(
+            id = 1L,
+            wiId = "buttons-wi-1",
+            role = MessageRole.AGENT,
+            type = MessageType.Buttons,
+            status = MessageStatus.DELIVERED,
+            content = "Pick an option:",
+            header = "Order help",
+            footer = "Tap any option",
+            buttons = listOf("Track order", "Cancel order", "Contact support"),
+            timestamp = 1000L,
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(MessageType.Buttons, loaded.type)
+        assertEquals("Order help", loaded.header)
+        assertEquals("Tap any option", loaded.footer)
+        assertEquals(listOf("Track order", "Cancel order", "Contact support"), loaded.buttons)
+        assertEquals("Pick an option:", loaded.content)
+    }
+
+    @Test
+    fun `buttons message with null header and footer round-trips without error`() = runTest {
+        val message = ChatMessage(
+            id = 2L,
+            role = MessageRole.AGENT,
+            type = MessageType.Buttons,
+            status = MessageStatus.DELIVERED,
+            content = "Choose:",
+            buttons = listOf("Yes", "No"),
+            timestamp = 2000L,
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(null, loaded.header)
+        assertEquals(null, loaded.footer)
+        assertEquals(listOf("Yes", "No"), loaded.buttons)
+    }
+
+    // ── CTA message round-trip ────────────────────────────────────────────────
+
+    @Test
+    fun `CTA message round-trips header, footer and ctaButtons through DB`() = runTest {
+        val message = ChatMessage(
+            id = 3L,
+            wiId = "cta-wi-1",
+            role = MessageRole.AGENT,
+            type = MessageType.CTA,
+            status = MessageStatus.DELIVERED,
+            content = "Check out our catalog",
+            header = "Shop now",
+            footer = "Limited time offer",
+            ctaButtons = listOf(
+                CtaButton(text = "View Catalog", url = "https://example.com/catalog"),
+                CtaButton(text = "View Promotions", url = "https://example.com/promos"),
+            ),
+            timestamp = 3000L,
+        )
+        repo.insertMessage(message)
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(MessageType.CTA, loaded.type)
+        assertEquals("Shop now", loaded.header)
+        assertEquals("Limited time offer", loaded.footer)
+        assertEquals(2, loaded.ctaButtons.size)
+        assertEquals("View Catalog", loaded.ctaButtons[0].text)
+        assertEquals("https://example.com/catalog", loaded.ctaButtons[0].url)
+        assertEquals("View Promotions", loaded.ctaButtons[1].text)
     }
 }

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -24,7 +24,6 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
-// FDE-55: LocalChatMessageRepository tests.
 // Uses JdbcSqliteDriver (in-memory) — no Android emulator required.
 @OptIn(ExperimentalCoroutinesApi::class)
 class LocalChatMessageRepositoryTest {

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlinx.serialization.json.Json
@@ -745,22 +746,23 @@ class YaloMessageRepositoryRemoteTest {
 
     // ── TypingStop behaviour ──────────────────────────────────────────────────────
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `pollIncomingMessages does not emit TypingStop when all polled messages are already cached`() = runTest(UnconfinedTestDispatcher()) {
-        // Serve the same message on two consecutive polls.
-        // First poll → new message → TypingStop fires.
-        // Second poll → already cached → batch is empty → TypingStop must NOT fire again.
-        val json = textMessageJson("id-cached", "Hello")
-        val repo = buildRepo(listOf(json, json))
-        val collectedEvents = mutableListOf<ChatEvent>()
-        val eventJob = launch { repo.events().collect { collectedEvents.add(it) } }
-        val pollJob = launch { repo.pollIncomingMessages().collect {} }
-        yield() // first poll: new message → emits + TypingStop
-        yield() // second poll: cached → empty batch → no TypingStop
-        pollJob.cancel()
+    fun `pollIncomingMessages does not emit TypingStop when all polled messages are already cached`() = runTest {
+        // Polls: (1) id-1 new → TypingStop + emit, (2) id-1 cached → no TypingStop no emit,
+        // (3) id-2 new → TypingStop + emit. take(2) waits for exactly the two emissions,
+        // spanning all three polls. If the bug returned (TypingStop on raw.isNotEmpty rather
+        // than batch.isNotEmpty) the count would be 3 instead of 2.
+        val repo = buildRepo(listOf(
+            textMessageJson("id-1", "First"),
+            textMessageJson("id-1", "First"),  // cached — no emit, no TypingStop
+            textMessageJson("id-2", "Second"),
+        ))
+        val events = mutableListOf<ChatEvent>()
+        val eventJob = launch { repo.events().collect { events.add(it) } }
+        repo.pollIncomingMessages().take(2).toList()
+        runCurrent() // flush any buffered events into eventJob before cancelling
         eventJob.cancel()
-        assertEquals(1, collectedEvents.count { it is ChatEvent.TypingStop })
+        assertEquals(2, events.count { it is ChatEvent.TypingStop })
     }
 
     // ── ensureReceiptOrder ────────────────────────────────────────────────────────
@@ -779,20 +781,15 @@ class YaloMessageRepositoryRemoteTest {
             "ID $id was bumped to current time on first poll — historical IDs should be preserved")
     }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `ensureReceiptOrder rewrites out-of-order IDs on subsequent polls`() = runTest(UnconfinedTestDispatcher()) {
-        // First poll: new message dated 2024 establishes pollHighWater.
-        // Second poll: different message with same 2024 date and an ID that falls
-        // below the current receiptFloor — must be rewritten to maintain monotonicity.
-        val repo = buildRepo(listOf(
+    fun `ensureReceiptOrder rewrites out-of-order IDs on subsequent polls`() = runTest {
+        // Both messages have the same 2024 date, so their stableIds are close.
+        // After the first poll sets pollHighWater, the second message is bumped so
+        // its id is strictly greater — verified by take(2) which avoids an infinite loop.
+        val batches = buildRepo(listOf(
             textMessageJson("id-a", "First"),
             textMessageJson("id-b", "Second"),
-        ))
-        val batches = mutableListOf<List<ChatMessage>>()
-        val pollJob = launch { repo.pollIncomingMessages().collect { batches.add(it) } }
-        yield(); yield(); yield()
-        pollJob.cancel()
+        )).pollIncomingMessages().take(2).toList()
         assertEquals(2, batches.size)
         val id1 = batches[0].first().id!!
         val id2 = batches[1].first().id!!

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -610,6 +610,139 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals(MessageRole.AGENT, batch.first().role)
     }
 
+    // ── pollIncomingMessages — buttons messages ────────────────────────────────────
+
+    private fun buttonsMessageJson(
+        id: String,
+        body: String = "Pick one",
+        buttons: List<String> = listOf("Yes", "No"),
+        header: String? = null,
+        footer: String? = null,
+    ): String {
+        val headerField = if (header != null) """"header":"$header",""" else ""
+        val footerField = if (footer != null) ""","footer":"$footer"""" else ""
+        val buttonsJson = buttons.joinToString(",") { """"$it"""" }
+        return """[{"id":"$id","message":{"buttonsMessageRequest":{"content":{${headerField}"body":"$body","buttons":[$buttonsJson]$footerField}}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+    }
+
+    @Test
+    fun `pollIncomingMessages emits buttons message`() = runTest {
+        val json = buttonsMessageJson("btn-1", body = "Choose:", buttons = listOf("A", "B"))
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals(MessageType.Buttons, batch.first().type)
+        assertEquals(MessageRole.AGENT, batch.first().role)
+        assertEquals("Choose:", batch.first().content)
+        assertEquals(listOf("A", "B"), batch.first().buttons)
+    }
+
+    @Test
+    fun `pollIncomingMessages emits buttons message with header and footer`() = runTest {
+        val json = buttonsMessageJson("btn-2", body = "Help?", header = "Order", footer = "Tap one", buttons = listOf("Track", "Cancel"))
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals("Order", batch.first().header)
+        assertEquals("Tap one", batch.first().footer)
+        assertEquals(listOf("Track", "Cancel"), batch.first().buttons)
+    }
+
+    // ── pollIncomingMessages — CTA messages ────────────────────────────────────────
+
+    private fun ctaMessageJson(
+        id: String,
+        body: String = "Visit us",
+        buttons: List<Pair<String, String>> = listOf("Open" to "https://example.com"),
+        header: String? = null,
+        footer: String? = null,
+    ): String {
+        val headerField = if (header != null) """"header":"$header",""" else ""
+        val footerField = if (footer != null) ""","footer":"$footer"""" else ""
+        val buttonsJson = buttons.joinToString(",") { (text, url) -> """{"text":"$text","url":"$url"}""" }
+        return """[{"id":"$id","message":{"ctaMessageRequest":{"content":{${headerField}"body":"$body","buttons":[$buttonsJson]$footerField}}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+    }
+
+    @Test
+    fun `pollIncomingMessages emits CTA message`() = runTest {
+        val json = ctaMessageJson("cta-1", body = "Shop now", buttons = listOf("View" to "https://shop.example.com"))
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals(MessageType.CTA, batch.first().type)
+        assertEquals(MessageRole.AGENT, batch.first().role)
+        assertEquals("Shop now", batch.first().content)
+        assertEquals(1, batch.first().ctaButtons.size)
+        assertEquals("View", batch.first().ctaButtons.first().text)
+        assertEquals("https://shop.example.com", batch.first().ctaButtons.first().url)
+    }
+
+    @Test
+    fun `pollIncomingMessages emits CTA message with header and footer`() = runTest {
+        val json = ctaMessageJson("cta-2", header = "Promo", footer = "Limited", buttons = listOf("Buy" to "https://a.com", "Learn" to "https://b.com"))
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals("Promo", batch.first().header)
+        assertEquals("Limited", batch.first().footer)
+        assertEquals(2, batch.first().ctaButtons.size)
+    }
+
+    // ── pollIncomingMessages — video messages ──────────────────────────────────────
+
+    private fun videoMessageJson(id: String, mediaUrl: String, caption: String = "", mediaType: String = "video/mp4"): String =
+        """[{"id":"$id","message":{"videoMessageRequest":{"content":{"mediaUrl":"$mediaUrl","mediaType":"$mediaType","text":"$caption","role":"MESSAGE_ROLE_AGENT","duration":5.0}}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+
+    @Test
+    fun `pollIncomingMessages emits video message and saves file locally`() = runTest {
+        val videoBytes = ByteArray(16) { it.toByte() }
+        val engine = MockEngine { request ->
+            when {
+                request.url.encodedPath.endsWith("/auth") ->
+                    respond(authResponse, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                request.url.encodedPath.endsWith("/inapp/messages") ->
+                    respond(
+                        videoMessageJson("vid-1", "https://cdn.example.com/video.mp4", caption = "Watch this"),
+                        HttpStatusCode.OK,
+                        headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                else ->
+                    respond(videoBytes, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "video/mp4"))
+            }
+        }
+        val repo = buildRepoWithEngine(engine)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        val msg = batch.first()
+        assertEquals(MessageType.Video, msg.type)
+        assertEquals(MessageRole.AGENT, msg.role)
+        assertEquals("Watch this", msg.content)
+        assertEquals(5_000L, msg.duration)
+        assertNotNull(msg.fileName, "fileName should be set to the local file path")
+        assertTrue(File(msg.fileName!!).exists(), "downloaded video file should exist on disk")
+    }
+
+    @Test
+    fun `pollIncomingMessages skips video message when download fails`() = runTest {
+        var pollCount = 0
+        val engine = MockEngine { request ->
+            when {
+                request.url.encodedPath.endsWith("/auth") ->
+                    respond(authResponse, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                request.url.encodedPath.endsWith("/inapp/messages") -> {
+                    pollCount++
+                    val body = if (pollCount == 1) videoMessageJson("vid-2", "https://cdn.example.com/video.mp4")
+                               else textMessageJson("txt-1", "fallback")
+                    respond(body, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                }
+                else -> respondError(HttpStatusCode.InternalServerError) // CDN download fails
+            }
+        }
+        // First poll: video skipped (download fails). Second poll: text arrives.
+        val repo = buildRepoWithEngine(engine)
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        assertEquals(MessageType.Text, batch.first().type)
+    }
+
     // ── TypingStop behaviour ──────────────────────────────────────────────────────
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -25,7 +25,6 @@ import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.yield
 import kotlinx.serialization.json.Json
@@ -747,11 +746,13 @@ class YaloMessageRepositoryRemoteTest {
     // ── TypingStop behaviour ──────────────────────────────────────────────────────
 
     @Test
-    fun `pollIncomingMessages does not emit TypingStop when all polled messages are already cached`() = runTest {
+    fun `pollIncomingMessages does not emit TypingStop when all polled messages are already cached`() = runTest(UnconfinedTestDispatcher()) {
         // Polls: (1) id-1 new → TypingStop + emit, (2) id-1 cached → no TypingStop no emit,
         // (3) id-2 new → TypingStop + emit. take(2) waits for exactly the two emissions,
         // spanning all three polls. If the bug returned (TypingStop on raw.isNotEmpty rather
         // than batch.isNotEmpty) the count would be 3 instead of 2.
+        // UnconfinedTestDispatcher: eventJob starts eagerly and collects events in real-time
+        // alongside the polling loop, no manual scheduler advancement needed.
         val repo = buildRepo(listOf(
             textMessageJson("id-1", "First"),
             textMessageJson("id-1", "First"),  // cached — no emit, no TypingStop
@@ -760,7 +761,7 @@ class YaloMessageRepositoryRemoteTest {
         val events = mutableListOf<ChatEvent>()
         val eventJob = launch { repo.events().collect { events.add(it) } }
         repo.pollIncomingMessages().take(2).toList()
-        runCurrent() // flush any buffered events into eventJob before cancelling
+        yield()
         eventJob.cancel()
         assertEquals(2, events.count { it is ChatEvent.TypingStop })
     }

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -610,6 +610,62 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals(MessageRole.AGENT, batch.first().role)
     }
 
+    // ── TypingStop behaviour ──────────────────────────────────────────────────────
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `pollIncomingMessages does not emit TypingStop when all polled messages are already cached`() = runTest(UnconfinedTestDispatcher()) {
+        // Serve the same message on two consecutive polls.
+        // First poll → new message → TypingStop fires.
+        // Second poll → already cached → batch is empty → TypingStop must NOT fire again.
+        val json = textMessageJson("id-cached", "Hello")
+        val repo = buildRepo(listOf(json, json))
+        val collectedEvents = mutableListOf<ChatEvent>()
+        val eventJob = launch { repo.events().collect { collectedEvents.add(it) } }
+        val pollJob = launch { repo.pollIncomingMessages().collect {} }
+        yield() // first poll: new message → emits + TypingStop
+        yield() // second poll: cached → empty batch → no TypingStop
+        pollJob.cancel()
+        eventJob.cancel()
+        assertEquals(1, collectedEvents.count { it is ChatEvent.TypingStop })
+    }
+
+    // ── ensureReceiptOrder ────────────────────────────────────────────────────────
+
+    @Test
+    fun `ensureReceiptOrder does not rewrite message IDs on first poll`() = runTest {
+        // On the very first poll pollHighWater is 0, so historical IDs must be preserved.
+        // The message date is 2024-01-01T12:00:00Z → stableId ~1_704_110_400_000.
+        // Without the fix the ID would be bumped to current time (~1_700_000_000_000+).
+        val repo = buildRepo(listOf(textMessageJson("id-first", "Hello")))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        val id = batch.first().id!!
+        // stableId for 2024-01-01 is ~1_704_110_400_000; current time is well above 1_750_000_000_000.
+        assertTrue(id < 1_750_000_000_000L,
+            "ID $id was bumped to current time on first poll — historical IDs should be preserved")
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `ensureReceiptOrder rewrites out-of-order IDs on subsequent polls`() = runTest(UnconfinedTestDispatcher()) {
+        // First poll: new message dated 2024 establishes pollHighWater.
+        // Second poll: different message with same 2024 date and an ID that falls
+        // below the current receiptFloor — must be rewritten to maintain monotonicity.
+        val repo = buildRepo(listOf(
+            textMessageJson("id-a", "First"),
+            textMessageJson("id-b", "Second"),
+        ))
+        val batches = mutableListOf<List<ChatMessage>>()
+        val pollJob = launch { repo.pollIncomingMessages().collect { batches.add(it) } }
+        yield(); yield(); yield()
+        pollJob.cancel()
+        assertEquals(2, batches.size)
+        val id1 = batches[0].first().id!!
+        val id2 = batches[1].first().id!!
+        assertTrue(id2 > id1, "Second poll ID $id2 must be > first poll ID $id1")
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `pollIncomingMessages emits TypingStop on network error`() = runTest(UnconfinedTestDispatcher()) {

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -23,7 +23,6 @@ import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.Json
 
-// Port of flutter-sdk ChatMessageRepositoryLocal (Drift) — same schema, same query semantics.
 // Free of Android-specific imports: ChatMessageQueries is injected, ioDispatcher is injectable.
 // KMP note: when splitting to KMP, pass the appropriate CoroutineDispatcher from the platform.
 internal class LocalChatMessageRepository(
@@ -32,7 +31,7 @@ internal class LocalChatMessageRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ChatMessageRepository {
 
-    // GET first page (no cursor) or cursor page — mirrors Flutter getChatMessagePageDesc.
+    // GET first page (no cursor) or cursor page.
     override suspend fun getMessages(cursor: Long?, limit: Int): Result<List<ChatMessage>> =
         withContext(ioDispatcher) {
             try {
@@ -63,7 +62,6 @@ internal class LocalChatMessageRepository(
     }
 
     // Batch INSERT OR REPLACE in a single transaction — used by MessageSyncService.
-    // Port of Flutter insertChatMessage called in a loop inside a Drift transaction.
     override suspend fun insertMessages(messages: List<ChatMessage>): Result<Unit> {
         val nullIdMessage = messages.firstOrNull { it.id == null }
         if (nullIdMessage != null) return Result.Error(
@@ -96,7 +94,6 @@ internal class LocalChatMessageRepository(
         }
 
     // Live observation: emits updated list whenever chat_message table changes.
-    // Port of Flutter stream returned by Drift's watchX.
     // Uses SQLDelight coroutines-extensions asFlow + mapToList.
     override fun observeMessages(): Flow<List<ChatMessage>> =
         queries.observeConversation()

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -8,6 +8,7 @@ import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.database.ChatMessageQueries
 import com.yalo.chat.sdk.database.Chat_message
 import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
@@ -119,6 +120,10 @@ internal class LocalChatMessageRepository(
         mediaType = media_type,
         products = products?.let { decodeProductList(it) } ?: emptyList(),
         quickReplies = quick_replies?.let { decodeStringList(it) } ?: emptyList(),
+        header = header_, // SQLDelight escapes 'header' (SQL keyword) → header_
+        footer = footer,
+        buttons = buttons?.let { decodeStringList(it) } ?: emptyList(),
+        ctaButtons = cta_buttons?.let { decodeCtaButtonList(it) } ?: emptyList(),
         timestamp = timestamp,
     )
 
@@ -136,6 +141,10 @@ internal class LocalChatMessageRepository(
         media_type = mediaType,
         products = products.takeIf { it.isNotEmpty() }?.let { encodeProductList(it) },
         quick_replies = quickReplies.takeIf { it.isNotEmpty() }?.let { encodeStringList(it) },
+        header_ = header,
+        footer = footer,
+        buttons = buttons.takeIf { it.isNotEmpty() }?.let { encodeStringList(it) },
+        cta_buttons = ctaButtons.takeIf { it.isNotEmpty() }?.let { encodeCtaButtonList(it) },
         timestamp = timestamp,
     )
 
@@ -144,6 +153,7 @@ internal class LocalChatMessageRepository(
     private val doubleListSerializer = ListSerializer(Double.serializer())
     private val productListSerializer = ListSerializer(Product.serializer())
     private val stringListSerializer = ListSerializer(String.serializer())
+    private val ctaButtonListSerializer = ListSerializer(CtaButton.serializer())
 
     private fun decodeDoubleList(json: String): List<Double> =
         try { Json.decodeFromString(doubleListSerializer, json) } catch (_: Exception) { emptyList() }
@@ -154,6 +164,9 @@ internal class LocalChatMessageRepository(
     private fun decodeStringList(json: String): List<String> =
         try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { emptyList() }
 
+    private fun decodeCtaButtonList(json: String): List<CtaButton> =
+        try { Json.decodeFromString(ctaButtonListSerializer, json) } catch (_: Exception) { emptyList() }
+
     private fun encodeDoubleList(list: List<Double>): String =
         Json.encodeToString(doubleListSerializer, list)
 
@@ -162,6 +175,9 @@ internal class LocalChatMessageRepository(
 
     private fun encodeStringList(list: List<String>): String =
         Json.encodeToString(stringListSerializer, list)
+
+    private fun encodeCtaButtonList(list: List<CtaButton>): String =
+        Json.encodeToString(ctaButtonListSerializer, list)
 }
 
 // Struct to carry insertOrReplace parameters (avoids a long positional call site).
@@ -179,6 +195,10 @@ private data class InsertOrReplaceParams(
     val media_type: String?,
     val products: String?,
     val quick_replies: String?,
+    val header_: String?,
+    val footer: String?,
+    val buttons: String?,
+    val cta_buttons: String?,
     val timestamp: Long,
 )
 
@@ -197,5 +217,9 @@ private fun ChatMessageQueries.insertOrReplace(p: InsertOrReplaceParams) =
         media_type = p.media_type,
         products = p.products,
         quick_replies = p.quick_replies,
+        header_ = p.header_,
+        footer = p.footer,
+        buttons = p.buttons,
+        cta_buttons = p.cta_buttons,
         timestamp = p.timestamp,
     )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -24,39 +24,33 @@ internal data class YaloFetchMessagesResponse(
 internal data class SdkMessageResponseDto(
     val textMessageRequest: SdkTextMessageResponseDto? = null,
     val imageMessageRequest: SdkImageMessageResponseDto? = null,
+    val videoMessageRequest: SdkVideoMessageResponseDto? = null,
     val productMessageRequest: SdkProductMessageResponseDto? = null,
+    val buttonsMessageRequest: SdkButtonsMessageResponseDto? = null,
+    val ctaMessageRequest: SdkCtaMessageResponseDto? = null,
 )
 
 // ── Text ──────────────────────────────────────────────────────────────────────
 
 @Serializable
 internal data class SdkTextMessageResponseDto(
-    // Nullable so a malformed TextMessageRequest (missing content) skips silently
-    // rather than throwing SerializationException and failing the entire fetch batch.
     val content: SdkTextMessageContentDto? = null,
 )
 
 @Serializable
 internal data class SdkTextMessageContentDto(
     val text: String,
-    // Proto MessageRole JSON encoding: "MESSAGE_ROLE_USER" or "MESSAGE_ROLE_AGENT".
-    // Omitted when the value is the default (MESSAGE_ROLE_UNSPECIFIED = 0).
     val role: String? = null,
 )
 
 // ── Product ───────────────────────────────────────────────────────────────────
 
-// Proto3 JSON for ProductMessageRequest.
-// orientation: "ORIENTATION_VERTICAL" → Product list, "ORIENTATION_HORIZONTAL" → ProductCarousel.
 @Serializable
 internal data class SdkProductMessageResponseDto(
     val products: List<SdkProductDto> = emptyList(),
-    // Proto3 JSON enum value name, e.g. "ORIENTATION_VERTICAL" or "ORIENTATION_HORIZONTAL".
-    // Absent when unspecified — treated as vertical (list) in toChatMessage().
     val orientation: String? = null,
 )
 
-// Mirrors proto Product message fields (proto3 JSON camelCase encoding).
 @Serializable
 internal data class SdkProductDto(
     val sku: String,
@@ -82,11 +76,66 @@ internal data class SdkImageMessageResponseDto(
 
 @Serializable
 internal data class SdkImageMessageContentDto(
-    // URL of the media file on the CDN — used to download the image bytes.
     val mediaUrl: String,
-    // MIME type as declared by the sender; may be empty string if not set.
     val mediaType: String = "",
-    // Optional caption text accompanying the image.
     val text: String? = null,
     val role: String? = null,
+)
+
+// ── Video ─────────────────────────────────────────────────────────────────────
+
+// Port of flutter-sdk videoMessageRequest handling in _translateMessageResponse.
+@Serializable
+internal data class SdkVideoMessageResponseDto(
+    val content: SdkVideoMessageContentDto? = null,
+)
+
+@Serializable
+internal data class SdkVideoMessageContentDto(
+    val mediaUrl: String,
+    val mediaType: String = "",
+    val text: String? = null,
+    val role: String? = null,
+    val byteCount: Long? = null,
+    val fileName: String = "",
+    // Duration in seconds (proto double); stored as Long millis in ChatMessage.
+    val duration: Double = 0.0,
+)
+
+// ── Buttons ───────────────────────────────────────────────────────────────────
+
+// Port of flutter-sdk buttonsMessageRequest — ButtonsMessage proto.
+@Serializable
+internal data class SdkButtonsMessageResponseDto(
+    val content: SdkButtonsMessageContentDto? = null,
+)
+
+@Serializable
+internal data class SdkButtonsMessageContentDto(
+    val header: String? = null,
+    val body: String = "",
+    val footer: String? = null,
+    val buttons: List<String> = emptyList(),
+)
+
+// ── CTA ───────────────────────────────────────────────────────────────────────
+
+// Port of flutter-sdk ctaMessageRequest — CTAMessage proto.
+@Serializable
+internal data class SdkCtaMessageResponseDto(
+    val content: SdkCtaMessageContentDto? = null,
+)
+
+@Serializable
+internal data class SdkCtaMessageContentDto(
+    val header: String? = null,
+    val body: String = "",
+    val footer: String? = null,
+    val buttons: List<SdkCtaButtonDto> = emptyList(),
+)
+
+@Serializable
+internal data class SdkCtaButtonDto(
+    val text: String,
+    val url: String,
 )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -84,7 +84,6 @@ internal data class SdkImageMessageContentDto(
 
 // ── Video ─────────────────────────────────────────────────────────────────────
 
-// Port of flutter-sdk videoMessageRequest handling in _translateMessageResponse.
 @Serializable
 internal data class SdkVideoMessageResponseDto(
     val content: SdkVideoMessageContentDto? = null,
@@ -103,7 +102,6 @@ internal data class SdkVideoMessageContentDto(
 
 // ── Buttons ───────────────────────────────────────────────────────────────────
 
-// Port of flutter-sdk buttonsMessageRequest — ButtonsMessage proto.
 @Serializable
 internal data class SdkButtonsMessageResponseDto(
     val content: SdkButtonsMessageContentDto? = null,
@@ -119,7 +117,6 @@ internal data class SdkButtonsMessageContentDto(
 
 // ── CTA ───────────────────────────────────────────────────────────────────────
 
-// Port of flutter-sdk ctaMessageRequest — CTAMessage proto.
 @Serializable
 internal data class SdkCtaMessageResponseDto(
     val content: SdkCtaMessageContentDto? = null,

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -96,7 +96,6 @@ internal data class SdkVideoMessageContentDto(
     val mediaType: String = "",
     val text: String? = null,
     val role: String? = null,
-    val byteCount: Long? = null,
     val fileName: String = "",
     // Duration in seconds (proto double); stored as Long millis in ChatMessage.
     val duration: Double = 0.0,

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -14,6 +14,7 @@ import com.yalo.chat.sdk.data.remote.model.SdkVoiceNoteMessageRequestBody
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
@@ -279,6 +280,79 @@ internal class YaloMessageRepositoryRemote(
                     )
                 }
             }
+        }
+
+        // Video message — download from CDN and save locally.
+        // Mirrors Flutter's videoMessageRequest case in _translateMessageResponse().
+        // Cache is set only after a successful download (same pattern as image).
+        message.videoMessageRequest?.content?.let { videoContent ->
+            return when (val downloadResult = apiService.downloadMedia(videoContent.mediaUrl)) {
+                is Result.Error -> null // skip silently — will retry on next poll cycle
+                is Result.Ok -> {
+                    val bytes = downloadResult.result
+                    val mimeType = videoContent.mediaType.takeIf { it.isNotEmpty() } ?: "video/mp4"
+                    val ext = mimeType.substringAfter('/').substringBefore(';').trim().let {
+                        if (it.contains("mp4") || it == "mp4") "mp4" else it
+                    }
+                    val localPath = PlatformFiles.writeToDir(
+                        dirPath = tempDir,
+                        filename = "${Uuid.random()}.$ext",
+                        bytes = bytes,
+                    ) ?: return null
+                    if (deduplicate) cache.set(id, true)
+                    ChatMessage(
+                        id = stableId,
+                        wiId = id,
+                        role = MessageRole.fromString(videoContent.role ?: "MESSAGE_ROLE_AGENT"),
+                        type = MessageType.Video,
+                        status = MessageStatus.DELIVERED,
+                        content = videoContent.text ?: "",
+                        fileName = localPath,
+                        mediaType = mimeType,
+                        byteCount = bytes.size.toLong(),
+                        // Flutter stores duration in seconds (Double) → convert to millis for ChatMessage.
+                        duration = (videoContent.duration * 1000).toLong(),
+                        timestamp = ts,
+                    )
+                }
+            }
+        }
+
+        // Buttons message — body text + a list of reply labels rendered as outlined buttons.
+        // Tapping a button sends the label as a text message (same as quick reply chips).
+        // Port of flutter-sdk buttonsMessageRequest case in _translateMessageResponse().
+        message.buttonsMessageRequest?.content?.let { buttonsContent ->
+            if (deduplicate) cache.set(id, true)
+            return ChatMessage(
+                id = stableId,
+                wiId = id,
+                role = MessageRole.AGENT,
+                type = MessageType.Buttons,
+                status = MessageStatus.DELIVERED,
+                content = buttonsContent.body,
+                header = buttonsContent.header.takeIf { !it.isNullOrEmpty() },
+                footer = buttonsContent.footer.takeIf { !it.isNullOrEmpty() },
+                buttons = buttonsContent.buttons,
+                timestamp = ts,
+            )
+        }
+
+        // CTA message — body text + buttons that each open a URL in the browser.
+        // Port of flutter-sdk ctaMessageRequest case in _translateMessageResponse().
+        message.ctaMessageRequest?.content?.let { ctaContent ->
+            if (deduplicate) cache.set(id, true)
+            return ChatMessage(
+                id = stableId,
+                wiId = id,
+                role = MessageRole.AGENT,
+                type = MessageType.CTA,
+                status = MessageStatus.DELIVERED,
+                content = ctaContent.body,
+                header = ctaContent.header.takeIf { !it.isNullOrEmpty() },
+                footer = ctaContent.footer.takeIf { !it.isNullOrEmpty() },
+                ctaButtons = ctaContent.buttons.map { CtaButton(text = it.text, url = it.url) },
+                timestamp = ts,
+            )
         }
 
         // Product message — vertical list or horizontal carousel, determined by orientation.

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -191,8 +191,8 @@ internal class YaloMessageRepositoryRemote(
         }
     }
 
-    // Guarantees that every message in a polled batch has an id strictly greater
-    // than all previously-polled messages and the current client clock.
+    // Assigns stable local ids to a polled batch so that messages are ordered
+    // consistently relative to user-sent messages and previous poll batches.
     //
     // Problem: stableId is derived from the SERVER timestamp, but user-message
     // tempIds are derived from the CLIENT clock. When the server takes a few
@@ -205,6 +205,11 @@ internal class YaloMessageRepositoryRemote(
     // is the client clock at receipt time. This mirrors Flutter's prepend-to-front
     // behaviour (newest message always at bottom) without changing the DB schema.
     // fetchMessages() (startup cold load) is NOT affected — it bypasses this function.
+    //
+    // First-poll exception: when pollHighWater == 0 (no prior poll has completed)
+    // rawIds are used as-is. On the first poll there are no user-sent tempIds to
+    // collide with, so clamping is not necessary and preserving rawIds avoids
+    // artificially advancing pollHighWater before the second poll.
     private fun ensureReceiptOrder(messages: List<ChatMessage>): List<ChatMessage> {
         if (messages.isEmpty()) return messages
         val highWaterEstablished = pollHighWater > 0L

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -207,17 +207,18 @@ internal class YaloMessageRepositoryRemote(
     // fetchMessages() (startup cold load) is NOT affected — it bypasses this function.
     private fun ensureReceiptOrder(messages: List<ChatMessage>): List<ChatMessage> {
         if (messages.isEmpty()) return messages
+        val highWaterEstablished = pollHighWater > 0L
         val receiptFloor = Clock.System.now().toEpochMilliseconds()
         var cursor = maxOf(receiptFloor, pollHighWater + 1)
         return messages.map { msg ->
             val rawId = msg.id ?: return@map msg
-            val id = if (rawId < cursor) {
+            val id = if (!highWaterEstablished || rawId >= cursor) {
+                cursor = maxOf(cursor, rawId + 1)
+                rawId
+            } else {
                 val assigned = cursor
                 cursor++
                 assigned
-            } else {
-                cursor = rawId + 1
-                rawId
             }
             if (id > pollHighWater) pollHighWater = id
             if (id == rawId) msg else msg.copy(id = id)

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -172,15 +172,17 @@ internal class YaloMessageRepositoryRemote(
             when (val result = apiService.fetchMessages()) {
                 is Result.Ok -> {
                     val raw = result.result
-                    // Check for genuinely new messages BEFORE toChatMessage updates the cache.
-                    // Using raw.isNotEmpty() (old approach) caused TypingStop to fire on the
-                    // first poll after a send, because cached (already-seen) messages also
-                    // make raw non-empty, hiding the typing indicator before the agent replies.
-                    val hasNewMessages = raw.any { cache.get(it.id) == null }
                     val batch = raw.mapNotNull { it.toChatMessage(deduplicate = true) }
                         .let { ensureReceiptOrder(it) }
-                    if (hasNewMessages) _events.tryEmit(ChatEvent.TypingStop)
-                    if (batch.isNotEmpty()) emit(batch)
+                    // Mirror Flutter: TypingStop fires only when at least one NEW message
+                    // was successfully translated. toChatMessage(deduplicate=true) returns
+                    // null for already-cached items, so batch contains only new arrivals.
+                    // This prevents the indicator from dismissing on cached messages
+                    // (old raw.isNotEmpty() bug) AND on untranslatable unknown types.
+                    if (batch.isNotEmpty()) {
+                        _events.tryEmit(ChatEvent.TypingStop)
+                        emit(batch)
+                    }
                 }
                 is Result.Error -> {
                     // Fetch failed — clear typing indicator so it doesn't get stuck.

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -31,12 +31,10 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
-// Port of flutter-sdk YaloMessageRepositoryRemote.
 // Polling: 1s interval, LRU deduplication cache (capacity 500).
-// The `since` query param is intentionally omitted — Flutter FIXME disables it too
-// ("wait for backend fix"). Client-side deduplication via SimpleCache handles repeats.
-// Network errors in the polling flow are swallowed and the loop continues — mirrors
-// flutter-sdk _startPolling() which logs the error and falls through to Future.delayed.
+// The `since` query param is intentionally omitted — backend fix pending.
+// Client-side deduplication via SimpleCache handles repeats.
+// Network errors in the polling flow are swallowed and the loop continues.
 @OptIn(ExperimentalUuidApi::class)
 internal class YaloMessageRepositoryRemote(
     private val apiService: YaloChatApiService,
@@ -322,7 +320,6 @@ internal class YaloMessageRepositoryRemote(
 
         // Buttons message — body text + a list of reply labels rendered as outlined buttons.
         // Tapping a button sends the label as a text message (same as quick reply chips).
-        // Port of flutter-sdk buttonsMessageRequest case in _translateMessageResponse().
         message.buttonsMessageRequest?.content?.let { buttonsContent ->
             if (deduplicate) cache.set(id, true)
             return ChatMessage(
@@ -340,7 +337,6 @@ internal class YaloMessageRepositoryRemote(
         }
 
         // CTA message — body text + buttons that each open a URL in the browser.
-        // Port of flutter-sdk ctaMessageRequest case in _translateMessageResponse().
         message.ctaMessageRequest?.content?.let { ctaContent ->
             if (deduplicate) cache.set(id, true)
             return ChatMessage(

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -53,7 +53,7 @@ internal class YaloMessageRepositoryRemote(
     // time of the next user send (which happens when the server takes a few
     // seconds to generate a response — its timestamp then exceeds the user's
     // subsequent message tempId, causing the wrong visual order).
-    // Reset to 0 on construction; seeded to Clock.System.now() on first poll.
+    // Reset to 0 on construction; advanced during polling from observed message ids.
     // No atomic needed: pollIncomingMessages() is a single sequential coroutine.
     private var pollHighWater: Long = 0L
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -48,6 +48,16 @@ internal class YaloMessageRepositoryRemote(
 
     private val cache = SimpleCache<String, Boolean>(capacity = 500)
 
+    // Highest message id assigned during the current polling session.
+    // Ensures new agent messages always sort AFTER previously-seen messages,
+    // even when the server's timestamp is later than the client's clock at the
+    // time of the next user send (which happens when the server takes a few
+    // seconds to generate a response — its timestamp then exceeds the user's
+    // subsequent message tempId, causing the wrong visual order).
+    // Reset to 0 on construction; seeded to Clock.System.now() on first poll.
+    // No atomic needed: pollIncomingMessages() is a single sequential coroutine.
+    private var pollHighWater: Long = 0L
+
     // Hot SharedFlow for typing events — mirrors Flutter's _typingEventsStreamController.
     // UNLIMITED buffer prevents event loss when TypingStart and TypingStop are emitted in
     // rapid succession (e.g. a poll cycle that errors immediately after a send).
@@ -161,14 +171,14 @@ internal class YaloMessageRepositoryRemote(
             when (val result = apiService.fetchMessages()) {
                 is Result.Ok -> {
                     val raw = result.result
+                    // Check for genuinely new messages BEFORE toChatMessage updates the cache.
+                    // Using raw.isNotEmpty() (old approach) caused TypingStop to fire on the
+                    // first poll after a send, because cached (already-seen) messages also
+                    // make raw non-empty, hiding the typing indicator before the agent replies.
+                    val hasNewMessages = raw.any { cache.get(it.id) == null }
                     val batch = raw.mapNotNull { it.toChatMessage(deduplicate = true) }
-                    // Emit TypingStop whenever the server returned any messages, not just
-                    // when the filtered batch is non-empty. Without this, a poll that returns
-                    // only non-text or fully-deduplicated messages would leave the typing
-                    // indicator stuck indefinitely.
-                    if (raw.isNotEmpty()) {
-                        _events.tryEmit(ChatEvent.TypingStop)
-                    }
+                        .let { ensureReceiptOrder(it) }
+                    if (hasNewMessages) _events.tryEmit(ChatEvent.TypingStop)
                     if (batch.isNotEmpty()) emit(batch)
                 }
                 is Result.Error -> {
@@ -177,6 +187,39 @@ internal class YaloMessageRepositoryRemote(
                 }
             }
             delay(pollingIntervalMs)
+        }
+    }
+
+    // Guarantees that every message in a polled batch has an id strictly greater
+    // than all previously-polled messages and the current client clock.
+    //
+    // Problem: stableId is derived from the SERVER timestamp, but user-message
+    // tempIds are derived from the CLIENT clock. When the server takes a few
+    // seconds to generate a response its timestamp can exceed the client's clock
+    // at the moment the user sends the next message. The agent response then gets
+    // a stableId > that user message's tempId and sorts AFTER it in ORDER BY id ASC,
+    // producing wrong visual order ("hey" appears before the reply to "hello").
+    //
+    // Fix: clamp each id to max(rawId, receiptFloor + batchIndex) where receiptFloor
+    // is the client clock at receipt time. This mirrors Flutter's prepend-to-front
+    // behaviour (newest message always at bottom) without changing the DB schema.
+    // fetchMessages() (startup cold load) is NOT affected — it bypasses this function.
+    private fun ensureReceiptOrder(messages: List<ChatMessage>): List<ChatMessage> {
+        if (messages.isEmpty()) return messages
+        val receiptFloor = Clock.System.now().toEpochMilliseconds()
+        var cursor = maxOf(receiptFloor, pollHighWater + 1)
+        return messages.map { msg ->
+            val rawId = msg.id ?: return@map msg
+            val id = if (rawId < cursor) {
+                val assigned = cursor
+                cursor++
+                assigned
+            } else {
+                cursor = rawId + 1
+                rawId
+            }
+            if (id > pollHighWater) pollHighWater = id
+            if (id == rawId) msg else msg.copy(id = id)
         }
     }
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
@@ -4,7 +4,6 @@ package com.yalo.chat.sdk.domain.model
 
 import kotlinx.datetime.Clock
 
-// Port of flutter-sdk/lib/src/domain/models/chat_message/chat_message.dart
 // timestamp is epoch millis (Long) instead of DateTime — avoids any Android dependency.
 // expand is a transient UI flag — it is NOT persisted in DB and always defaults to false
 // when messages are loaded from storage. Toggled in-memory by ChatToggleMessageExpand.
@@ -27,14 +26,11 @@ data class ChatMessage(
     val expand: Boolean = false,
     val quickReplies: List<QuickReply> = emptyList(),
     // Optional header/footer text for buttons and CTA messages.
-    // Port of flutter-sdk ChatMessage.header / ChatMessage.footer.
     val header: String? = null,
     val footer: String? = null,
     // Reply button labels for ButtonsMessage — tapping sends the label as a text message.
-    // Port of flutter-sdk ChatMessage.buttons.
     val buttons: List<String> = emptyList(),
     // CTA buttons (text + URL) for CtaMessage — tapping opens the URL in the browser.
-    // Port of flutter-sdk ChatMessage.ctaButtons.
     val ctaButtons: List<CtaButton> = emptyList(),
     val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
@@ -26,5 +26,15 @@ data class ChatMessage(
     // Transient UI state — not stored in DB. Defaults to false on every load from storage.
     val expand: Boolean = false,
     val quickReplies: List<QuickReply> = emptyList(),
+    // Optional header/footer text for buttons and CTA messages.
+    // Port of flutter-sdk ChatMessage.header / ChatMessage.footer.
+    val header: String? = null,
+    val footer: String? = null,
+    // Reply button labels for ButtonsMessage — tapping sends the label as a text message.
+    // Port of flutter-sdk ChatMessage.buttons.
+    val buttons: List<String> = emptyList(),
+    // CTA buttons (text + URL) for CtaMessage — tapping opens the URL in the browser.
+    // Port of flutter-sdk ChatMessage.ctaButtons.
+    val ctaButtons: List<CtaButton> = emptyList(),
     val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/CtaButton.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/CtaButton.kt
@@ -4,7 +4,6 @@ package com.yalo.chat.sdk.domain.model
 
 import kotlinx.serialization.Serializable
 
-// Port of flutter-sdk/lib/src/domain/models/chat_message/cta_button.dart
 // A CTA button has a display label and a URL to open when tapped.
 @Serializable
 data class CtaButton(

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/CtaButton.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/CtaButton.kt
@@ -1,0 +1,13 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.domain.model
+
+import kotlinx.serialization.Serializable
+
+// Port of flutter-sdk/lib/src/domain/models/chat_message/cta_button.dart
+// A CTA button has a display label and a URL to open when tapped.
+@Serializable
+data class CtaButton(
+    val text: String,
+    val url: String,
+)

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/MessageType.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/MessageType.kt
@@ -2,7 +2,6 @@
 
 package com.yalo.chat.sdk.domain.model
 
-// Port of MessageType enum from flutter-sdk/lib/src/domain/models/chat_message/chat_message.dart
 // Unknown is the safe fallback for any unrecognized server value — never throws.
 sealed class MessageType(val value: String) {
     data object Text : MessageType("text")

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/MessageType.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/MessageType.kt
@@ -8,17 +8,20 @@ sealed class MessageType(val value: String) {
     data object Text : MessageType("text")
     data object Image : MessageType("image")
     data object Voice : MessageType("voice")
+    data object Video : MessageType("video")
     data object Product : MessageType("product")
     data object ProductCarousel : MessageType("productCarousel")
     data object Promotion : MessageType("promotion")
     data object QuickReply : MessageType("quickReply")
+    data object Buttons : MessageType("buttons")
+    data object CTA : MessageType("cta")
     data object Unknown : MessageType("unknown")
 
     companion object {
         // Lazy to avoid JVM circular-initialization: companion runs before data objects
         // are fully initialized when MessageType class is first loaded.
         private val BY_VALUE: Map<String, MessageType> by lazy {
-            listOf(Text, Image, Voice, Product, ProductCarousel, Promotion, QuickReply, Unknown)
+            listOf(Text, Image, Voice, Video, Product, ProductCarousel, Promotion, QuickReply, Buttons, CTA, Unknown)
                 .associateBy { it.value }
         }
 

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -1,0 +1,6 @@
+-- Migration 2: add columns for buttons and CTA message types
+-- Port of flutter-sdk chat_message.drift addition in PR #94 (cta-buttons-repo-flutter).
+ALTER TABLE chat_message ADD COLUMN header TEXT;
+ALTER TABLE chat_message ADD COLUMN footer TEXT;
+ALTER TABLE chat_message ADD COLUMN buttons TEXT;
+ALTER TABLE chat_message ADD COLUMN cta_buttons TEXT;

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -1,9 +1,8 @@
--- Migration 2: add columns for buttons/CTA message types + align wi_id with Flutter schema.
--- Port of flutter-sdk chat_message.drift addition in PR #94 (cta-buttons-repo-flutter).
+-- Migration 2: add columns for buttons/CTA message types + add UNIQUE constraint on wi_id.
 --
 -- SQLite does not support ALTER TABLE ADD COLUMN ... UNIQUE, so we recreate the table
--- to add the UNIQUE constraint on wi_id (present in Flutter's Drift schema) while also
--- adding the four new columns (header, footer, buttons, cta_buttons).
+-- to add the UNIQUE constraint on wi_id while also adding the four new columns
+-- (header, footer, buttons, cta_buttons).
 
 CREATE TABLE chat_message_v2 (
     id              INTEGER NOT NULL PRIMARY KEY,

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -3,6 +3,9 @@
 -- SQLite does not support ALTER TABLE ADD COLUMN ... UNIQUE, so we recreate the table
 -- to add the UNIQUE constraint on wi_id while also adding the four new columns
 -- (header, footer, buttons, cta_buttons).
+--
+-- Deduplication: if any rows share the same wi_id, ORDER BY id DESC + INSERT OR IGNORE
+-- keeps the row with the highest id (newest), discarding older duplicates.
 
 CREATE TABLE chat_message_v2 (
     id              INTEGER NOT NULL PRIMARY KEY,
@@ -32,7 +35,7 @@ INSERT OR IGNORE INTO chat_message_v2
            NULL, NULL, NULL, NULL,
            timestamp
     FROM chat_message
-    ORDER BY id ASC;
+    ORDER BY id DESC;
 
 DROP TABLE chat_message;
 

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -25,7 +25,7 @@ CREATE TABLE chat_message_v2 (
     timestamp       INTEGER NOT NULL
 );
 
-INSERT INTO chat_message_v2
+INSERT OR IGNORE INTO chat_message_v2
     SELECT id, wi_id, role, content, type, status,
            file_name, amplitudes, duration, byte_count, media_type,
            products, quick_replies,

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -1,6 +1,39 @@
--- Migration 2: add columns for buttons and CTA message types
+-- Migration 2: add columns for buttons/CTA message types + align wi_id with Flutter schema.
 -- Port of flutter-sdk chat_message.drift addition in PR #94 (cta-buttons-repo-flutter).
-ALTER TABLE chat_message ADD COLUMN header TEXT;
-ALTER TABLE chat_message ADD COLUMN footer TEXT;
-ALTER TABLE chat_message ADD COLUMN buttons TEXT;
-ALTER TABLE chat_message ADD COLUMN cta_buttons TEXT;
+--
+-- SQLite does not support ALTER TABLE ADD COLUMN ... UNIQUE, so we recreate the table
+-- to add the UNIQUE constraint on wi_id (present in Flutter's Drift schema) while also
+-- adding the four new columns (header, footer, buttons, cta_buttons).
+
+CREATE TABLE chat_message_v2 (
+    id              INTEGER NOT NULL PRIMARY KEY,
+    wi_id           TEXT UNIQUE,
+    role            TEXT NOT NULL,
+    content         TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    status          TEXT NOT NULL,
+    file_name       TEXT,
+    amplitudes      TEXT,
+    duration        INTEGER,
+    byte_count      INTEGER,
+    media_type      TEXT,
+    products        TEXT,
+    quick_replies   TEXT,
+    header          TEXT,
+    footer          TEXT,
+    buttons         TEXT,
+    cta_buttons     TEXT,
+    timestamp       INTEGER NOT NULL
+);
+
+INSERT INTO chat_message_v2
+    SELECT id, wi_id, role, content, type, status,
+           file_name, amplitudes, duration, byte_count, media_type,
+           products, quick_replies,
+           NULL, NULL, NULL, NULL,
+           timestamp
+    FROM chat_message;
+
+DROP TABLE chat_message;
+
+ALTER TABLE chat_message_v2 RENAME TO chat_message;

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/2.sqm
@@ -31,7 +31,8 @@ INSERT OR IGNORE INTO chat_message_v2
            products, quick_replies,
            NULL, NULL, NULL, NULL,
            timestamp
-    FROM chat_message;
+    FROM chat_message
+    ORDER BY id ASC;
 
 DROP TABLE chat_message;
 

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
@@ -1,6 +1,4 @@
 -- Copyright (c) Yalochat, Inc. All rights reserved.
--- Port of flutter-sdk/lib/src/data/services/database/chat_message.drift
--- Schema matches the Flutter Drift schema exactly (same column names and types).
 -- JSON columns (amplitudes, products, quick_replies, buttons, cta_buttons) are stored
 -- as TEXT and are encoded/decoded in the Kotlin repository layer.
 
@@ -34,14 +32,12 @@ INSERT OR REPLACE INTO chat_message (
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- First page: most recent messages, ordered newest-first.
--- Port of Flutter getMessagesFirstPage(limit).
 selectFirstPage:
 SELECT * FROM chat_message
 ORDER BY id DESC
 LIMIT :limit;
 
 -- Cursor page: messages with id < cursor, ordered newest-first.
--- Port of Flutter getMessagesPage(cursor, limit).
 selectPageBefore:
 SELECT * FROM chat_message
 WHERE id < :cursor

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
@@ -1,8 +1,8 @@
 -- Copyright (c) Yalochat, Inc. All rights reserved.
 -- Port of flutter-sdk/lib/src/data/services/database/chat_message.drift
 -- Schema matches the Flutter Drift schema exactly (same column names and types).
--- JSON columns (amplitudes, products, quick_replies) are stored as TEXT and are
--- encoded/decoded in the Kotlin repository layer (see LocalChatMessageRepository).
+-- JSON columns (amplitudes, products, quick_replies, buttons, cta_buttons) are stored
+-- as TEXT and are encoded/decoded in the Kotlin repository layer.
 
 CREATE TABLE chat_message (
     id              INTEGER NOT NULL PRIMARY KEY,
@@ -18,6 +18,10 @@ CREATE TABLE chat_message (
     media_type      TEXT,
     products        TEXT,
     quick_replies   TEXT,
+    header          TEXT,
+    footer          TEXT,
+    buttons         TEXT,
+    cta_buttons     TEXT,
     timestamp       INTEGER NOT NULL
 );
 
@@ -25,8 +29,9 @@ CREATE TABLE chat_message (
 insertOrReplace:
 INSERT OR REPLACE INTO chat_message (
     id, wi_id, role, content, type, status,
-    file_name, amplitudes, duration, byte_count, media_type, products, quick_replies, timestamp
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+    file_name, amplitudes, duration, byte_count, media_type, products, quick_replies,
+    header, footer, buttons, cta_buttons, timestamp
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 
 -- First page: most recent messages, ordered newest-first.
 -- Port of Flutter getMessagesFirstPage(limit).

--- a/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
+++ b/android-sdk/sdk/src/commonMain/sqldelight/com/yalo/chat/sdk/database/ChatMessage.sq
@@ -6,7 +6,7 @@
 
 CREATE TABLE chat_message (
     id              INTEGER NOT NULL PRIMARY KEY,
-    wi_id           TEXT,
+    wi_id           TEXT UNIQUE,
     role            TEXT NOT NULL,
     content         TEXT NOT NULL,
     type            TEXT NOT NULL,

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/MessageSyncServiceTest.kt
@@ -12,8 +12,10 @@ import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -90,7 +92,9 @@ class MessageSyncServiceTest {
 
     @Test
     fun `stop cancels polling`() = runTest {
-        // Repo that tracks whether insertMessages was called after stop
+        // Flow emits one batch then suspends indefinitely — simulates a real long-running
+        // polling loop. awaitCancellation() only returns via CancellationException, so
+        // insertCallCount must stay at 1 after stop() is called.
         var insertCallCount = 0
         val trackingRepo = object : ChatMessageRepository {
             override suspend fun getMessages(cursor: Long?, limit: Int) = Result.Ok(emptyList<ChatMessage>())
@@ -102,14 +106,24 @@ class MessageSyncServiceTest {
             override suspend fun updateMessage(message: ChatMessage) = Result.Ok(Unit)
             override fun observeMessages() = kotlinx.coroutines.flow.MutableStateFlow(emptyList<ChatMessage>())
         }
-        val batch = listOf(msg(1L))
-        val service = MessageSyncService(yaloRepo(batch), trackingRepo)
+        val infiniteRepo = object : YaloMessageRepository {
+            override suspend fun sendMessage(message: ChatMessage) = Result.Ok(Unit)
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): Flow<List<ChatMessage>> = flow {
+                emit(listOf(msg(1L))) // one real batch
+                awaitCancellation()   // then block until the job is cancelled
+            }
+            override fun events(): Flow<ChatEvent> = emptyFlow()
+        }
+        val service = MessageSyncService(infiniteRepo, trackingRepo)
 
         service.start(this)
-        service.stop()
-        testScheduler.advanceUntilIdle()
+        testScheduler.advanceUntilIdle() // let the first batch run
+        assertEquals(1, insertCallCount) // first batch was inserted
 
-        // After stop, no further inserts should happen from the cancelled flow
-        assertEquals(0, insertCallCount)
+        service.stop()
+        testScheduler.advanceUntilIdle() // cancellation propagates
+
+        assertEquals(1, insertCallCount) // no more inserts after stop
     }
 }

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeAudioImageRepositoryTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeAudioImageRepositoryTest.kt
@@ -3,6 +3,7 @@
 package com.yalo.chat.sdk.data.repository.fake
 
 import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.domain.model.AudioData
 import com.yalo.chat.sdk.domain.model.ImageData
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
@@ -26,7 +27,8 @@ class FakeAudioImageRepositoryTest {
     @Test
     fun `FakeAudioRepository stopRecording returns Ok with AudioData`() = runTest {
         val result = FakeAudioRepository().stopRecording()
-        assertIs<Result.Ok<*>>(result)
+        assertIs<Result.Ok<AudioData>>(result)
+        assertNotNull(result.result.fileName)
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Add **Video**, **Buttons**, and **CTA** message types to the Android SDK (M10)
- Fix message ordering bug (`ensureReceiptOrder` + `pollHighWater`)
- Fix typing indicator (`TypingStop` now fires only on non-empty batch)
- Fix pre-existing proto compile error (exclude 11 generated Kotlin DSL wrapper files that reference types absent from the committed `SdkMessageOuterClass.java`)

## What's new

**Video messages** — thumbnail extracted via `MediaMetadataRetriever`, tap-to-play via `AndroidView(VideoView)`, optional caption below.

**Buttons messages** — agent bubble with optional header/footer, body text, and outlined reply buttons. Tapping a button sends the label as a text message (same mechanic as quick reply chips).

**CTA messages** — same layout as Buttons but buttons open URLs via `Intent.ACTION_VIEW`. Row layout: text left-aligned, arrow icon right-aligned.

**DB schema migration** — new `header`, `footer`, `buttons`, `cta_buttons` columns; `wi_id UNIQUE` constraint added via table recreation (`2.sqm`). Duplicate `wi_id` rows are resolved by keeping the highest id (newest).

**ChatTheme** — 11 new tokens for Buttons/CTA button colors, borders, text styles, and CTA arrow icon.

## Linear

[FDE-112](https://linear.app/yalo/issue/FDE-112/android-sdk-video-buttons-and-cta-message-types-m10)

## Test plan

- [x] `./gradlew :sdk:testDebugUnitTest` — all tests pass
- [x] `./gradlew :sdk:lint` — clean
- [ ] Demo app: verify Video, Buttons, and CTA messages render correctly against staging backend
- [ ] Demo app: verify Buttons tapping sends the label as a text message
- [ ] Demo app: verify CTA buttons open the correct URL in browser
- [ ] Demo app: verify DB migration runs cleanly on an existing install (no data loss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)