### PR TITLE
feat(ios-sdk): Core SwiftUI UI Layer — M3 text-only chat (FDE-129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ flutter-sdk/pubspec.lock
 **/build/
 **/coverage/
 /.agent-shell/
+
+# iOS demo credentials — never commit
+ios-sdk/YaloChatDemo/Credentials.swift

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ flutter-sdk/pubspec.lock
 
 # iOS demo credentials — never commit
 ios-sdk/YaloChatDemo/Credentials.swift
+
+# Xcode user-specific data (workspace state, breakpoints, derived data)
+*.xcworkspace/xcuserdata/
+*.xcodeproj/xcuserdata/
+*.xcodeproj/project.xcworkspace/xcuserdata/

--- a/android-sdk/app/build.gradle.kts
+++ b/android-sdk/app/build.gradle.kts
@@ -40,6 +40,7 @@ android {
         buildConfigField("String",  "YALO_CHANNEL_ID",        "\"${localProp("yalo.channelId")}\"")
         buildConfigField("String",  "YALO_ORGANIZATION_ID",   "\"${localProp("yalo.organizationId")}\"")
         buildConfigField("Boolean", "USE_FAKE_REPOSITORY",    localProps.getProperty("yalo.useFakeRepository", "false"))
+        buildConfigField("String",  "YALO_ENVIRONMENT",       "\"${localProps.getProperty("yalo.environment", "PRODUCTION")}\"")
     }
 
     compileOptions {

--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -25,7 +25,7 @@ class MainActivity : ComponentActivity() {
                 channelName = BuildConfig.YALO_CHANNEL_NAME,
                 channelId = BuildConfig.YALO_CHANNEL_ID,
                 organizationId = BuildConfig.YALO_ORGANIZATION_ID,
-                environment = YaloChatEnvironment.STAGING,
+                environment = YaloChatEnvironment.valueOf(BuildConfig.YALO_ENVIRONMENT),
                 useFakeRepository = BuildConfig.USE_FAKE_REPOSITORY,
             ),
             context = this,

--- a/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
+++ b/android-sdk/app/src/main/kotlin/com/yalo/chat/demo/MainActivity.kt
@@ -25,7 +25,8 @@ class MainActivity : ComponentActivity() {
                 channelName = BuildConfig.YALO_CHANNEL_NAME,
                 channelId = BuildConfig.YALO_CHANNEL_ID,
                 organizationId = BuildConfig.YALO_ORGANIZATION_ID,
-                environment = YaloChatEnvironment.valueOf(BuildConfig.YALO_ENVIRONMENT),
+                environment = runCatching { YaloChatEnvironment.valueOf(BuildConfig.YALO_ENVIRONMENT) }
+                    .getOrDefault(YaloChatEnvironment.PRODUCTION),
                 useFakeRepository = BuildConfig.USE_FAKE_REPOSITORY,
             ),
             context = this,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
@@ -7,8 +7,10 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,7 +39,12 @@ internal fun MessageList(
         return
     }
     val sorted = remember(messages) { messages.sortedByDescending { it.timestamp } }
+    val listState = rememberLazyListState()
+    LaunchedEffect(sorted.size) {
+        listState.animateScrollToItem(0)
+    }
     LazyColumn(
+        state = listState,
         reverseLayout = true,
         modifier = modifier
             .fillMaxSize()

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
@@ -10,7 +10,7 @@ import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
-import kotlin.concurrent.AtomicLong
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -18,25 +18,22 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 
-// iOS counterpart to Android's MessagesViewModel.
-// Owns the coroutine scope, sync lifecycle, and optimistic send logic.
-// Uses a callback API so Swift never has to collect a KMP Flow directly.
+// Swift-facing counterpart to Android's MessagesViewModel.
+// Callback API avoids requiring Swift callers to collect a KMP Flow directly.
+// mainDispatcher defaults to Dispatchers.Main; inject a test dispatcher in unit tests.
 class MessagesController internal constructor(
     private val yaloRepo: YaloMessageRepository,
     private val localRepo: ChatMessageRepository,
     private val syncService: MessageSyncService,
+    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) {
     private var scope: CoroutineScope? = null
+    // Counter is only ever read/written from the main thread (same dispatcher as the scope).
+    private var tempIdSeq: Long = Clock.System.now().toEpochMilliseconds()
 
-    // Seeded from current epoch-ms — mirrors Android MessagesViewModel.tempIdSeq.
-    private val tempIdSeq = AtomicLong(Clock.System.now().toEpochMilliseconds())
-
-    // Starts the coroutine scope, polling sync, and local DB observation.
-    // Idempotent — a second call while already active is a no-op.
-    // Mirrors Android's SubscribeToMessages handler.
     fun start(onMessagesUpdate: (List<ChatMessage>) -> Unit) {
         if (scope != null) return
-        val s = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        val s = CoroutineScope(SupervisorJob() + mainDispatcher)
         scope = s
         syncService.start(s)
         s.launch {
@@ -52,8 +49,6 @@ class MessagesController internal constructor(
         scope = null
     }
 
-    // One-shot read of current local DB state.
-    // Mirrors Android's LoadMessages handler (reads LOCAL DB, not remote).
     fun loadMessages(onComplete: ((Boolean) -> Unit)? = null) {
         val s = scope ?: return
         s.launch {
@@ -62,13 +57,10 @@ class MessagesController internal constructor(
         }
     }
 
-    // Optimistic text send — mirrors Android MessagesViewModel.sendTextMessage().
-    // Inserts a local optimistic bubble immediately, then sends to the remote asynchronously.
-    // On remote error, updates the message status to ERROR.
     fun sendTextMessage(text: String) {
         if (text.isBlank()) return
         val s = scope ?: return
-        val tempId = tempIdSeq.getAndIncrement()
+        val tempId = tempIdSeq++
         val optimistic = ChatMessage(
             id = tempId,
             role = MessageRole.USER,

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -39,7 +39,7 @@ internal data class SdkTextMessageResponseDto(
 
 @Serializable
 internal data class SdkTextMessageContentDto(
-    val text: String,
+    val text: String = "",
     val role: String? = null,
 )
 
@@ -76,7 +76,7 @@ internal data class SdkImageMessageResponseDto(
 
 @Serializable
 internal data class SdkImageMessageContentDto(
-    val mediaUrl: String,
+    val mediaUrl: String = "",
     val mediaType: String = "",
     val text: String? = null,
     val role: String? = null,
@@ -91,7 +91,7 @@ internal data class SdkVideoMessageResponseDto(
 
 @Serializable
 internal data class SdkVideoMessageContentDto(
-    val mediaUrl: String,
+    val mediaUrl: String = "",
     val mediaType: String = "",
     val text: String? = null,
     val role: String? = null,

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -22,6 +22,7 @@ import com.yalo.chat.sdk.domain.model.Product
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -172,6 +173,7 @@ internal class YaloMessageRepositoryRemote(
                     val raw = result.result
                     val batch = raw.mapNotNull { item ->
                         try { item.toChatMessage(deduplicate = true) }
+                        catch (e: CancellationException) { throw e }
                         catch (e: Exception) { println("[YaloChatSdk] skip message ${item.id}: $e"); null }
                     }.let { ensureReceiptOrder(it) }
                     // Mirror Flutter: TypingStop fires only when at least one NEW message

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -170,8 +170,10 @@ internal class YaloMessageRepositoryRemote(
             when (val result = apiService.fetchMessages()) {
                 is Result.Ok -> {
                     val raw = result.result
-                    val batch = raw.mapNotNull { it.toChatMessage(deduplicate = true) }
-                        .let { ensureReceiptOrder(it) }
+                    val batch = raw.mapNotNull { item ->
+                        try { item.toChatMessage(deduplicate = true) }
+                        catch (e: Exception) { println("[YaloChatSdk] skip message ${item.id}: $e"); null }
+                    }.let { ensureReceiptOrder(it) }
                     // Mirror Flutter: TypingStop fires only when at least one NEW message
                     // was successfully translated. toChatMessage(deduplicate=true) returns
                     // null for already-cached items, so batch contains only new arrivals.

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
@@ -44,7 +44,7 @@ class MessagesControllerTest {
         localRepo: FakeChatMessageRepository = FakeChatMessageRepository(),
     ) = MessagesController(
         yaloRepo, localRepo,
-        MessageSyncService(FakeYaloMessageRepository(), localRepo),
+        MessageSyncService(yaloRepo, localRepo),
         dispatcher,
     ).also { tracked.add(it) }
 

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
@@ -1,0 +1,216 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.MessageSyncService
+import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
+import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.domain.model.ChatEvent
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
+import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MessagesControllerTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private val tracked = mutableListOf<MessagesController>()
+
+    @AfterTest
+    fun tearDown() {
+        tracked.forEach { it.stop() }
+        tracked.clear()
+    }
+
+    private fun controller(
+        yaloRepo: YaloMessageRepository = FakeYaloMessageRepository(),
+        localRepo: FakeChatMessageRepository = FakeChatMessageRepository(),
+    ) = MessagesController(
+        yaloRepo, localRepo,
+        MessageSyncService(FakeYaloMessageRepository(), localRepo),
+        dispatcher,
+    ).also { tracked.add(it) }
+
+    private fun msg(id: Long, content: String = "msg $id") = ChatMessage(
+        id = id,
+        role = MessageRole.AGENT,
+        type = MessageType.Text,
+        status = MessageStatus.DELIVERED,
+        content = content,
+    )
+
+    // ── start ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `start delivers existing messages via callback`() = runTest {
+        val localRepo = FakeChatMessageRepository(listOf(msg(1L, "hi")))
+        val received = mutableListOf<List<ChatMessage>>()
+        controller(localRepo = localRepo).start { received.add(it) }
+        assertTrue(received.isNotEmpty())
+        assertEquals(1, received.last().size)
+    }
+
+    @Test
+    fun `start delivers new messages inserted after start`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val received = mutableListOf<List<ChatMessage>>()
+        controller(localRepo = localRepo).start { received.add(it) }
+        localRepo.insertMessage(msg(1L, "new"))
+        assertEquals(1, received.last().size)
+    }
+
+    @Test
+    fun `start is idempotent — second call does not add a second observer`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        var observer1Fires = 0
+        var observer2Fires = 0
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { observer1Fires++ }
+        ctrl.start { observer2Fires++ } // no-op — scope already exists
+        localRepo.insertMessage(msg(1L))
+        assertEquals(0, observer2Fires)
+    }
+
+    // ── stop ──────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `stop prevents further callbacks`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        var count = 0
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { count++ }
+        val countBeforeStop = count
+        ctrl.stop()
+        localRepo.insertMessage(msg(1L))
+        assertEquals(countBeforeStop, count)
+    }
+
+    // ── loadMessages ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `loadMessages before start is a no-op`() = runTest {
+        var completed = false
+        controller().loadMessages { completed = true }
+        assertFalse(completed)
+    }
+
+    @Test
+    fun `loadMessages after start reports success`() = runTest {
+        var result: Boolean? = null
+        val ctrl = controller()
+        ctrl.start { }
+        ctrl.loadMessages { result = it }
+        assertEquals(true, result)
+    }
+
+    @Test
+    fun `loadMessages reports failure when repo errors`() = runTest {
+        val failingLocalRepo = object : ChatMessageRepository {
+            override suspend fun getMessages(cursor: Long?, limit: Int) =
+                Result.Error<List<ChatMessage>>(RuntimeException("db error"))
+            override suspend fun insertMessage(msg: ChatMessage) = Result.Ok(Unit)
+            override suspend fun insertMessages(msgs: List<ChatMessage>) = Result.Ok(Unit)
+            override suspend fun updateMessage(msg: ChatMessage) = Result.Ok(Unit)
+            override fun observeMessages(): Flow<List<ChatMessage>> =
+                MutableStateFlow(emptyList<ChatMessage>()).asStateFlow()
+        }
+        val ctrl = MessagesController(
+            FakeYaloMessageRepository(), failingLocalRepo,
+            MessageSyncService(FakeYaloMessageRepository(), failingLocalRepo),
+            dispatcher,
+        ).also { tracked.add(it) }
+        ctrl.start { }
+        var result: Boolean? = null
+        ctrl.loadMessages { result = it }
+        assertEquals(false, result)
+    }
+
+    // ── sendTextMessage ───────────────────────────────────────────────────────
+
+    @Test
+    fun `sendTextMessage with blank text does not insert a message`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendTextMessage("   ")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendTextMessage before start is a no-op`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        controller(localRepo = localRepo).sendTextMessage("hello")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendTextMessage inserts optimistic message with USER role and SENT status`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendTextMessage("hello")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val message = result.result.single()
+        assertEquals("hello", message.content)
+        assertEquals(MessageRole.USER, message.role)
+        assertEquals(MessageStatus.SENT, message.status)
+        assertEquals(MessageType.Text, message.type)
+    }
+
+    @Test
+    fun `sendTextMessage updates status to ERROR when remote send fails`() = runTest {
+        val failingYaloRepo = object : YaloMessageRepository {
+            override suspend fun sendMessage(msg: ChatMessage) =
+                Result.Error<Unit>(RuntimeException("network error"))
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): Flow<List<ChatMessage>> = emptyFlow()
+            override fun events(): Flow<ChatEvent> = emptyFlow()
+        }
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = MessagesController(
+            failingYaloRepo, localRepo,
+            MessageSyncService(failingYaloRepo, localRepo),
+            dispatcher,
+        ).also { tracked.add(it) }
+        ctrl.start { }
+        ctrl.sendTextMessage("hello")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(MessageStatus.ERROR, result.result.single().status)
+    }
+
+    @Test
+    fun `sendTextMessage consecutive sends produce unique message ids`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendTextMessage("first")
+        ctrl.sendTextMessage("second")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val ids = result.result.mapNotNull { it.id }
+        assertEquals(2, ids.distinct().size)
+    }
+}

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
@@ -1,0 +1,91 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk
+
+import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.data.MessageSyncService
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
+import com.yalo.chat.sdk.domain.model.MessageType
+import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
+import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
+import kotlin.concurrent.AtomicLong
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.datetime.Clock
+
+// iOS counterpart to Android's MessagesViewModel.
+// Owns the coroutine scope, sync lifecycle, and optimistic send logic.
+// Uses a callback API so Swift never has to collect a KMP Flow directly.
+class MessagesController internal constructor(
+    private val yaloRepo: YaloMessageRepository,
+    private val localRepo: ChatMessageRepository,
+    private val syncService: MessageSyncService,
+) {
+    private var scope: CoroutineScope? = null
+
+    // Seeded from current epoch-ms — mirrors Android MessagesViewModel.tempIdSeq.
+    private val tempIdSeq = AtomicLong(Clock.System.now().toEpochMilliseconds())
+
+    // Starts the coroutine scope, polling sync, and local DB observation.
+    // Idempotent — a second call while already active is a no-op.
+    // Mirrors Android's SubscribeToMessages handler.
+    fun start(onMessagesUpdate: (List<ChatMessage>) -> Unit) {
+        if (scope != null) return
+        val s = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+        scope = s
+        syncService.start(s)
+        s.launch {
+            localRepo.observeMessages().collect { messages ->
+                onMessagesUpdate(messages)
+            }
+        }
+    }
+
+    fun stop() {
+        syncService.stop()
+        scope?.cancel()
+        scope = null
+    }
+
+    // One-shot read of current local DB state.
+    // Mirrors Android's LoadMessages handler (reads LOCAL DB, not remote).
+    fun loadMessages(onComplete: ((Boolean) -> Unit)? = null) {
+        val s = scope ?: return
+        s.launch {
+            val ok = localRepo.getMessages(cursor = null, limit = 30) is Result.Ok
+            onComplete?.invoke(ok)
+        }
+    }
+
+    // Optimistic text send — mirrors Android MessagesViewModel.sendTextMessage().
+    // Inserts a local optimistic bubble immediately, then sends to the remote asynchronously.
+    // On remote error, updates the message status to ERROR.
+    fun sendTextMessage(text: String) {
+        if (text.isBlank()) return
+        val s = scope ?: return
+        val tempId = tempIdSeq.getAndIncrement()
+        val optimistic = ChatMessage(
+            id = tempId,
+            role = MessageRole.USER,
+            type = MessageType.Text,
+            status = MessageStatus.SENT,
+            content = text,
+            timestamp = Clock.System.now().toEpochMilliseconds(),
+        )
+        s.launch {
+            when (localRepo.insertMessage(optimistic)) {
+                is Result.Ok -> s.launch {
+                    if (yaloRepo.sendMessage(optimistic) is Result.Error) {
+                        localRepo.updateMessage(optimistic.copy(status = MessageStatus.ERROR))
+                    }
+                }
+                is Result.Error -> Unit
+            }
+        }
+    }
+}

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -94,7 +94,6 @@ object YaloChatSdk {
     fun stop() {
         messagesController?.stop()
         messagesController = null
-        _syncService?.stop()
         _syncService = null
         _httpClient?.close()
         _httpClient = null

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -34,6 +34,9 @@ object YaloChatSdk {
     internal var localRepo: LocalChatMessageRepository? = null
         private set
 
+    var messagesController: MessagesController? = null
+        private set
+
     var config: YaloChatConfig? = null
         private set
 
@@ -72,16 +75,25 @@ object YaloChatSdk {
         val local = LocalChatMessageRepository(db.chatMessageQueries, Dispatchers.Default)
         localRepo = local
 
-        // Sync service is started lazily by the Swift presentation layer (M5 ViewModel),
+        // Sync service is started lazily by MessagesController (via MessagesObservable.onAppear),
         // mirroring how MessagesViewModel governs the polling lifecycle on Android.
-        _syncService = MessageSyncService(
+        val syncSvc = MessageSyncService(
             yaloRepo = repo,
             localRepo = local,
             onSyncError = { e -> println("[YaloChatSdk] sync error: $e") },
         )
+        _syncService = syncSvc
+
+        messagesController = MessagesController(
+            yaloRepo = repo,
+            localRepo = local,
+            syncService = syncSvc,
+        )
     }
 
     fun stop() {
+        messagesController?.stop()
+        messagesController = null
         _syncService?.stop()
         _syncService = null
         _httpClient?.close()

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/data/repository/remote/PlatformFiles.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/data/repository/remote/PlatformFiles.kt
@@ -2,13 +2,50 @@
 
 package com.yalo.chat.sdk.data.repository.remote
 
-// iOS file operations — implemented in Phase 1 M3 (Image Picker milestone).
-// Throws NotImplementedError to fail fast if accidentally called before the real
-// implementation lands, rather than silently uploading empty bytes or dropping media.
-internal actual object PlatformFiles {
-    actual fun readBytes(path: String): ByteArray =
-        throw NotImplementedError("PlatformFiles.readBytes not implemented for iOS — implement in Phase 1 M3")
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.convert
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSFileManager
+import platform.Foundation.dataWithBytes
+import platform.Foundation.dataWithContentsOfFile
+import platform.posix.memcpy
 
-    actual fun writeToDir(dirPath: String?, filename: String, bytes: ByteArray): String? =
-        throw NotImplementedError("PlatformFiles.writeToDir not implemented for iOS — implement in Phase 1 M3")
+@OptIn(ExperimentalForeignApi::class)
+internal actual object PlatformFiles {
+
+    actual fun readBytes(path: String): ByteArray {
+        val data = NSData.dataWithContentsOfFile(path)
+            ?: throw Exception("Cannot read file: $path")
+        return ByteArray(data.length.toInt()).also { arr ->
+            if (arr.isNotEmpty()) arr.usePinned { pinned ->
+                memcpy(pinned.addressOf(0), data.bytes, data.length)
+            }
+        }
+    }
+
+    actual fun writeToDir(dirPath: String?, filename: String, bytes: ByteArray): String? {
+        val dir = dirPath ?: return null
+        return try {
+            NSFileManager.defaultManager.createDirectoryAtPath(
+                path = dir,
+                withIntermediateDirectories = true,
+                attributes = null,
+                error = null,
+            )
+            val filePath = if (dir.endsWith("/")) "$dir$filename" else "$dir/$filename"
+            val data = bytes.usePinned { pinned ->
+                NSData.dataWithBytes(pinned.addressOf(0), bytes.size.convert())
+            }
+            val ok = NSFileManager.defaultManager.createFileAtPath(
+                path = filePath,
+                contents = data,
+                attributes = null,
+            )
+            if (ok) filePath else null
+        } catch (_: Exception) {
+            null
+        }
+    }
 }

--- a/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
+++ b/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
@@ -7,12 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F144E784B4B0E906FE68740 /* ChatInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23407D6589CAA8A5F7913634 /* ChatInput.swift */; };
 		293282042EBD6BFA90E3A048 /* ChatSdk.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */; };
+		322A00049C2FC71AD22F25E1 /* MessagesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F820AEACBF2AB583B73D583F /* MessagesObservable.swift */; };
 		3B6D0B8DF56C3C234BB333F7 /* ChatSdk.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		674DB9AB8BB94548B4659911 /* YaloChatDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */; };
+		68B260F91753D81C4891F80D /* MessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF775B29AF50036FBF2DD96 /* MessageList.swift */; };
 		6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C966BE803A724D942922CAA /* YaloChat.swift */; };
+		839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D563B68F202040D37D6212 /* MessageItem.swift */; };
 		E65E5168702C7E1DFC950C7C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6524E179EB88397E204954 /* ContentView.swift */; };
 		E87B26E53C6C69473298A5A5 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE541740117006132C1A380 /* Credentials.swift */; };
+		EFC453D69C9FCE945A1CE6B7 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FDB5E608E371946FE0DFC6 /* ChatView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -30,13 +35,18 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		05D563B68F202040D37D6212 /* MessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageItem.swift; sourceTree = "<group>"; };
+		23407D6589CAA8A5F7913634 /* ChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInput.swift; sourceTree = "<group>"; };
 		34E80F747F4EC2822662317B /* YaloChatDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = YaloChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		43FDB5E608E371946FE0DFC6 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ChatSdk.xcframework; path = "../android-sdk/sdk/build/XCFrameworks/release/ChatSdk.xcframework"; sourceTree = "<group>"; };
 		6C966BE803A724D942922CAA /* YaloChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChat.swift; sourceTree = "<group>"; };
 		83913A0C24BC4B8FD220EB07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChatDemoApp.swift; sourceTree = "<group>"; };
 		BA6524E179EB88397E204954 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		CDF775B29AF50036FBF2DD96 /* MessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageList.swift; sourceTree = "<group>"; };
 		EAE541740117006132C1A380 /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
+		F820AEACBF2AB583B73D583F /* MessagesObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesObservable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,9 +89,14 @@
 		EFF4F2C90E18DCE164B40765 /* YaloChatDemo */ = {
 			isa = PBXGroup;
 			children = (
+				23407D6589CAA8A5F7913634 /* ChatInput.swift */,
+				43FDB5E608E371946FE0DFC6 /* ChatView.swift */,
 				BA6524E179EB88397E204954 /* ContentView.swift */,
 				EAE541740117006132C1A380 /* Credentials.swift */,
 				83913A0C24BC4B8FD220EB07 /* Info.plist */,
+				05D563B68F202040D37D6212 /* MessageItem.swift */,
+				CDF775B29AF50036FBF2DD96 /* MessageList.swift */,
+				F820AEACBF2AB583B73D583F /* MessagesObservable.swift */,
 				6C966BE803A724D942922CAA /* YaloChat.swift */,
 				A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */,
 			);
@@ -149,8 +164,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F144E784B4B0E906FE68740 /* ChatInput.swift in Sources */,
+				EFC453D69C9FCE945A1CE6B7 /* ChatView.swift in Sources */,
 				E65E5168702C7E1DFC950C7C /* ContentView.swift in Sources */,
 				E87B26E53C6C69473298A5A5 /* Credentials.swift in Sources */,
+				839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */,
+				68B260F91753D81C4891F80D /* MessageList.swift in Sources */,
+				322A00049C2FC71AD22F25E1 /* MessagesObservable.swift in Sources */,
 				6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */,
 				674DB9AB8BB94548B4659911 /* YaloChatDemoApp.swift in Sources */,
 			);

--- a/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
+++ b/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
@@ -34,8 +34,32 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		AA11BB22CC33DD44EE55FF66 /* Bootstrap Credentials */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/YaloChatDemo/Credentials.swift.example",
+			);
+			name = "Bootstrap Credentials";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/YaloChatDemo/Credentials.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "[ -f \"${SRCROOT}/YaloChatDemo/Credentials.swift\" ] || cp \"${SRCROOT}/YaloChatDemo/Credentials.swift.example\" \"${SRCROOT}/YaloChatDemo/Credentials.swift\"\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXFileReference section */
 		05D563B68F202040D37D6212 /* MessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageItem.swift; sourceTree = "<group>"; };
+		BB22CC33DD44EE55FF66AA11 /* Credentials.swift.example */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Credentials.swift.example"; sourceTree = "<group>"; };
 		23407D6589CAA8A5F7913634 /* ChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInput.swift; sourceTree = "<group>"; };
 		34E80F747F4EC2822662317B /* YaloChatDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = YaloChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		43FDB5E608E371946FE0DFC6 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
@@ -93,6 +117,7 @@
 				43FDB5E608E371946FE0DFC6 /* ChatView.swift */,
 				BA6524E179EB88397E204954 /* ContentView.swift */,
 				EAE541740117006132C1A380 /* Credentials.swift */,
+				BB22CC33DD44EE55FF66AA11 /* Credentials.swift.example */,
 				83913A0C24BC4B8FD220EB07 /* Info.plist */,
 				05D563B68F202040D37D6212 /* MessageItem.swift */,
 				CDF775B29AF50036FBF2DD96 /* MessageList.swift */,
@@ -110,6 +135,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F93A0F24576A972127FF74D9 /* Build configuration list for PBXNativeTarget "YaloChatDemo" */;
 			buildPhases = (
+				AA11BB22CC33DD44EE55FF66 /* Bootstrap Credentials */,
 				99083C9C646CE6D473F49E2E /* Sources */,
 				F01839D22CEC480BB22E7A08 /* Frameworks */,
 				065FDEBDB472A792738FDE77 /* Embed Frameworks */,

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -1,0 +1,36 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+
+// Mirrors Flutter ChatInput (text-only, M3 scope — no attachment or mic button).
+// Send button is disabled while the text field is blank or whitespace-only.
+struct ChatInput: View {
+
+    @ObservedObject var observable: MessagesObservable
+
+    private var isBlank: Bool {
+        observable.userMessage.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            TextField("Type a message…", text: $observable.userMessage)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color(.systemGray6))
+                .cornerRadius(25)
+                .onSubmit { observable.sendMessage() }
+
+            Button(action: observable.sendMessage) {
+                Image(systemName: "paperplane.fill")
+                    .foregroundColor(.white)
+                    .padding(10)
+                    .background(isBlank ? Color.gray : Color.accentColor)
+                    .clipShape(Circle())
+            }
+            .disabled(isBlank)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}

--- a/ios-sdk/YaloChatDemo/ChatView.swift
+++ b/ios-sdk/YaloChatDemo/ChatView.swift
@@ -1,0 +1,26 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+import ChatSdk
+
+// Root chat screen. Mirrors Flutter's Chat widget: NavigationView (ChatAppBar) +
+// MessageList + ChatInput stacked vertically.
+struct ChatView: View {
+
+    @StateObject private var observable = MessagesObservable()
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                MessageList(observable: observable)
+                Divider()
+                ChatInput(observable: observable)
+            }
+            .navigationTitle(YaloChatSdk.shared.config?.channelName ?? "Chat")
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .navigationViewStyle(.stack)
+        .onAppear { observable.onAppear() }
+        .onDisappear { observable.onDisappear() }
+    }
+}

--- a/ios-sdk/YaloChatDemo/ContentView.swift
+++ b/ios-sdk/YaloChatDemo/ContentView.swift
@@ -2,31 +2,11 @@
 
 import SwiftUI
 
-// Placeholder chat view — replaced in iOS M5 (Core SwiftUI UI Layer).
-// M1 goal: confirm the XCFramework imports and that YaloChat.initialize() wires
-// the Darwin HTTP engine + NativeSqliteDriver without crashing.
-// Polling starts in M5 when the ViewModel calls MessageSyncService.start(scope:).
+// Entry point for the demo app UI. Presents ChatView (iOS M3).
 struct ContentView: View {
 
     var body: some View {
-        NavigationView {
-            VStack(spacing: 24) {
-                Image(systemName: "message.fill")
-                    .font(.system(size: 64))
-                    .foregroundColor(.accentColor)
-
-                Text("Yalo Chat")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-
-                Text("SDK connected.\nChat UI coming in M5.")
-                    .font(.body)
-                    .foregroundColor(.secondary)
-                    .multilineTextAlignment(.center)
-            }
-            .padding()
-            .navigationTitle("Yalo Chat Demo")
-        }
+        ChatView()
     }
 }
 

--- a/ios-sdk/YaloChatDemo/ContentView.swift
+++ b/ios-sdk/YaloChatDemo/ContentView.swift
@@ -2,7 +2,6 @@
 
 import SwiftUI
 
-// Entry point for the demo app UI. Presents ChatView (iOS M3).
 struct ContentView: View {
 
     var body: some View {

--- a/ios-sdk/YaloChatDemo/Credentials.swift
+++ b/ios-sdk/YaloChatDemo/Credentials.swift
@@ -1,9 +1,0 @@
-// Copyright (c) Yalochat, Inc. All rights reserved.
-
-// Demo app credentials — fill in real values before running.
-// Mirrors android-sdk/local.properties: never commit real credentials to source control.
-enum Credentials {
-    static let channelName = "REPLACE_WITH_CHANNEL_NAME"
-    static let channelId = "REPLACE_WITH_CHANNEL_ID"
-    static let organizationId = "REPLACE_WITH_ORGANIZATION_ID"
-}

--- a/ios-sdk/YaloChatDemo/Credentials.swift.example
+++ b/ios-sdk/YaloChatDemo/Credentials.swift.example
@@ -1,0 +1,12 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+// Demo app credentials template.
+// Copy this file to Credentials.swift and fill in real values before running.
+// Credentials.swift is gitignored so real values can never be committed accidentally.
+import ChatSdk
+enum Credentials {
+    static let channelName = "REPLACE_WITH_CHANNEL_NAME"
+    static let channelId = "REPLACE_WITH_CHANNEL_ID"
+    static let organizationId = "REPLACE_WITH_ORGANIZATION_ID"
+    static let environment: YaloChatEnvironment = .production
+}

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -1,0 +1,50 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+import ChatSdk
+
+// Mirrors Flutter Message → UserMessage / AssistantMessage routing.
+// Role dispatch: user = right-aligned bubble, agent = left-aligned bubble.
+// Type dispatch: text renders content; all other types show a graceful fallback
+// (improvement over Flutter's UnimplementedError — see M3 scope decision).
+struct MessageItem: View {
+
+    let message: ChatMessage
+
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 0) {
+            if message.role == .user {
+                Spacer(minLength: 48)
+                bubble
+            } else {
+                bubble
+                Spacer(minLength: 48)
+            }
+        }
+    }
+
+    private var bubble: some View {
+        bubbleContent
+            .padding(12)
+            .background(bubbleColor)
+            .cornerRadius(16)
+            .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: message.role == .user ? .trailing : .leading)
+    }
+
+    @ViewBuilder
+    private var bubbleContent: some View {
+        if message.type is MessageTypeText {
+            Text(message.content)
+                .foregroundColor(message.role == .user ? .white : .primary)
+        } else {
+            Text("Unsupported message type")
+                .font(.caption)
+                .italic()
+                .foregroundColor(message.role == .user ? .white.opacity(0.8) : .secondary)
+        }
+    }
+
+    private var bubbleColor: Color {
+        message.role == .user ? .accentColor : Color(.systemGray5)
+    }
+}

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -11,9 +11,11 @@ struct MessageItem: View {
 
     let message: ChatMessage
 
+    private var isUser: Bool { message.role === MessageRole.user }
+
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            if message.role == .user {
+            if isUser {
                 Spacer(minLength: 48)
                 bubble
             } else {
@@ -28,23 +30,23 @@ struct MessageItem: View {
             .padding(12)
             .background(bubbleColor)
             .cornerRadius(16)
-            .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: message.role == .user ? .trailing : .leading)
+            .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: isUser ? .trailing : .leading)
     }
 
     @ViewBuilder
     private var bubbleContent: some View {
-        if message.type is MessageTypeText {
+        if message.type is MessageType.Text {
             Text(message.content)
-                .foregroundColor(message.role == .user ? .white : .primary)
+                .foregroundColor(isUser ? .white : .primary)
         } else {
             Text("Unsupported message type")
                 .font(.caption)
                 .italic()
-                .foregroundColor(message.role == .user ? .white.opacity(0.8) : .secondary)
+                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
         }
     }
 
     private var bubbleColor: Color {
-        message.role == .user ? .accentColor : Color(.systemGray5)
+        isUser ? .accentColor : Color(.systemGray5)
     }
 }

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -3,10 +3,6 @@
 import SwiftUI
 import ChatSdk
 
-// Mirrors Flutter Message → UserMessage / AssistantMessage routing.
-// Role dispatch: user = right-aligned bubble, agent = left-aligned bubble.
-// Type dispatch: text renders content; all other types show a graceful fallback
-// (improvement over Flutter's UnimplementedError — see M3 scope decision).
 struct MessageItem: View {
 
     let message: ChatMessage
@@ -30,7 +26,6 @@ struct MessageItem: View {
             .padding(12)
             .background(bubbleColor)
             .cornerRadius(16)
-            .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: isUser ? .trailing : .leading)
     }
 
     @ViewBuilder

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -3,9 +3,6 @@
 import SwiftUI
 import ChatSdk
 
-// Mirrors Flutter MessageList (ListView reverse:true).
-// Messages are sorted ascending by MessagesObservable so the newest appears at the bottom.
-// ScrollViewReader auto-scrolls to the last item when the count changes.
 struct MessageList: View {
 
     @ObservedObject var observable: MessagesObservable
@@ -24,26 +21,21 @@ struct MessageList: View {
                                 .padding(.top, 32)
                         }
                     } else {
-                        ForEach(observable.messages, id: \.timestamp) { message in
+                        ForEach(Array(observable.messages.enumerated()), id: \.offset) { _, message in
                             MessageItem(message: message)
-                                .id(message.timestamp)
                         }
+                        // Invisible anchor used for scroll-to-bottom
+                        Color.clear.frame(height: 0).id("bottom")
                     }
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
             }
             .onChange(of: observable.messages.count) { _ in
-                if let last = observable.messages.last {
-                    withAnimation {
-                        proxy.scrollTo(last.timestamp, anchor: .bottom)
-                    }
-                }
+                withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
             }
             .onAppear {
-                if let last = observable.messages.last {
-                    proxy.scrollTo(last.timestamp, anchor: .bottom)
-                }
+                proxy.scrollTo("bottom", anchor: .bottom)
             }
         }
     }

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -24,9 +24,9 @@ struct MessageList: View {
                         ForEach(Array(observable.messages.enumerated()), id: \.offset) { _, message in
                             MessageItem(message: message)
                         }
-                        // Invisible anchor used for scroll-to-bottom
-                        Color.clear.frame(height: 0).id("bottom")
                     }
+                    // Anchor always present so scrollTo("bottom") never targets a missing id.
+                    Color.clear.frame(height: 0).id("bottom")
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -1,0 +1,50 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+import ChatSdk
+
+// Mirrors Flutter MessageList (ListView reverse:true).
+// Messages are sorted ascending by MessagesObservable so the newest appears at the bottom.
+// ScrollViewReader auto-scrolls to the last item when the count changes.
+struct MessageList: View {
+
+    @ObservedObject var observable: MessagesObservable
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: 8) {
+                    if observable.messages.isEmpty {
+                        if observable.isLoading {
+                            ProgressView()
+                                .padding(.top, 32)
+                        } else {
+                            Text("No messages yet")
+                                .foregroundColor(.secondary)
+                                .padding(.top, 32)
+                        }
+                    } else {
+                        ForEach(observable.messages, id: \.timestamp) { message in
+                            MessageItem(message: message)
+                                .id(message.timestamp)
+                        }
+                    }
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+            .onChange(of: observable.messages.count) { _ in
+                if let last = observable.messages.last {
+                    withAnimation {
+                        proxy.scrollTo(last.timestamp, anchor: .bottom)
+                    }
+                }
+            }
+            .onAppear {
+                if let last = observable.messages.last {
+                    proxy.scrollTo(last.timestamp, anchor: .bottom)
+                }
+            }
+        }
+    }
+}

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -1,0 +1,46 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import Foundation
+import ChatSdk
+
+// Mirrors Flutter MessagesBloc: wraps MessagesController and exposes @Published
+// properties for SwiftUI. Initialization sequence follows Flutter's dependency
+// injection order: SubscribeToMessages → LoadMessages.
+class MessagesObservable: ObservableObject {
+
+    @Published var messages: [ChatMessage] = []
+    @Published var userMessage: String = ""
+    @Published var isLoading: Bool = false
+
+    private var controller: MessagesController? {
+        YaloChatSdk.shared.messagesController
+    }
+
+    // Called from ChatView.onAppear — mirrors Flutter bloc initialization.
+    func onAppear() {
+        isLoading = true
+        // Start sync + observe local DB (mirrors ChatSubscribeToMessages).
+        controller?.start { [weak self] messages in
+            DispatchQueue.main.async {
+                self?.messages = messages.sorted { $0.timestamp < $1.timestamp }
+                self?.isLoading = false
+            }
+        }
+        // One-shot local DB read (mirrors ChatLoadMessages).
+        controller?.loadMessages()
+    }
+
+    // Called from ChatView.onDisappear — stops polling to avoid background work.
+    func onDisappear() {
+        controller?.stop()
+        isLoading = false
+    }
+
+    // Mirrors Flutter ChatSendTextMessage: validates, clears input, sends optimistically.
+    func sendMessage() {
+        let text = userMessage.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        userMessage = ""
+        controller?.sendTextMessage(text: text)
+    }
+}

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -25,10 +25,12 @@ class MessagesObservable: ObservableObject {
         controller?.start { [weak self] messages in
             DispatchQueue.main.async {
                 let sorted = messages.sorted { $0.timestamp < $1.timestamp }
+                #if DEBUG
                 Self.log.debug("messages update: \(sorted.count) total")
                 for msg in sorted {
-                    Self.log.debug("  [\(String(describing: msg.role))] [\(String(describing: msg.type))] id=\(msg.id?.int64Value ?? -1) ts=\(msg.timestamp) content=\(msg.content.prefix(60))")
+                    Self.log.debug("  [\(String(describing: msg.role))] [\(String(describing: msg.type))] id=\(msg.id?.int64Value ?? -1) ts=\(msg.timestamp)")
                 }
+                #endif
                 self?.messages = sorted
                 self?.isLoading = false
             }

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import ChatSdk
+import os
 
 // Mirrors Flutter MessagesBloc: wraps MessagesController and exposes @Published
 // properties for SwiftUI. Initialization sequence follows Flutter's dependency
@@ -12,35 +13,41 @@ class MessagesObservable: ObservableObject {
     @Published var userMessage: String = ""
     @Published var isLoading: Bool = false
 
+    private static let log = Logger(subsystem: "com.yalo.chat.demo", category: "MessagesObservable")
+
     private var controller: MessagesController? {
         YaloChatSdk.shared.messagesController
     }
 
-    // Called from ChatView.onAppear — mirrors Flutter bloc initialization.
     func onAppear() {
         isLoading = true
-        // Start sync + observe local DB (mirrors ChatSubscribeToMessages).
+        Self.log.debug("onAppear — starting controller")
         controller?.start { [weak self] messages in
             DispatchQueue.main.async {
-                self?.messages = messages.sorted { $0.timestamp < $1.timestamp }
+                let sorted = messages.sorted { $0.timestamp < $1.timestamp }
+                Self.log.debug("messages update: \(sorted.count) total")
+                for msg in sorted {
+                    Self.log.debug("  [\(String(describing: msg.role))] [\(String(describing: msg.type))] id=\(msg.id?.int64Value ?? -1) ts=\(msg.timestamp) content=\(msg.content.prefix(60))")
+                }
+                self?.messages = sorted
                 self?.isLoading = false
             }
         }
-        // One-shot local DB read (mirrors ChatLoadMessages).
         controller?.loadMessages()
     }
 
-    // Called from ChatView.onDisappear — stops polling to avoid background work.
     func onDisappear() {
+        Self.log.debug("onDisappear — stopping controller")
         controller?.stop()
         isLoading = false
     }
 
-    // Mirrors Flutter ChatSendTextMessage: validates, clears input, sends optimistically.
     func sendMessage() {
         let text = userMessage.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
+        Self.log.debug("sendMessage: \(text.prefix(60))")
         userMessage = ""
         controller?.sendTextMessage(text: text)
     }
 }
+

--- a/ios-sdk/YaloChatDemo/YaloChatDemoApp.swift
+++ b/ios-sdk/YaloChatDemo/YaloChatDemoApp.swift
@@ -11,7 +11,7 @@ struct YaloChatDemoApp: App {
             channelName: Credentials.channelName,
             channelId: Credentials.channelId,
             organizationId: Credentials.organizationId,
-            environment: .staging
+            environment: Credentials.environment
         )
     }
 


### PR DESCRIPTION
## Summary

### KMP — Kotlin layer

- **\`MessagesController\`** (new, \`commonMain\`): iOS counterpart to Android's \`MessagesViewModel\`. Owns the coroutine scope, \`MessageSyncService\` lifecycle, and optimistic send logic. Callback API avoids Swift callers needing to collect a KMP \`Flow\`. Mirrors Flutter \`MessagesBloc\`. Moved to \`commonMain\` (no iOS-specific imports) so it can be unit-tested on the JVM without an iOS simulator.
- **\`YaloChatSdk\` (iosMain)**: wires \`MessagesController\` into \`initialize()\` / \`stop()\`; removes redundant double-stop of \`_syncService\`.
- **\`PlatformFiles\` (iosMain)**: fully implemented using \`NSFileManager\`/\`NSData\` (was throwing \`NotImplementedError\`, crashing the polling coroutine when any media message arrived).
- **\`YaloFetchMessagesResponse\`**: defensive string defaults (\`text = ""\`, \`mediaUrl = ""\`) prevent \`MissingFieldException\` from killing the entire poll-batch deserialization.
- **\`YaloMessageRepositoryRemote\`**: per-message try-catch so one malformed message skips silently; \`CancellationException\` is re-thrown so coroutine cancellation is never swallowed.
- **Android demo — \`build.gradle.kts\` / \`MainActivity\`**: \`YALO_ENVIRONMENT\` read from \`local.properties\` with defensive \`runCatching + getOrDefault(PRODUCTION)\` so the demo app is no longer hardcoded to \`.staging\` and won't crash on a bad value.

### Swift — UI layer

- **\`MessagesObservable\`**: \`ObservableObject\` wrapping \`MessagesController\`; \`os.Logger\` debug logging gated behind \`#if DEBUG\`, message content excluded from log lines.
- **\`ChatView\` / \`MessageList\` / \`MessageItem\` / \`ChatInput\`**: full SwiftUI chat screen. Text renders inline; all other message types show "Unsupported message type" fallback (mirrors Flutter). Duplicate-ID fix (\`id: \.offset\` + \`"bottom"\` scroll anchor always present outside the empty/non-empty conditional).
- **\`ContentView\`**: replaced M1 placeholder with \`ChatView()\`.
- **\`Credentials.swift.example\`**: tracked template with all 4 fields. Xcode "Bootstrap Credentials" pre-build phase auto-copies it to \`Credentials.swift\` on first build. \`Credentials.swift\` is gitignored so real values can never be committed accidentally.

### Android — UI layer

- **\`MessageList\`**: added \`rememberLazyListState\` + \`LaunchedEffect(sorted.size)\` that calls \`animateScrollToItem(0)\` whenever the message count changes, keeping the view pinned to the latest message. With \`reverseLayout = true\`, item 0 is the newest message at the visual bottom.

### Tests

- **\`MessagesControllerTest\`** (11 cases, \`commonTest\`): start/stop lifecycle, idempotent start, \`loadMessages\` before/after start and on repo error, \`sendTextMessage\` blank guard, before-start no-op, optimistic insert with correct role/status, remote-error → \`ERROR\` status update, consecutive IDs are unique.

### Housekeeping

- \`.gitignore\`: ignore Xcode \`xcuserdata/\` directories (same rationale as \`.idea/\` / \`.vscode/\`).

## Test plan

- [ ] \`./gradlew :sdk:testDebugUnitTest\` — all tests green including new \`MessagesControllerTest\`
- [ ] \`./gradlew :sdk:assembleChatSdkXCFramework\` — XCFramework builds clean
- [ ] Open \`ios-sdk/\` in Xcode, build & run on iOS 15+ simulator — \`Credentials.swift\` is auto-created by pre-build script on first build
- [ ] Fill \`Credentials.swift\` with staging/production values
- [ ] Messages load from local DB on appear; sync starts; agent messages appear in list
- [ ] Sending a text message shows an optimistic right-aligned bubble immediately
- [ ] Non-text messages show "Unsupported message type" in grey italic
- [ ] Navigating away stops sync (no background polling after screen disappear)
- [ ] Fresh clone builds without manually creating \`Credentials.swift\`
- [ ] Android: new incoming messages auto-scroll the list to the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)