### PR TITLE
feat(ios-sdk): Image picker + Audio recording/playback — M4 & M5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,6 @@ flutter-sdk/pubspec.lock
 ios-sdk/YaloChatDemo/Credentials.swift
 
 # Xcode user-specific data (workspace state, breakpoints, derived data)
-*.xcworkspace/xcuserdata/
-*.xcodeproj/xcuserdata/
-*.xcodeproj/project.xcworkspace/xcuserdata/
+**/*.xcworkspace/xcuserdata/
+**/*.xcodeproj/xcuserdata/
+**/*.xcodeproj/project.xcworkspace/xcuserdata/

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -15,7 +15,6 @@ import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.repository.ChatMessageRepository
 import com.yalo.chat.sdk.domain.repository.YaloMessageRepository
-import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -42,12 +41,15 @@ internal class MessagesViewModel(
     // Keeps the active events job so SubscribeToEvents is idempotent.
     private var eventsJob: Job? = null
 
-    // Incrementing counter seeded from current epoch-ms so optimistic temp IDs:
-    //  1. Never collide across sessions (different session → different starting time)
-    //  2. Sort at the bottom in ORDER BY id ASC (most recent, correct chat position)
-    // Server message IDs are also epoch-ms based, so optimistic and server messages
-    // interleave correctly by send time.
-    private val tempIdSeq = AtomicLong(System.currentTimeMillis())
+    // Refreshed against the wall clock on every send so user-message tempIds always sort
+    // AFTER agent messages whose ids were bumped to receiptFloor by ensureReceiptOrder.
+    private var tempIdSeq: Long = 0L
+
+    private fun nextTempId(): Long {
+        val now = System.currentTimeMillis()
+        if (now > tempIdSeq) tempIdSeq = now
+        return tempIdSeq++
+    }
 
     fun handleEvent(event: MessagesEvent) {
         when (event) {
@@ -225,7 +227,7 @@ internal class MessagesViewModel(
     private fun sendTextMessage(text: String) {
         if (text.isBlank()) return
         viewModelScope.launch {
-            val tempId = tempIdSeq.getAndIncrement()
+            val tempId = nextTempId()
             val optimistic = ChatMessage(
                 id = tempId,
                 role = MessageRole.USER,
@@ -253,7 +255,7 @@ internal class MessagesViewModel(
     private fun sendVoiceMessage(audioData: AudioData) {
         if (audioData.fileName.isEmpty()) return
         viewModelScope.launch {
-            val tempId = tempIdSeq.getAndIncrement()
+            val tempId = nextTempId()
             val message = ChatMessage(
                 id = tempId,
                 role = MessageRole.USER,
@@ -280,7 +282,7 @@ internal class MessagesViewModel(
     private fun sendImageMessage(imageData: ImageData) {
         if (imageData.path == null) return
         viewModelScope.launch {
-            val tempId = tempIdSeq.getAndIncrement()
+            val tempId = nextTempId()
             val message = ChatMessage(
                 id = tempId,
                 role = MessageRole.USER,

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -769,17 +769,17 @@ class YaloMessageRepositoryRemoteTest {
     // ── ensureReceiptOrder ────────────────────────────────────────────────────────
 
     @Test
-    fun `ensureReceiptOrder does not rewrite message IDs on first poll`() = runTest {
-        // On the very first poll pollHighWater is 0, so historical IDs must be preserved.
-        // The message date is 2024-01-01T12:00:00Z → stableId ~1_704_110_400_000.
-        // Without the fix the ID would be bumped to current time (~1_700_000_000_000+).
+    fun `ensureReceiptOrder clamps message IDs to receipt time on first poll`() = runTest {
+        // IDs are always clamped to receipt time so bot responses never sort before the
+        // user's message (which uses a client-clock tempId at millisecond precision).
+        // The message date is 2024-01-01T12:00:00Z → raw stableId ~1_704_110_400_000,
+        // but receipt time in 2026 is ~1_745_000_000_000 → id must be clamped up.
         val repo = buildRepo(listOf(textMessageJson("id-first", "Hello")))
         val batch = repo.pollIncomingMessages().first()
         assertEquals(1, batch.size)
         val id = batch.first().id!!
-        // stableId for 2024-01-01 is ~1_704_110_400_000; current time is well above 1_750_000_000_000.
-        assertTrue(id < 1_750_000_000_000L,
-            "ID $id was bumped to current time on first poll — historical IDs should be preserved")
+        assertTrue(id >= 1_740_000_000_000L,
+            "ID $id was not clamped to receipt time — all polled IDs must be >= receipt timestamp")
     }
 
     @Test

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -772,14 +772,14 @@ class YaloMessageRepositoryRemoteTest {
     fun `ensureReceiptOrder clamps message IDs to receipt time on first poll`() = runTest {
         // IDs are always clamped to receipt time so bot responses never sort before the
         // user's message (which uses a client-clock tempId at millisecond precision).
-        // The message date is 2024-01-01T12:00:00Z → raw stableId ~1_704_110_400_000,
-        // but receipt time in 2026 is ~1_745_000_000_000 → id must be clamped up.
+        // Capture wall-clock time before the poll; the assigned id must be >= that value.
+        val before = System.currentTimeMillis()
         val repo = buildRepo(listOf(textMessageJson("id-first", "Hello")))
         val batch = repo.pollIncomingMessages().first()
         assertEquals(1, batch.size)
         val id = batch.first().id!!
-        assertTrue(id >= 1_740_000_000_000L,
-            "ID $id was not clamped to receipt time — all polled IDs must be >= receipt timestamp")
+        assertTrue(id >= before,
+            "ID $id was not clamped to receipt time — must be >= wall-clock $before")
     }
 
     @Test

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
@@ -80,4 +80,56 @@ class MessagesController internal constructor(
             }
         }
     }
+
+    fun sendImageMessage(fileName: String, mimeType: String) {
+        if (fileName.isEmpty()) return
+        val s = scope ?: return
+        val tempId = tempIdSeq++
+        val message = ChatMessage(
+            id = tempId,
+            role = MessageRole.USER,
+            type = MessageType.Image,
+            status = MessageStatus.SENT,
+            fileName = fileName,
+            mediaType = mimeType,
+            timestamp = Clock.System.now().toEpochMilliseconds(),
+        )
+        s.launch {
+            when (localRepo.insertMessage(message)) {
+                is Result.Ok -> s.launch {
+                    if (yaloRepo.sendMessage(message) is Result.Error) {
+                        localRepo.updateMessage(message.copy(status = MessageStatus.ERROR))
+                    }
+                }
+                is Result.Error -> Unit
+            }
+        }
+    }
+
+    fun sendVoiceMessage(fileName: String, amplitudes: List<Double>, durationMs: Long) {
+        if (fileName.isEmpty()) return
+        val s = scope ?: return
+        val tempId = tempIdSeq++
+        val message = ChatMessage(
+            id = tempId,
+            role = MessageRole.USER,
+            type = MessageType.Voice,
+            status = MessageStatus.SENT,
+            fileName = fileName,
+            amplitudes = amplitudes,
+            duration = durationMs,
+            mediaType = "audio/mp4",
+            timestamp = Clock.System.now().toEpochMilliseconds(),
+        )
+        s.launch {
+            when (localRepo.insertMessage(message)) {
+                is Result.Ok -> s.launch {
+                    if (yaloRepo.sendMessage(message) is Result.Error) {
+                        localRepo.updateMessage(message.copy(status = MessageStatus.ERROR))
+                    }
+                }
+                is Result.Error -> Unit
+            }
+        }
+    }
 }

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
@@ -91,7 +91,7 @@ class MessagesController internal constructor(
             type = MessageType.Image,
             status = MessageStatus.SENT,
             fileName = fileName,
-            mediaType = mimeType,
+            mediaType = mimeType.ifBlank { "image/jpeg" },
             timestamp = Clock.System.now().toEpochMilliseconds(),
         )
         s.launch {

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/MessagesController.kt
@@ -29,7 +29,15 @@ class MessagesController internal constructor(
 ) {
     private var scope: CoroutineScope? = null
     // Counter is only ever read/written from the main thread (same dispatcher as the scope).
-    private var tempIdSeq: Long = Clock.System.now().toEpochMilliseconds()
+    // Refreshed against the wall clock on every send so user-message tempIds always sort
+    // AFTER agent messages whose ids were bumped to receiptFloor by ensureReceiptOrder.
+    private var tempIdSeq: Long = 0L
+
+    private fun nextTempId(): Long {
+        val now = Clock.System.now().toEpochMilliseconds()
+        if (now > tempIdSeq) tempIdSeq = now
+        return tempIdSeq++
+    }
 
     fun start(onMessagesUpdate: (List<ChatMessage>) -> Unit) {
         if (scope != null) return
@@ -60,7 +68,7 @@ class MessagesController internal constructor(
     fun sendTextMessage(text: String) {
         if (text.isBlank()) return
         val s = scope ?: return
-        val tempId = tempIdSeq++
+        val tempId = nextTempId()
         val optimistic = ChatMessage(
             id = tempId,
             role = MessageRole.USER,
@@ -84,7 +92,7 @@ class MessagesController internal constructor(
     fun sendImageMessage(fileName: String, mimeType: String) {
         if (fileName.isEmpty()) return
         val s = scope ?: return
-        val tempId = tempIdSeq++
+        val tempId = nextTempId()
         val message = ChatMessage(
             id = tempId,
             role = MessageRole.USER,
@@ -109,7 +117,7 @@ class MessagesController internal constructor(
     fun sendVoiceMessage(fileName: String, amplitudes: List<Double>, durationMs: Long) {
         if (fileName.isEmpty()) return
         val s = scope ?: return
-        val tempId = tempIdSeq++
+        val tempId = nextTempId()
         val message = ChatMessage(
             id = tempId,
             role = MessageRole.USER,

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/MessageSyncService.kt
@@ -31,9 +31,16 @@ internal class MessageSyncService(
     private var job: Job? = null
 
     // Start polling. Idempotent — calling while already active is a no-op.
+    // Before the first poll, pre-warms the remote repo's dedup cache with the wiIds of
+    // messages already in the local DB, so media files from previous sessions are never
+    // re-downloaded on cold restart (which would block text responses for minutes).
     fun start(scope: CoroutineScope) {
         if (job?.isActive == true) return
         job = scope.launch {
+            val existing = localRepo.getMessages(cursor = null, limit = 500)
+            if (existing is Result.Ok) {
+                yaloRepo.warmDedupCache(existing.result.mapNotNull { it.wiId })
+            }
             yaloRepo.pollIncomingMessages().collect { batch ->
                 // Insert the whole poll batch in one SQLDelight transaction.
                 // Polling continues on the next cycle regardless of insert outcome.

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -269,10 +269,10 @@ internal fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, deb
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
         }
-        // Prevent media downloads from blocking the polling loop indefinitely.
-        // 30s covers slow CDN responses; API calls (auth, send, fetch) are much faster.
+        // Global timeouts: 60s request covers CDN downloads and large image uploads on slow
+        // networks; 10s connect and 30s socket provide safety nets for all request types.
         install(HttpTimeout) {
-            requestTimeoutMillis = 30_000
+            requestTimeoutMillis = 60_000
             connectTimeoutMillis = 10_000
             socketTimeoutMillis = 30_000
         }

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloChatApiService.kt
@@ -10,6 +10,7 @@ import com.yalo.chat.sdk.data.remote.model.SdkMessageBody
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.forms.formData
 import io.ktor.client.request.forms.submitForm
@@ -267,6 +268,13 @@ internal fun buildHttpClient(engine: io.ktor.client.engine.HttpClientEngine, deb
     HttpClient(engine) {
         install(ContentNegotiation) {
             json(Json { ignoreUnknownKeys = true })
+        }
+        // Prevent media downloads from blocking the polling loop indefinitely.
+        // 30s covers slow CDN responses; API calls (auth, send, fetch) are much faster.
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30_000
+            connectTimeoutMillis = 10_000
+            socketTimeoutMillis = 30_000
         }
         if (debug) {
             install(io.ktor.client.plugins.logging.Logging) {

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -25,6 +25,7 @@ internal data class SdkMessageResponseDto(
     val textMessageRequest: SdkTextMessageResponseDto? = null,
     val imageMessageRequest: SdkImageMessageResponseDto? = null,
     val videoMessageRequest: SdkVideoMessageResponseDto? = null,
+    val voiceNoteMessageRequest: SdkVoiceNoteMessageResponseDto? = null,
     val productMessageRequest: SdkProductMessageResponseDto? = null,
     val buttonsMessageRequest: SdkButtonsMessageResponseDto? = null,
     val ctaMessageRequest: SdkCtaMessageResponseDto? = null,
@@ -98,6 +99,25 @@ internal data class SdkVideoMessageContentDto(
     val fileName: String = "",
     // Duration in seconds (proto double); stored as Long millis in ChatMessage.
     val duration: Double = 0.0,
+)
+
+// ── Voice ─────────────────────────────────────────────────────────────────────
+
+@Serializable
+internal data class SdkVoiceNoteMessageResponseDto(
+    val content: SdkVoiceMessageContentDto? = null,
+)
+
+@Serializable
+internal data class SdkVoiceMessageContentDto(
+    val mediaUrl: String = "",
+    val mediaType: String = "",
+    val role: String? = null,
+    val fileName: String = "",
+    // Duration in seconds (proto double); stored as Long millis in ChatMessage.
+    val duration: Double = 0.0,
+    val byteCount: Long = 0L,
+    val amplitudesPreview: List<Float> = emptyList(),
 )
 
 // ── Buttons ───────────────────────────────────────────────────────────────────

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -64,6 +64,13 @@ internal class YaloMessageRepositoryRemote(
     private val _events = MutableSharedFlow<ChatEvent>(extraBufferCapacity = Channel.UNLIMITED)
     override fun events(): Flow<ChatEvent> = _events.asSharedFlow()
 
+    // Pre-warms the in-memory dedup cache with message IDs that are already in the local DB,
+    // so the first poll after a cold restart does not re-download media for known messages.
+    // Called by MessageSyncService before starting the polling loop.
+    override fun warmDedupCache(wiIds: Collection<String>) {
+        wiIds.forEach { cache.set(it, true) }
+    }
+
     override suspend fun sendMessage(message: ChatMessage): Result<Unit> {
         val nowIso = Clock.System.now().toString()
 
@@ -158,7 +165,7 @@ internal class YaloMessageRepositoryRemote(
     // NOTE: `since` param is intentionally ignored — Flutter FIXME disables it too ("wait for backend fix").
     override suspend fun fetchMessages(since: Long): Result<List<ChatMessage>> =
         when (val result = apiService.fetchMessages()) {
-            is Result.Ok -> Result.Ok(result.result.mapNotNull { it.toChatMessage(deduplicate = false) })
+            is Result.Ok -> Result.Ok(result.result.mapIndexedNotNull { index, it -> it.toChatMessage(deduplicate = false, index = index) })
             is Result.Error -> Result.Error(result.error)
         }
 
@@ -166,24 +173,43 @@ internal class YaloMessageRepositoryRemote(
     // from one poll cycle. Empty batches are suppressed so downstream only sees real data.
     // Network errors are swallowed and the loop continues on the next tick, mirroring
     // flutter-sdk YaloMessageRepositoryRemote._startPolling().
+    //
+    // Two-phase processing per cycle:
+    //   Phase 1 — non-media messages (text, buttons, CTA, etc.) are translated instantly
+    //             and emitted immediately so the UI updates without waiting for downloads.
+    //   Phase 2 — media messages (image, video, voice) are translated one by one; each is
+    //             emitted as its CDN download completes.
     override fun pollIncomingMessages(): Flow<List<ChatMessage>> = flow {
         while (true) {
             when (val result = apiService.fetchMessages()) {
                 is Result.Ok -> {
                     val raw = result.result
-                    val batch = raw.mapNotNull { item ->
-                        try { item.toChatMessage(deduplicate = true) }
+
+                    // Phase 1: non-media messages — translate without IO and emit right away.
+                    val nonMediaBatch = raw.mapIndexedNotNull { index, item ->
+                        if (item.requiresMediaDownload()) return@mapIndexedNotNull null
+                        try { item.toChatMessage(deduplicate = true, index = index) }
                         catch (e: CancellationException) { throw e }
                         catch (e: Exception) { null }
                     }.let { ensureReceiptOrder(it) }
-                    // Mirror Flutter: TypingStop fires only when at least one NEW message
-                    // was successfully translated. toChatMessage(deduplicate=true) returns
-                    // null for already-cached items, so batch contains only new arrivals.
-                    // This prevents the indicator from dismissing on cached messages
-                    // (old raw.isNotEmpty() bug) AND on untranslatable unknown types.
-                    if (batch.isNotEmpty()) {
+
+                    if (nonMediaBatch.isNotEmpty()) {
                         _events.tryEmit(ChatEvent.TypingStop)
-                        emit(batch)
+                        emit(nonMediaBatch)
+                    }
+
+                    // Phase 2: media messages — download one by one and emit each when ready.
+                    raw.forEachIndexed { index, item ->
+                        if (!item.requiresMediaDownload()) return@forEachIndexed
+                        val msg = try { item.toChatMessage(deduplicate = true, index = index) }
+                        catch (e: CancellationException) { throw e }
+                        catch (e: Exception) { null }
+                        ?: return@forEachIndexed
+                        val ordered = ensureReceiptOrder(listOf(msg))
+                        if (ordered.isNotEmpty()) {
+                            _events.tryEmit(ChatEvent.TypingStop)
+                            emit(ordered)
+                        }
                     }
                 }
                 is Result.Error -> {
@@ -198,30 +224,23 @@ internal class YaloMessageRepositoryRemote(
     // Assigns stable local ids to a polled batch so that messages are ordered
     // consistently relative to user-sent messages and previous poll batches.
     //
-    // Problem: stableId is derived from the SERVER timestamp, but user-message
-    // tempIds are derived from the CLIENT clock. When the server takes a few
-    // seconds to generate a response its timestamp can exceed the client's clock
-    // at the moment the user sends the next message. The agent response then gets
-    // a stableId > that user message's tempId and sorts AFTER it in ORDER BY id ASC,
-    // producing wrong visual order ("hey" appears before the reply to "hello").
+    // Problem: stableId is derived from the SERVER timestamp (second precision), but
+    // user-message tempIds use the CLIENT clock in milliseconds. When the bot responds
+    // in the same second the user sent a message, the bot's stableId (second*1000+index)
+    // is less than the user's tempId (millisecond), so the bot response sorts before the
+    // user message in ORDER BY id ASC — visually wrong.
     //
-    // Fix: clamp each id to max(rawId, receiptFloor + batchIndex) where receiptFloor
-    // is the client clock at receipt time. This mirrors Flutter's prepend-to-front
-    // behaviour (newest message always at bottom) without changing the DB schema.
-    // fetchMessages() (startup cold load) is NOT affected — it bypasses this function.
-    //
-    // First-poll exception: when pollHighWater == 0 (no prior poll has completed)
-    // rawIds are used as-is. On the first poll there are no user-sent tempIds to
-    // collide with, so clamping is not necessary and preserving rawIds avoids
-    // artificially advancing pollHighWater before the second poll.
+    // Fix: clamp every polled message id to max(rawId, receiptFloor) where receiptFloor
+    // is the client clock at receipt time. Receipt always happens after the user sent the
+    // message, so clamped ids are always > the user's tempId. fetchMessages() (startup cold
+    // load) is NOT affected — it bypasses this function.
     private fun ensureReceiptOrder(messages: List<ChatMessage>): List<ChatMessage> {
         if (messages.isEmpty()) return messages
-        val highWaterEstablished = pollHighWater > 0L
         val receiptFloor = Clock.System.now().toEpochMilliseconds()
         var cursor = maxOf(receiptFloor, pollHighWater + 1)
         return messages.map { msg ->
             val rawId = msg.id ?: return@map msg
-            val id = if (!highWaterEstablished || rawId >= cursor) {
+            val id = if (rawId >= cursor) {
                 cursor = maxOf(cursor, rawId + 1)
                 rawId
             } else {
@@ -235,14 +254,14 @@ internal class YaloMessageRepositoryRemote(
     }
 
     // Translates a poll response item to a ChatMessage.
-    // Handles text and image payloads; skips unknown types silently.
-    // For image messages, downloads from CDN and saves to tempDir.
-    private suspend fun YaloFetchMessagesResponse.toChatMessage(deduplicate: Boolean): ChatMessage? {
+    // index is the position of this item in the server response array; used as the sub-second
+    // tiebreaker in stableId so messages with identical timestamps preserve server order.
+    private suspend fun YaloFetchMessagesResponse.toChatMessage(deduplicate: Boolean, index: Int = 0): ChatMessage? {
         if (deduplicate && cache.get(id) != null) return null
 
         val ts = parseIso8601(date)
-        val hashOffset = ((id.hashCode() % 1000) + 1000) % 1000
-        val stableId = if (ts != 0L) (ts / 1000L) * 1000L + hashOffset else hashOffset.toLong()
+        val indexOffset = index % 1000
+        val stableId = if (ts != 0L) (ts / 1000L) * 1000L + indexOffset else indexOffset.toLong()
 
         // Text message
         message.textMessageRequest?.content?.let { textContent ->
@@ -446,6 +465,14 @@ private const val TYPING_STATUS_TEXT = "Writing message..."
 // Proto3 JSON enum value name for horizontal orientation (carousel layout).
 // Any other value (including null/ORIENTATION_VERTICAL/unknown) maps to Product (list).
 private const val ORIENTATION_HORIZONTAL = "ORIENTATION_HORIZONTAL"
+
+// True for message types that require a CDN download before they can be translated.
+// Used by pollIncomingMessages() to separate the fast (text/buttons) path from the
+// slow (media download) path so non-media messages are emitted without delay.
+private fun YaloFetchMessagesResponse.requiresMediaDownload(): Boolean =
+    message.imageMessageRequest != null ||
+    message.videoMessageRequest != null ||
+    message.voiceNoteMessageRequest != null
 
 // ── ISO 8601 date parsing ─────────────────────────────────────────────────────
 private fun parseIso8601(date: String): Long =

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -174,7 +174,7 @@ internal class YaloMessageRepositoryRemote(
                     val batch = raw.mapNotNull { item ->
                         try { item.toChatMessage(deduplicate = true) }
                         catch (e: CancellationException) { throw e }
-                        catch (e: Exception) { println("[YaloChatSdk] skip message ${item.id}: $e"); null }
+                        catch (e: Exception) { null }
                     }.let { ensureReceiptOrder(it) }
                     // Mirror Flutter: TypingStop fires only when at least one NEW message
                     // was successfully translated. toChatMessage(deduplicate=true) returns

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemote.kt
@@ -328,6 +328,46 @@ internal class YaloMessageRepositoryRemote(
             }
         }
 
+        // Voice message — download from CDN and save locally.
+        // Mirrors the image/video download pattern; cache is set only after a successful download.
+        // amplitudesPreview (List<Float> from proto) is mapped to List<Double> for ChatMessage.
+        // duration arrives in seconds (proto double) → stored as millis in ChatMessage.
+        message.voiceNoteMessageRequest?.content?.let { voiceContent ->
+            return when (val downloadResult = apiService.downloadMedia(voiceContent.mediaUrl)) {
+                is Result.Error -> null // skip silently — will retry on next poll cycle
+                is Result.Ok -> {
+                    val bytes = downloadResult.result
+                    val mimeType = voiceContent.mediaType.takeIf { it.isNotEmpty() } ?: "audio/mp4"
+                    val ext = mimeType.substringAfter('/').substringBefore(';').trim().let {
+                        when {
+                            it.contains("mp4") -> "m4a"
+                            it.contains("mpeg") || it.contains("mp3") -> "mp3"
+                            else -> it
+                        }
+                    }
+                    val localPath = PlatformFiles.writeToDir(
+                        dirPath = tempDir,
+                        filename = "${Uuid.random()}.$ext",
+                        bytes = bytes,
+                    ) ?: return null
+                    if (deduplicate) cache.set(id, true)
+                    ChatMessage(
+                        id = stableId,
+                        wiId = id,
+                        role = MessageRole.fromString(voiceContent.role ?: "MESSAGE_ROLE_AGENT"),
+                        type = MessageType.Voice,
+                        status = MessageStatus.DELIVERED,
+                        fileName = localPath,
+                        amplitudes = voiceContent.amplitudesPreview.map { it.toDouble() },
+                        duration = (voiceContent.duration * 1000).toLong(),
+                        mediaType = mimeType,
+                        byteCount = bytes.size.toLong(),
+                        timestamp = ts,
+                    )
+                }
+            }
+        }
+
         // Buttons message — body text + a list of reply labels rendered as outlined buttons.
         // Tapping a button sends the label as a text message (same as quick reply chips).
         message.buttonsMessageRequest?.content?.let { buttonsContent ->

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/repository/YaloMessageRepository.kt
@@ -28,4 +28,10 @@ interface YaloMessageRepository {
     // TypingStart is emitted by sendMessage(); TypingStop is emitted when the poll receives
     // messages or encounters an error. FakeYaloMessageRepository returns emptyFlow().
     fun events(): Flow<ChatEvent> = emptyFlow()
+
+    // Pre-warm the in-memory dedup cache with message IDs already persisted in the local DB.
+    // Called by MessageSyncService on start() so the first poll after a cold restart does not
+    // re-download media for messages that were already processed in a previous session.
+    // Default is a no-op; overridden by YaloMessageRepositoryRemote.
+    fun warmDedupCache(wiIds: Collection<String>) {}
 }

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
@@ -213,4 +213,127 @@ class MessagesControllerTest {
         val ids = result.result.mapNotNull { it.id }
         assertEquals(2, ids.distinct().size)
     }
+
+    // ── sendImageMessage ──────────────────────────────────────────────────────
+
+    @Test
+    fun `sendImageMessage with empty fileName does not insert a message`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendImageMessage("", "image/jpeg")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendImageMessage before start is a no-op`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        controller(localRepo = localRepo).sendImageMessage("/tmp/photo.jpg", "image/jpeg")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendImageMessage inserts optimistic message with USER role and SENT status`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendImageMessage("/tmp/photo.jpg", "image/jpeg")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val message = result.result.single()
+        assertEquals(MessageRole.USER, message.role)
+        assertEquals(MessageStatus.SENT, message.status)
+        assertEquals(MessageType.Image, message.type)
+        assertEquals("/tmp/photo.jpg", message.fileName)
+        assertEquals("image/jpeg", message.mediaType)
+    }
+
+    @Test
+    fun `sendImageMessage updates status to ERROR when remote send fails`() = runTest {
+        val failingYaloRepo = object : YaloMessageRepository {
+            override suspend fun sendMessage(msg: ChatMessage) =
+                Result.Error<Unit>(RuntimeException("network error"))
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): Flow<List<ChatMessage>> = emptyFlow()
+            override fun events(): Flow<ChatEvent> = emptyFlow()
+        }
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = MessagesController(
+            failingYaloRepo, localRepo,
+            MessageSyncService(failingYaloRepo, localRepo),
+            dispatcher,
+        ).also { tracked.add(it) }
+        ctrl.start { }
+        ctrl.sendImageMessage("/tmp/photo.jpg", "image/jpeg")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(MessageStatus.ERROR, result.result.single().status)
+    }
+
+    // ── sendVoiceMessage ──────────────────────────────────────────────────────
+
+    @Test
+    fun `sendVoiceMessage with empty fileName does not insert a message`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendVoiceMessage("", emptyList(), 1000L)
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendVoiceMessage before start is a no-op`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        controller(localRepo = localRepo).sendVoiceMessage("/tmp/audio.m4a", emptyList(), 1000L)
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertTrue(result.result.isEmpty())
+    }
+
+    @Test
+    fun `sendVoiceMessage inserts optimistic message with USER role and SENT status`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        val amps = listOf(-20.0, -15.0, -10.0)
+        ctrl.sendVoiceMessage("/tmp/audio.m4a", amps, 2500L)
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val message = result.result.single()
+        assertEquals(MessageRole.USER, message.role)
+        assertEquals(MessageStatus.SENT, message.status)
+        assertEquals(MessageType.Voice, message.type)
+        assertEquals("/tmp/audio.m4a", message.fileName)
+        assertEquals("audio/mp4", message.mediaType)
+        assertEquals(amps, message.amplitudes)
+        assertEquals(2500L, message.duration)
+    }
+
+    @Test
+    fun `sendVoiceMessage updates status to ERROR when remote send fails`() = runTest {
+        val failingYaloRepo = object : YaloMessageRepository {
+            override suspend fun sendMessage(msg: ChatMessage) =
+                Result.Error<Unit>(RuntimeException("network error"))
+            override suspend fun fetchMessages(since: Long) = Result.Ok(emptyList<ChatMessage>())
+            override fun pollIncomingMessages(): Flow<List<ChatMessage>> = emptyFlow()
+            override fun events(): Flow<ChatEvent> = emptyFlow()
+        }
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = MessagesController(
+            failingYaloRepo, localRepo,
+            MessageSyncService(failingYaloRepo, localRepo),
+            dispatcher,
+        ).also { tracked.add(it) }
+        ctrl.start { }
+        ctrl.sendVoiceMessage("/tmp/audio.m4a", emptyList(), 2000L)
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        assertEquals(MessageStatus.ERROR, result.result.single().status)
+    }
 }

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/MessagesControllerTest.kt
@@ -336,4 +336,30 @@ class MessagesControllerTest {
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         assertEquals(MessageStatus.ERROR, result.result.single().status)
     }
+
+    @Test
+    fun `sendImageMessage consecutive sends produce unique message ids`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendImageMessage("/tmp/a.jpg", "image/jpeg")
+        ctrl.sendImageMessage("/tmp/b.jpg", "image/jpeg")
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val ids = result.result.mapNotNull { it.id }
+        assertEquals(2, ids.distinct().size)
+    }
+
+    @Test
+    fun `sendVoiceMessage consecutive sends produce unique message ids`() = runTest {
+        val localRepo = FakeChatMessageRepository()
+        val ctrl = controller(localRepo = localRepo)
+        ctrl.start { }
+        ctrl.sendVoiceMessage("/tmp/a.m4a", emptyList(), 1000L)
+        ctrl.sendVoiceMessage("/tmp/b.m4a", emptyList(), 2000L)
+        val result = localRepo.getMessages(null, 10)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val ids = result.result.mapNotNull { it.id }
+        assertEquals(2, ids.distinct().size)
+    }
 }

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -15,7 +15,10 @@ import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import kotlin.native.Platform
 import kotlinx.coroutines.Dispatchers
-import platform.Foundation.NSTemporaryDirectory
+import platform.Foundation.NSCachesDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSURL
+import platform.Foundation.NSUserDomainMask
 
 // iOS entry point — mirrors YaloChat.kt in androidMain.
 // Wires the shared commonMain business logic with iOS platform drivers:
@@ -62,9 +65,18 @@ object YaloChatSdk {
             organizationId = config.organizationId,
             httpClient = httpClient,
         )
+        // Use app-specific caches directory — mirrors Android's context.cacheDir.
+        // NSTemporaryDirectory() is purged aggressively by the OS between app launches;
+        // NSCachesDirectory is only cleared under storage pressure, so downloaded media
+        // (images, audio, video) survives cold restarts.
+        val cacheDir = (NSFileManager.defaultManager
+            .URLsForDirectory(NSCachesDirectory, NSUserDomainMask)
+            .firstOrNull() as? NSURL)
+            ?.path
+            ?.let { "$it/ChatSdk" }
         val repo = YaloMessageRepositoryRemote(
             apiService = apiService,
-            tempDir = NSTemporaryDirectory(),
+            tempDir = cacheDir,
         )
         yaloRepo = repo
 

--- a/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
+++ b/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
@@ -15,9 +15,15 @@
 		68B260F91753D81C4891F80D /* MessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF775B29AF50036FBF2DD96 /* MessageList.swift */; };
 		6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C966BE803A724D942922CAA /* YaloChat.swift */; };
 		839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D563B68F202040D37D6212 /* MessageItem.swift */; };
+		AA69F96977B9913EF39272DD /* ImageObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192FC4739922F8D122901DB5 /* ImageObservable.swift */; };
+		D26FBEBB44B22F7370ED0CFF /* ImagePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3435CA5533A84581B92E052 /* ImagePreview.swift */; };
+		E2F2085FD79C697C9C902DC8 /* WaveformRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */; };
 		E65E5168702C7E1DFC950C7C /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA6524E179EB88397E204954 /* ContentView.swift */; };
 		E87B26E53C6C69473298A5A5 /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE541740117006132C1A380 /* Credentials.swift */; };
+		E93401D6E82F2C157FF4EC0A /* Credentials.swift.example in Resources */ = {isa = PBXBuildFile; fileRef = 8FCF82F16CCFF7E3A3D06DB5 /* Credentials.swift.example */; };
 		EFC453D69C9FCE945A1CE6B7 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43FDB5E608E371946FE0DFC6 /* ChatView.swift */; };
+		F0D47773279173F7C3093CA2 /* WaveformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4AE3EAFF0C8C544F642946C /* WaveformView.swift */; };
+		F3A87F41CBA199E01A739311 /* AudioObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF05C7967323A2B01F9565F3 /* AudioObservable.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -34,41 +40,23 @@
 		};
 /* End PBXCopyFilesBuildPhase section */
 
-/* Begin PBXShellScriptBuildPhase section */
-		AA11BB22CC33DD44EE55FF66 /* Bootstrap Credentials */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/YaloChatDemo/Credentials.swift.example",
-			);
-			name = "Bootstrap Credentials";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(SRCROOT)/YaloChatDemo/Credentials.swift",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "[ -f \"${SRCROOT}/YaloChatDemo/Credentials.swift\" ] || cp \"${SRCROOT}/YaloChatDemo/Credentials.swift.example\" \"${SRCROOT}/YaloChatDemo/Credentials.swift\"\n";
-		};
-/* End PBXShellScriptBuildPhase section */
-
 /* Begin PBXFileReference section */
 		05D563B68F202040D37D6212 /* MessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageItem.swift; sourceTree = "<group>"; };
-		BB22CC33DD44EE55FF66AA11 /* Credentials.swift.example */ = {isa = PBXFileReference; lastKnownFileType = text; path = "Credentials.swift.example"; sourceTree = "<group>"; };
+		192FC4739922F8D122901DB5 /* ImageObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageObservable.swift; sourceTree = "<group>"; };
 		23407D6589CAA8A5F7913634 /* ChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInput.swift; sourceTree = "<group>"; };
 		34E80F747F4EC2822662317B /* YaloChatDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = YaloChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		43FDB5E608E371946FE0DFC6 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ChatSdk.xcframework; path = "../android-sdk/sdk/build/XCFrameworks/release/ChatSdk.xcframework"; sourceTree = "<group>"; };
+		6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformRecorder.swift; sourceTree = "<group>"; };
 		6C966BE803A724D942922CAA /* YaloChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChat.swift; sourceTree = "<group>"; };
 		83913A0C24BC4B8FD220EB07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		8FCF82F16CCFF7E3A3D06DB5 /* Credentials.swift.example */ = {isa = PBXFileReference; path = Credentials.swift.example; sourceTree = "<group>"; };
 		A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChatDemoApp.swift; sourceTree = "<group>"; };
+		B4AE3EAFF0C8C544F642946C /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		BA6524E179EB88397E204954 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		BF05C7967323A2B01F9565F3 /* AudioObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioObservable.swift; sourceTree = "<group>"; };
 		CDF775B29AF50036FBF2DD96 /* MessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageList.swift; sourceTree = "<group>"; };
+		D3435CA5533A84581B92E052 /* ImagePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreview.swift; sourceTree = "<group>"; };
 		EAE541740117006132C1A380 /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		F820AEACBF2AB583B73D583F /* MessagesObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesObservable.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -113,15 +101,20 @@
 		EFF4F2C90E18DCE164B40765 /* YaloChatDemo */ = {
 			isa = PBXGroup;
 			children = (
+				BF05C7967323A2B01F9565F3 /* AudioObservable.swift */,
 				23407D6589CAA8A5F7913634 /* ChatInput.swift */,
 				43FDB5E608E371946FE0DFC6 /* ChatView.swift */,
 				BA6524E179EB88397E204954 /* ContentView.swift */,
 				EAE541740117006132C1A380 /* Credentials.swift */,
-				BB22CC33DD44EE55FF66AA11 /* Credentials.swift.example */,
+				8FCF82F16CCFF7E3A3D06DB5 /* Credentials.swift.example */,
+				192FC4739922F8D122901DB5 /* ImageObservable.swift */,
+				D3435CA5533A84581B92E052 /* ImagePreview.swift */,
 				83913A0C24BC4B8FD220EB07 /* Info.plist */,
 				05D563B68F202040D37D6212 /* MessageItem.swift */,
 				CDF775B29AF50036FBF2DD96 /* MessageList.swift */,
 				F820AEACBF2AB583B73D583F /* MessagesObservable.swift */,
+				6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */,
+				B4AE3EAFF0C8C544F642946C /* WaveformView.swift */,
 				6C966BE803A724D942922CAA /* YaloChat.swift */,
 				A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */,
 			);
@@ -135,8 +128,8 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F93A0F24576A972127FF74D9 /* Build configuration list for PBXNativeTarget "YaloChatDemo" */;
 			buildPhases = (
-				AA11BB22CC33DD44EE55FF66 /* Bootstrap Credentials */,
 				99083C9C646CE6D473F49E2E /* Sources */,
+				0D757EA09496DEDAF5182910 /* Resources */,
 				F01839D22CEC480BB22E7A08 /* Frameworks */,
 				065FDEBDB472A792738FDE77 /* Embed Frameworks */,
 			);
@@ -185,18 +178,34 @@
 		};
 /* End PBXProject section */
 
+/* Begin PBXResourcesBuildPhase section */
+		0D757EA09496DEDAF5182910 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E93401D6E82F2C157FF4EC0A /* Credentials.swift.example in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		99083C9C646CE6D473F49E2E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F3A87F41CBA199E01A739311 /* AudioObservable.swift in Sources */,
 				1F144E784B4B0E906FE68740 /* ChatInput.swift in Sources */,
 				EFC453D69C9FCE945A1CE6B7 /* ChatView.swift in Sources */,
 				E65E5168702C7E1DFC950C7C /* ContentView.swift in Sources */,
 				E87B26E53C6C69473298A5A5 /* Credentials.swift in Sources */,
+				AA69F96977B9913EF39272DD /* ImageObservable.swift in Sources */,
+				D26FBEBB44B22F7370ED0CFF /* ImagePreview.swift in Sources */,
 				839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */,
 				68B260F91753D81C4891F80D /* MessageList.swift in Sources */,
 				322A00049C2FC71AD22F25E1 /* MessagesObservable.swift in Sources */,
+				E2F2085FD79C697C9C902DC8 /* WaveformRecorder.swift in Sources */,
+				F0D47773279173F7C3093CA2 /* WaveformView.swift in Sources */,
 				6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */,
 				674DB9AB8BB94548B4659911 /* YaloChatDemoApp.swift in Sources */,
 			);

--- a/ios-sdk/YaloChatDemo/AudioObservable.swift
+++ b/ios-sdk/YaloChatDemo/AudioObservable.swift
@@ -63,6 +63,7 @@ class AudioObservable: NSObject, ObservableObject {
         } catch {
             Self.log.error("AVAudioRecorder failed: \(error)")
             recordingFileURL = nil
+            try? session.setActive(false)
             return
         }
 
@@ -91,12 +92,9 @@ class AudioObservable: NSObject, ObservableObject {
     }
 
     func cancelRecording() {
-        if let url = recordingFileURL {
-            stopRecordingSession()
-            try? FileManager.default.removeItem(at: url)
-        } else {
-            stopRecordingSession()
-        }
+        let url = recordingFileURL
+        stopRecordingSession()
+        if let url { try? FileManager.default.removeItem(at: url) }
     }
 
     func stopRecording() -> RecordingData? {
@@ -133,6 +131,8 @@ class AudioObservable: NSObject, ObservableObject {
         isRecording = false
         durationText = "0:00"
         recordingAmplitudes = Array(repeating: -30.0, count: 48)
+        // Release the microphone so other apps (phone, Siri) can record.
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     func togglePlayback(messageId: Int64, fileName: String) {

--- a/ios-sdk/YaloChatDemo/AudioObservable.swift
+++ b/ios-sdk/YaloChatDemo/AudioObservable.swift
@@ -1,0 +1,185 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import AVFoundation
+import Foundation
+import os
+
+class AudioObservable: NSObject, ObservableObject {
+
+    @Published var isRecording = false
+    @Published var durationText = "0:00"
+    @Published var recordingAmplitudes: [Double] = Array(repeating: -30.0, count: 48)
+    @Published var playingMessageId: Int64? = nil
+
+    private static let log = Logger(subsystem: "com.yalo.chat.demo", category: "AudioObservable")
+
+    private var audioRecorder: AVAudioRecorder?
+    private var audioPlayer: AVAudioPlayer?
+    private var recordingTimer: Timer?
+    private var rawAmplitudes: [Double] = []
+    private var recordingStartTime: Date?
+    private var recordingFileURL: URL?
+
+    struct RecordingData {
+        let fileName: String
+        let amplitudes: [Double]
+        let durationMs: Int64
+    }
+
+    func startRecording() {
+        AVAudioSession.sharedInstance().requestRecordPermission { [weak self] granted in
+            DispatchQueue.main.async {
+                guard granted else { return }
+                self?.beginRecording()
+            }
+        }
+    }
+
+    private func beginRecording() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker])
+            try session.setActive(true)
+        } catch {
+            Self.log.error("Audio session error: \(error)")
+            return
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".m4a")
+        recordingFileURL = url
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+        ]
+
+        do {
+            audioRecorder = try AVAudioRecorder(url: url, settings: settings)
+            audioRecorder?.isMeteringEnabled = true
+            audioRecorder?.record()
+        } catch {
+            Self.log.error("AVAudioRecorder failed: \(error)")
+            recordingFileURL = nil
+            return
+        }
+
+        rawAmplitudes = []
+        recordingStartTime = Date()
+        isRecording = true
+        durationText = "0:00"
+        recordingAmplitudes = Array(repeating: -30.0, count: 48)
+
+        recordingTimer = Timer.scheduledTimer(withTimeInterval: 0.025, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+    }
+
+    private func tick() {
+        guard let recorder = audioRecorder, recorder.isRecording else { return }
+        recorder.updateMeters()
+        let dBFS = Double(recorder.averagePower(forChannel: 0))
+        rawAmplitudes.append(dBFS)
+        recordingAmplitudes = compressWaveform(rawAmplitudes, to: 48)
+
+        if let start = recordingStartTime {
+            let elapsed = Int(Date().timeIntervalSince(start))
+            durationText = String(format: "%d:%02d", elapsed / 60, elapsed % 60)
+        }
+    }
+
+    func cancelRecording() {
+        if let url = recordingFileURL {
+            stopRecordingSession()
+            try? FileManager.default.removeItem(at: url)
+        } else {
+            stopRecordingSession()
+        }
+    }
+
+    func stopRecording() -> RecordingData? {
+        guard let url = recordingFileURL, let start = recordingStartTime else {
+            stopRecordingSession()
+            return nil
+        }
+
+        let durationMs = Int64(Date().timeIntervalSince(start) * 1000)
+        let ampsCopy = rawAmplitudes
+
+        stopRecordingSession()
+
+        guard durationMs > 500 else {
+            try? FileManager.default.removeItem(at: url)
+            return nil
+        }
+
+        return RecordingData(
+            fileName: url.path,
+            amplitudes: compressWaveform(ampsCopy, to: 48),
+            durationMs: durationMs
+        )
+    }
+
+    private func stopRecordingSession() {
+        recordingTimer?.invalidate()
+        recordingTimer = nil
+        audioRecorder?.stop()
+        audioRecorder = nil
+        recordingFileURL = nil
+        recordingStartTime = nil
+        rawAmplitudes = []
+        isRecording = false
+        durationText = "0:00"
+        recordingAmplitudes = Array(repeating: -30.0, count: 48)
+    }
+
+    func togglePlayback(messageId: Int64, fileName: String) {
+        if playingMessageId == messageId {
+            audioPlayer?.stop()
+            audioPlayer = nil
+            playingMessageId = nil
+            return
+        }
+        audioPlayer?.stop()
+        audioPlayer = nil
+
+        guard !fileName.isEmpty,
+              let player = try? AVAudioPlayer(contentsOf: URL(fileURLWithPath: fileName)) else {
+            return
+        }
+        player.delegate = self
+        player.play()
+        audioPlayer = player
+        playingMessageId = messageId
+    }
+
+    // Mirrors Flutter AudioProcessingUseCase.compressWaveformForPreview:
+    // maps rawSamples to exactly `count` bins — max of each bin when compressing,
+    // nearest-neighbor repeat when stretching.
+    private func compressWaveform(_ samples: [Double], to count: Int) -> [Double] {
+        guard !samples.isEmpty else { return Array(repeating: -60.0, count: count) }
+        if samples.count <= count {
+            return (0..<count).map { i in
+                let src = Int(Double(i) * Double(samples.count) / Double(count))
+                return samples[min(src, samples.count - 1)]
+            }
+        }
+        let binSize = Double(samples.count) / Double(count)
+        return (0..<count).map { i in
+            let start = Int(Double(i) * binSize)
+            let end = min(Int(Double(i + 1) * binSize), samples.count)
+            return samples[start..<end].max() ?? -60.0
+        }
+    }
+}
+
+extension AudioObservable: AVAudioPlayerDelegate {
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.playingMessageId = nil
+            self?.audioPlayer = nil
+        }
+    }
+}

--- a/ios-sdk/YaloChatDemo/AudioObservable.swift
+++ b/ios-sdk/YaloChatDemo/AudioObservable.swift
@@ -193,6 +193,13 @@ class AudioObservable: NSObject, ObservableObject {
             return samples[start..<end].max() ?? -60.0
         }
     }
+
+    deinit {
+        recordingTimer?.invalidate()
+        audioRecorder?.stop()
+        audioPlayer?.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
 }
 
 extension AudioObservable: AVAudioPlayerDelegate {
@@ -205,11 +212,3 @@ extension AudioObservable: AVAudioPlayerDelegate {
     }
 }
 
-extension AudioObservable {
-    deinit {
-        recordingTimer?.invalidate()
-        audioRecorder?.stop()
-        audioPlayer?.stop()
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
-    }
-}

--- a/ios-sdk/YaloChatDemo/AudioObservable.swift
+++ b/ios-sdk/YaloChatDemo/AudioObservable.swift
@@ -83,7 +83,12 @@ class AudioObservable: NSObject, ObservableObject {
         recorder.updateMeters()
         let dBFS = Double(recorder.averagePower(forChannel: 0))
         rawAmplitudes.append(dBFS)
-        recordingAmplitudes = compressWaveform(rawAmplitudes, to: 48)
+        // Mirrors Flutter AudioBloc sliding window: fixed 48-element display array,
+        // shift left by 1 and append the new sample on every tick.
+        var next = recordingAmplitudes
+        next.removeFirst()
+        next.append(dBFS)
+        recordingAmplitudes = next
 
         if let start = recordingStartTime {
             let elapsed = Int(Date().timeIntervalSince(start))
@@ -140,6 +145,7 @@ class AudioObservable: NSObject, ObservableObject {
             audioPlayer?.stop()
             audioPlayer = nil
             playingMessageId = nil
+            deactivatePlaybackSession()
             return
         }
         audioPlayer?.stop()
@@ -149,10 +155,24 @@ class AudioObservable: NSObject, ObservableObject {
               let player = try? AVAudioPlayer(contentsOf: URL(fileURLWithPath: fileName)) else {
             return
         }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.playback, mode: .default)
+            try session.setActive(true)
+        } catch {
+            Self.log.error("Playback session error: \(error)")
+            return
+        }
+
         player.delegate = self
         player.play()
         audioPlayer = player
         playingMessageId = messageId
+    }
+
+    private func deactivatePlaybackSession() {
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 
     // Mirrors Flutter AudioProcessingUseCase.compressWaveformForPreview:
@@ -180,6 +200,16 @@ extension AudioObservable: AVAudioPlayerDelegate {
         DispatchQueue.main.async { [weak self] in
             self?.playingMessageId = nil
             self?.audioPlayer = nil
+            self?.deactivatePlaybackSession()
         }
+    }
+}
+
+extension AudioObservable {
+    deinit {
+        recordingTimer?.invalidate()
+        audioRecorder?.stop()
+        audioPlayer?.stop()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
     }
 }

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -1,6 +1,7 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
 import SwiftUI
+import UIKit
 
 // Mirrors Flutter ChatInput. Action-button logic follows Flutter's switch:
 //   recording → stop/send voice  |  has-image → send image

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -20,7 +20,7 @@ struct ChatInput: View {
     var body: some View {
         VStack(spacing: 0) {
             if let image = imageObservable.pickedRawImage {
-                ImagePreview(image: image, onCancel: imageObservable.clearImage) {
+                ImagePreview(image: image, onCancel: imageObservable.discardImage) {
                     sendImage()
                 }
                 Divider()

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -2,35 +2,109 @@
 
 import SwiftUI
 
-// Mirrors Flutter ChatInput (text-only, M3 scope — no attachment or mic button).
-// Send button is disabled while the text field is blank or whitespace-only.
+// Mirrors Flutter ChatInput. Action-button logic follows Flutter's switch:
+//   recording → stop/send voice  |  has-image → send image
+//   has-text → send text  |  else → mic (start recording)
 struct ChatInput: View {
 
-    @ObservedObject var observable: MessagesObservable
+    @ObservedObject var messagesObservable: MessagesObservable
+    @ObservedObject var imageObservable: ImageObservable
+    @ObservedObject var audioObservable: AudioObservable
 
     private var isBlank: Bool {
-        observable.userMessage.trimmingCharacters(in: .whitespaces).isEmpty
+        messagesObservable.userMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    var body: some View {
-        HStack(spacing: 8) {
-            TextField("Type a message…", text: $observable.userMessage)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
-                .background(Color(.systemGray6))
-                .cornerRadius(25)
-                .onSubmit { observable.sendMessage() }
+    private var hasImage: Bool { imageObservable.pickedImagePath != nil }
 
-            Button(action: observable.sendMessage) {
+    var body: some View {
+        VStack(spacing: 0) {
+            if let image = imageObservable.pickedRawImage {
+                ImagePreview(image: image, onCancel: imageObservable.clearImage) {
+                    sendImage()
+                }
+                Divider()
+            }
+
+            if audioObservable.isRecording {
+                WaveformRecorder(audioObservable: audioObservable) { fileName, amplitudes, durationMs in
+                    messagesObservable.sendVoiceMessage(
+                        fileName: fileName,
+                        amplitudes: amplitudes,
+                        durationMs: durationMs
+                    )
+                }
+            } else {
+                HStack(spacing: 8) {
+                    Button {
+                        imageObservable.showSourceSheet = true
+                    } label: {
+                        Image(systemName: "paperclip")
+                            .foregroundColor(.secondary)
+                            .padding(.leading, 4)
+                    }
+
+                    TextField("Type a message…", text: $messagesObservable.userMessage)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 10)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(25)
+                        .onSubmit { messagesObservable.sendMessage() }
+
+                    actionButton
+                }
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+        }
+        .confirmationDialog("Attach Image", isPresented: $imageObservable.showSourceSheet) {
+            Button("Photo Library") { imageObservable.showGallery = true }
+            if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                Button("Camera") { imageObservable.showCamera = true }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: $imageObservable.showGallery) {
+            PHPickerRepresentable(imageObservable: imageObservable)
+        }
+        .fullScreenCover(isPresented: $imageObservable.showCamera) {
+            CameraPickerRepresentable(imageObservable: imageObservable)
+                .ignoresSafeArea()
+        }
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if hasImage || !isBlank {
+            Button(action: sendAction) {
                 Image(systemName: "paperplane.fill")
                     .foregroundColor(.white)
                     .padding(10)
-                    .background(isBlank ? Color.gray : Color.accentColor)
+                    .background(Color.accentColor)
                     .clipShape(Circle())
             }
-            .disabled(isBlank)
+        } else {
+            Button(action: audioObservable.startRecording) {
+                Image(systemName: "mic.fill")
+                    .foregroundColor(.white)
+                    .padding(10)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
+            }
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
+    }
+
+    private func sendAction() {
+        if hasImage {
+            sendImage()
+        } else {
+            messagesObservable.sendMessage()
+        }
+    }
+
+    private func sendImage() {
+        guard let path = imageObservable.pickedImagePath else { return }
+        messagesObservable.sendImageMessage(fileName: path, mimeType: imageObservable.mimeType)
+        imageObservable.clearImage()
     }
 }

--- a/ios-sdk/YaloChatDemo/ChatView.swift
+++ b/ios-sdk/YaloChatDemo/ChatView.swift
@@ -3,18 +3,22 @@
 import SwiftUI
 import ChatSdk
 
-// Root chat screen. Mirrors Flutter's Chat widget: NavigationView (ChatAppBar) +
-// MessageList + ChatInput stacked vertically.
 struct ChatView: View {
 
     @StateObject private var observable = MessagesObservable()
+    @StateObject private var imageObservable = ImageObservable()
+    @StateObject private var audioObservable = AudioObservable()
 
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
-                MessageList(observable: observable)
+                MessageList(observable: observable, audioObservable: audioObservable)
                 Divider()
-                ChatInput(observable: observable)
+                ChatInput(
+                    messagesObservable: observable,
+                    imageObservable: imageObservable,
+                    audioObservable: audioObservable
+                )
             }
             .navigationTitle(YaloChatSdk.shared.config?.channelName ?? "Chat")
             .navigationBarTitleDisplayMode(.inline)

--- a/ios-sdk/YaloChatDemo/ImageObservable.swift
+++ b/ios-sdk/YaloChatDemo/ImageObservable.swift
@@ -1,0 +1,109 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import Foundation
+import PhotosUI
+import SwiftUI
+import UIKit
+
+class ImageObservable: ObservableObject {
+
+    @Published var pickedRawImage: UIImage? = nil
+    @Published var pickedImagePath: String? = nil
+    @Published var mimeType: String = "image/jpeg"
+    @Published var showSourceSheet: Bool = false
+    @Published var showGallery: Bool = false
+    @Published var showCamera: Bool = false
+
+    func setPickedImage(_ image: UIImage) {
+        guard let data = image.jpegData(compressionQuality: 0.85) else { return }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString + ".jpg")
+        do {
+            try data.write(to: url)
+            pickedRawImage = image
+            pickedImagePath = url.path
+            mimeType = "image/jpeg"
+        } catch {
+            // No-op — user can retry by picking again
+        }
+    }
+
+    func clearImage() {
+        pickedRawImage = nil
+        pickedImagePath = nil
+    }
+}
+
+// ── Gallery picker (iOS 14+) ──────────────────────────────────────────────────
+
+struct PHPickerRepresentable: UIViewControllerRepresentable {
+
+    let imageObservable: ImageObservable
+
+    func makeUIViewController(context: Context) -> PHPickerViewController {
+        var config = PHPickerConfiguration()
+        config.selectionLimit = 1
+        config.filter = .images
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: PHPickerViewController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(imageObservable) }
+
+    class Coordinator: NSObject, PHPickerViewControllerDelegate {
+        let observable: ImageObservable
+        init(_ observable: ImageObservable) { self.observable = observable }
+
+        func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+            picker.dismiss(animated: true)
+            guard let result = results.first else { return }
+            result.itemProvider.loadObject(ofClass: UIImage.self) { object, _ in
+                DispatchQueue.main.async {
+                    if let image = object as? UIImage {
+                        self.observable.setPickedImage(image)
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ── Camera picker ─────────────────────────────────────────────────────────────
+
+struct CameraPickerRepresentable: UIViewControllerRepresentable {
+
+    let imageObservable: ImageObservable
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator { Coordinator(imageObservable) }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let observable: ImageObservable
+        init(_ observable: ImageObservable) { self.observable = observable }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            picker.dismiss(animated: true)
+            if let image = info[.originalImage] as? UIImage {
+                observable.setPickedImage(image)
+            }
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/ios-sdk/YaloChatDemo/ImageObservable.swift
+++ b/ios-sdk/YaloChatDemo/ImageObservable.swift
@@ -15,6 +15,10 @@ class ImageObservable: ObservableObject {
     @Published var showCamera: Bool = false
 
     func setPickedImage(_ image: UIImage) {
+        // Delete any previously staged temp file before overwriting.
+        if let existing = pickedImagePath {
+            try? FileManager.default.removeItem(atPath: existing)
+        }
         guard let data = image.jpegData(compressionQuality: 0.85) else { return }
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString + ".jpg")
@@ -28,7 +32,17 @@ class ImageObservable: ObservableObject {
         }
     }
 
+    // Called after send — KMP already has the path, do NOT delete the file.
     func clearImage() {
+        pickedRawImage = nil
+        pickedImagePath = nil
+    }
+
+    // Called on cancel — deletes the staged temp file from disk.
+    func discardImage() {
+        if let path = pickedImagePath {
+            try? FileManager.default.removeItem(atPath: path)
+        }
         pickedRawImage = nil
         pickedImagePath = nil
     }

--- a/ios-sdk/YaloChatDemo/ImagePreview.swift
+++ b/ios-sdk/YaloChatDemo/ImagePreview.swift
@@ -1,0 +1,43 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+import UIKit
+
+// Shows a thumbnail of the selected image with cancel and send controls.
+// Displayed above ChatInput when an image has been picked but not yet sent.
+struct ImagePreview: View {
+
+    let image: UIImage
+    let onCancel: () -> Void
+    let onSend: () -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(uiImage: image)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 64, height: 64)
+                .clipped()
+                .cornerRadius(8)
+
+            Spacer()
+
+            Button(action: onCancel) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.secondary)
+                    .font(.title2)
+            }
+
+            Button(action: onSend) {
+                Image(systemName: "paperplane.fill")
+                    .foregroundColor(.white)
+                    .padding(8)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(Color(.systemBackground))
+    }
+}

--- a/ios-sdk/YaloChatDemo/Info.plist
+++ b/ios-sdk/YaloChatDemo/Info.plist
@@ -31,5 +31,11 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Select a photo to send in the chat.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>Take a photo to send in the chat.</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Record a voice message to send in the chat.</string>
 </dict>
 </plist>

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -71,19 +71,19 @@ struct MessageItem: View {
 
     @ViewBuilder
     private var voiceContent: some View {
-        let messageId = message.id?.int64Value ?? 0
-        let isPlaying = audioObservable.playingMessageId == messageId
+        let messageId = message.id?.int64Value
+        let isPlaying = messageId.map { audioObservable.playingMessageId == $0 } ?? false
 
         HStack(spacing: 8) {
             Button {
-                guard let path = message.fileName else { return }
-                audioObservable.togglePlayback(messageId: messageId, fileName: path)
+                guard let mid = messageId, let path = message.fileName else { return }
+                audioObservable.togglePlayback(messageId: mid, fileName: path)
             } label: {
                 Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
                     .font(.title2)
                     .foregroundColor(isUser ? .white : .accentColor)
             }
-            .disabled(message.fileName == nil)
+            .disabled(message.fileName == nil || messageId == nil)
 
             WaveformView(
                 amplitudes: resolvedAmplitudes,

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -63,12 +63,8 @@ struct MessageItem: View {
 
     @ViewBuilder
     private var imageContent: some View {
-        if let path = message.fileName, let uiImage = UIImage(contentsOfFile: path) {
-            Image(uiImage: uiImage)
-                .resizable()
-                .scaledToFill()
-                .frame(maxWidth: 200, maxHeight: 200)
-                .clipped()
+        if let path = message.fileName {
+            LocalFileImage(path: path, fallbackColor: bubbleColor)
         } else {
             Label("Image unavailable", systemImage: "photo")
                 .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
@@ -224,5 +220,36 @@ struct MessageItem: View {
 
     private var bubbleColor: Color {
         isUser ? .accentColor : Color(.systemGray5)
+    }
+}
+
+// Loads an image from a local file path exactly once, off the main thread.
+// Avoids calling UIImage(contentsOfFile:) in the SwiftUI body on every render.
+private struct LocalFileImage: View {
+    let path: String
+    let fallbackColor: Color
+
+    @State private var uiImage: UIImage? = nil
+
+    var body: some View {
+        Group {
+            if let img = uiImage {
+                Image(uiImage: img)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: 200, maxHeight: 200)
+                    .clipped()
+            } else {
+                fallbackColor
+                    .frame(width: 200, height: 150)
+                    .overlay(ProgressView())
+            }
+        }
+        .task(id: path) {
+            guard uiImage == nil else { return }
+            uiImage = await Task.detached(priority: .userInitiated) {
+                UIImage(contentsOfFile: path)
+            }.value
+        }
     }
 }

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -2,12 +2,14 @@
 
 import SwiftUI
 import UIKit
+import AVKit
 import ChatSdk
 
 struct MessageItem: View {
 
     let message: ChatMessage
     @ObservedObject var audioObservable: AudioObservable
+    var onButtonTap: (String) -> Void = { _ in }
 
     private var isUser: Bool { message.role === MessageRole.user }
 
@@ -28,6 +30,9 @@ struct MessageItem: View {
             if message.type is MessageType.Image {
                 imageContent
                     .cornerRadius(16)
+            } else if message.type is MessageType.Video {
+                videoContent
+                    .cornerRadius(16)
             } else {
                 bubbleContent
                     .padding(12)
@@ -44,6 +49,10 @@ struct MessageItem: View {
                 .foregroundColor(isUser ? .white : .primary)
         } else if message.type is MessageType.Voice {
             voiceContent
+        } else if message.type is MessageType.Buttons {
+            buttonsContent
+        } else if message.type is MessageType.CTA {
+            ctaContent
         } else {
             Text("Unsupported message type")
                 .font(.caption)
@@ -62,6 +71,110 @@ struct MessageItem: View {
                 .clipped()
         } else {
             Label("Image unavailable", systemImage: "photo")
+                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .font(.caption)
+                .padding(12)
+                .background(bubbleColor)
+        }
+    }
+
+    @ViewBuilder
+    private var buttonsContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let header = message.header, !header.isEmpty {
+                Text(header)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+            }
+            if !message.content.isEmpty {
+                Text(message.content)
+                    .foregroundColor(.primary)
+            }
+            if let footer = message.footer, !footer.isEmpty {
+                Text(footer)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            let labels = message.buttons.compactMap { $0 as? String }
+            if !labels.isEmpty {
+                VStack(spacing: 6) {
+                    ForEach(labels, id: \.self) { label in
+                        Button(action: { onButtonTap(label) }) {
+                            Text(label)
+                                .font(.subheadline)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 8)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .stroke(Color.accentColor, lineWidth: 1)
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.accentColor)
+                    }
+                }
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var ctaContent: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let header = message.header, !header.isEmpty {
+                Text(header)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.primary)
+            }
+            if !message.content.isEmpty {
+                Text(message.content)
+                    .foregroundColor(.primary)
+            }
+            if let footer = message.footer, !footer.isEmpty {
+                Text(footer)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            let buttons = message.ctaButtons.compactMap { $0 as? CtaButton }
+            if !buttons.isEmpty {
+                VStack(spacing: 6) {
+                    ForEach(buttons, id: \.url) { button in
+                        Button(action: {
+                            if let url = URL(string: button.url) {
+                                UIApplication.shared.open(url)
+                            }
+                        }) {
+                            HStack {
+                                Text(button.text)
+                                    .font(.subheadline)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                Image(systemName: "arrow.up.right")
+                                    .font(.caption)
+                            }
+                            .padding(.vertical, 8)
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .stroke(Color.accentColor, lineWidth: 1)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundColor(.accentColor)
+                    }
+                }
+                .padding(.top, 4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var videoContent: some View {
+        if let path = message.fileName {
+            VideoPlayer(player: AVPlayer(url: URL(fileURLWithPath: path)))
+                .frame(maxWidth: 240, minHeight: 160, maxHeight: 180)
+        } else {
+            Label("Video unavailable", systemImage: "video")
                 .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
                 .font(.caption)
                 .padding(12)

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -1,11 +1,13 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
 import SwiftUI
+import UIKit
 import ChatSdk
 
 struct MessageItem: View {
 
     let message: ChatMessage
+    @ObservedObject var audioObservable: AudioObservable
 
     private var isUser: Bool { message.role === MessageRole.user }
 
@@ -22,10 +24,17 @@ struct MessageItem: View {
     }
 
     private var bubble: some View {
-        bubbleContent
-            .padding(12)
-            .background(bubbleColor)
-            .cornerRadius(16)
+        Group {
+            if message.type is MessageType.Image {
+                imageContent
+                    .cornerRadius(16)
+            } else {
+                bubbleContent
+                    .padding(12)
+                    .background(bubbleColor)
+                    .cornerRadius(16)
+            }
+        }
     }
 
     @ViewBuilder
@@ -33,12 +42,71 @@ struct MessageItem: View {
         if message.type is MessageType.Text {
             Text(message.content)
                 .foregroundColor(isUser ? .white : .primary)
+        } else if message.type is MessageType.Voice {
+            voiceContent
         } else {
             Text("Unsupported message type")
                 .font(.caption)
                 .italic()
                 .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
         }
+    }
+
+    @ViewBuilder
+    private var imageContent: some View {
+        if let path = message.fileName, let uiImage = UIImage(contentsOfFile: path) {
+            Image(uiImage: uiImage)
+                .resizable()
+                .scaledToFill()
+                .frame(maxWidth: 200, maxHeight: 200)
+                .clipped()
+        } else {
+            Label("Image unavailable", systemImage: "photo")
+                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .font(.caption)
+                .padding(12)
+                .background(bubbleColor)
+        }
+    }
+
+    @ViewBuilder
+    private var voiceContent: some View {
+        let messageId = message.id?.int64Value ?? 0
+        let isPlaying = audioObservable.playingMessageId == messageId
+
+        HStack(spacing: 8) {
+            Button {
+                guard let path = message.fileName else { return }
+                audioObservable.togglePlayback(messageId: messageId, fileName: path)
+            } label: {
+                Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(isUser ? .white : .accentColor)
+            }
+            .disabled(message.fileName == nil)
+
+            WaveformView(
+                amplitudes: resolvedAmplitudes,
+                color: isUser ? .white.opacity(0.7) : .accentColor
+            )
+            .frame(width: 100, height: 28)
+
+            Text(voiceDuration)
+                .monospacedDigit()
+                .font(.caption)
+                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+        }
+    }
+
+    private var resolvedAmplitudes: [Double] {
+        let raw = message.amplitudes.compactMap { ($0 as? NSNumber)?.doubleValue }
+        return raw.isEmpty ? Array(repeating: -30.0, count: 48) : raw
+    }
+
+    private var voiceDuration: String {
+        let ms = message.duration?.int64Value ?? 0
+        let s = ms / 1000
+        return String(format: "%d:%02d", s / 60, s % 60)
     }
 
     private var bubbleColor: Color {

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -99,7 +99,7 @@ struct MessageItem: View {
     }
 
     private var resolvedAmplitudes: [Double] {
-        let raw = message.amplitudes.compactMap { ($0 as? NSNumber)?.doubleValue }
+        let raw = message.amplitudes.map { $0.doubleValue }
         return raw.isEmpty ? Array(repeating: -30.0, count: 48) : raw
     }
 

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -6,6 +6,7 @@ import ChatSdk
 struct MessageList: View {
 
     @ObservedObject var observable: MessagesObservable
+    @ObservedObject var audioObservable: AudioObservable
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -22,7 +23,7 @@ struct MessageList: View {
                         }
                     } else {
                         ForEach(Array(observable.messages.enumerated()), id: \.offset) { _, message in
-                            MessageItem(message: message)
+                            MessageItem(message: message, audioObservable: audioObservable)
                         }
                     }
                     // Anchor always present so scrollTo("bottom") never targets a missing id.

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -22,21 +22,31 @@ struct MessageList: View {
                                 .padding(.top, 32)
                         }
                     } else {
-                        ForEach(Array(observable.messages.enumerated()), id: \.offset) { _, message in
-                            MessageItem(message: message, audioObservable: audioObservable)
+                        ForEach(Array(observable.messages.enumerated()), id: \.offset) { index, message in
+                            MessageItem(
+                                message: message,
+                                audioObservable: audioObservable,
+                                onButtonTap: { label in observable.sendTextMessage(text: label) }
+                            )
+                            .id(index)
                         }
                     }
-                    // Anchor always present so scrollTo("bottom") never targets a missing id.
-                    Color.clear.frame(height: 0).id("bottom")
+                    Color.clear.frame(height: 1).id("bottom")
                 }
                 .padding(.horizontal, 16)
                 .padding(.vertical, 8)
             }
-            .onChange(of: observable.messages.count) { _ in
-                withAnimation { proxy.scrollTo("bottom", anchor: .bottom) }
+            .onChange(of: observable.messages.count) { count in
+                DispatchQueue.main.async {
+                    withAnimation(.linear(duration: 0.15)) {
+                        proxy.scrollTo("bottom", anchor: .bottom)
+                    }
+                }
             }
             .onAppear {
-                proxy.scrollTo("bottom", anchor: .bottom)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    proxy.scrollTo("bottom", anchor: .bottom)
+                }
             }
         }
     }

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -50,7 +50,9 @@ class MessagesObservable: ObservableObject {
     func sendMessage() {
         let text = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
+        #if DEBUG
         Self.log.debug("sendMessage: \(text.prefix(60))")
+        #endif
         userMessage = ""
         controller?.sendTextMessage(text: text)
     }
@@ -58,7 +60,9 @@ class MessagesObservable: ObservableObject {
     func sendTextMessage(text: String) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
+        #if DEBUG
         Self.log.debug("sendTextMessage: \(trimmed.prefix(60))")
+        #endif
         controller?.sendTextMessage(text: trimmed)
     }
 

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -57,6 +57,10 @@ class MessagesObservable: ObservableObject {
     }
 
     func sendVoiceMessage(fileName: String, amplitudes: [Double], durationMs: Int64) {
-        controller?.sendVoiceMessage(fileName: fileName, amplitudes: amplitudes, durationMs: durationMs)
+        controller?.sendVoiceMessage(
+            fileName: fileName,
+            amplitudes: amplitudes.map { KotlinDouble(value: $0) },
+            durationMs: durationMs
+        )
     }
 }

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -60,4 +60,3 @@ class MessagesObservable: ObservableObject {
         controller?.sendVoiceMessage(fileName: fileName, amplitudes: amplitudes, durationMs: durationMs)
     }
 }
-

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -24,14 +24,17 @@ class MessagesObservable: ObservableObject {
         Self.log.debug("onAppear — starting controller")
         controller?.start { [weak self] messages in
             DispatchQueue.main.async {
-                let sorted = messages.sorted { $0.timestamp < $1.timestamp }
+                // DB returns messages ORDER BY id ASC — correct receipt order.
+                // Do NOT re-sort by timestamp: server timestamps have only second
+                // precision, so bot messages sent in the same second as a user message
+                // would sort before it despite arriving later.
                 #if DEBUG
-                Self.log.debug("messages update: \(sorted.count) total")
-                for msg in sorted {
+                Self.log.debug("messages update: \(messages.count) total")
+                for msg in messages {
                     Self.log.debug("  [\(String(describing: msg.role))] [\(String(describing: msg.type))] id=\(msg.id?.int64Value ?? -1) ts=\(msg.timestamp)")
                 }
                 #endif
-                self?.messages = sorted
+                self?.messages = messages
                 self?.isLoading = false
             }
         }
@@ -50,6 +53,13 @@ class MessagesObservable: ObservableObject {
         Self.log.debug("sendMessage: \(text.prefix(60))")
         userMessage = ""
         controller?.sendTextMessage(text: text)
+    }
+
+    func sendTextMessage(text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        Self.log.debug("sendTextMessage: \(trimmed.prefix(60))")
+        controller?.sendTextMessage(text: trimmed)
     }
 
     func sendImageMessage(fileName: String, mimeType: String) {

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -45,11 +45,19 @@ class MessagesObservable: ObservableObject {
     }
 
     func sendMessage() {
-        let text = userMessage.trimmingCharacters(in: .whitespaces)
+        let text = userMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !text.isEmpty else { return }
         Self.log.debug("sendMessage: \(text.prefix(60))")
         userMessage = ""
         controller?.sendTextMessage(text: text)
+    }
+
+    func sendImageMessage(fileName: String, mimeType: String) {
+        controller?.sendImageMessage(fileName: fileName, mimeType: mimeType)
+    }
+
+    func sendVoiceMessage(fileName: String, amplitudes: [Double], durationMs: Int64) {
+        controller?.sendVoiceMessage(fileName: fileName, amplitudes: amplitudes, durationMs: durationMs)
     }
 }
 

--- a/ios-sdk/YaloChatDemo/WaveformRecorder.swift
+++ b/ios-sdk/YaloChatDemo/WaveformRecorder.swift
@@ -1,0 +1,45 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+
+// Active recording overlay shown in place of the normal ChatInput row.
+// Mirrors Flutter's AudioRecordingWidget: cancel button, duration, live waveform, send button.
+struct WaveformRecorder: View {
+
+    @ObservedObject var audioObservable: AudioObservable
+    // Called with (fileName, amplitudes, durationMs) when the user taps send.
+    let onSend: (String, [Double], Int64) -> Void
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(action: audioObservable.cancelRecording) {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundColor(.secondary)
+                    .font(.title2)
+            }
+
+            Text(audioObservable.durationText)
+                .monospacedDigit()
+                .foregroundColor(.red)
+                .frame(width: 48, alignment: .leading)
+
+            WaveformView(amplitudes: audioObservable.recordingAmplitudes, color: .red)
+                .frame(height: 32)
+
+            Button {
+                if let data = audioObservable.stopRecording() {
+                    onSend(data.fileName, data.amplitudes, data.durationMs)
+                }
+            } label: {
+                Image(systemName: "stop.circle.fill")
+                    .foregroundColor(.white)
+                    .font(.title2)
+                    .padding(6)
+                    .background(Color.accentColor)
+                    .clipShape(Circle())
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+    }
+}

--- a/ios-sdk/YaloChatDemo/WaveformView.swift
+++ b/ios-sdk/YaloChatDemo/WaveformView.swift
@@ -1,0 +1,30 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import SwiftUI
+
+// Bar-chart waveform mirroring Flutter WaveformPainter.
+// Each amplitude is in dBFS (–∞…0). Bar height = max(5 %, 10^(dBFS/20)) × maxHeight.
+// Bars occupy 80 % of available width; remaining 20 % is distributed as inter-bar gaps.
+struct WaveformView: View {
+
+    let amplitudes: [Double]
+    let color: Color
+
+    var body: some View {
+        Canvas { context, size in
+            let count = max(1, amplitudes.count)
+            let barW = size.width * 0.8 / CGFloat(count)
+            let gap = count > 1 ? size.width * 0.2 / CGFloat(count - 1) : 0
+
+            for (i, dBFS) in amplitudes.enumerated() {
+                let linear = pow(10.0, dBFS / 20.0)
+                let fraction = max(0.05, min(1.0, linear))
+                let bh = size.height * fraction
+                let x = CGFloat(i) * (barW + gap)
+                let y = (size.height - bh) / 2
+                let rect = CGRect(x: x, y: y, width: max(barW, 1), height: bh)
+                context.fill(Path(roundedRect: rect, cornerRadius: 2), with: .color(color))
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **M4 (Image Picker + Image UI)**: `ImageObservable` wraps `PHPickerViewController` (gallery) and `UIImagePickerController` (camera) with gallery/camera `confirmationDialog` on the attachment button. Picked images are saved as JPEG to a temp file and shown in `ImagePreview` above the input. `MessageItem` renders image bubbles from local file paths (works for both user-sent and CDN-downloaded agent images). `MessagesController.sendImageMessage` mirrors Android's `SendImageMessage` handler.

- **M5 (Audio Recording + Playback + Audio UI)**: `AudioObservable` drives `AVAudioRecorder` (AAC/m4a, 25ms metering tick) and `AVAudioPlayer` with `AVAudioPlayerDelegate` for auto-stop. `WaveformView` uses `Canvas` to render 48 bars matching Flutter's `WaveformPainter` algorithm (`height = max(5%, 10^(dBFS/20))`). `WaveformRecorder` replaces the input row during recording. `MessageItem` voice bubble shows play/pause + waveform + duration. `MessagesController.sendVoiceMessage` mirrors Android's `SendVoiceMessage` handler.

- **Action button logic** mirrors Flutter `ChatInput` switch: recording → stop/send voice | has-image → send image | has-text → send text | else → mic.

- **Copilot fixes** from PR #104: `.whitespaces` → `.whitespacesAndNewlines` in `MessagesObservable` and `ChatInput`; removed `println` from `YaloMessageRepositoryRemote`.

- **8 new unit tests** for `sendImageMessage` and `sendVoiceMessage` (empty-guard, before-start no-op, optimistic insert, remote-failure ERROR status).

## Test plan

- [ ] Run `./gradlew :sdk:testDebugUnitTest` — all tests green (19 total in `MessagesControllerTest`)
- [ ] `xcodegen generate` in `ios-sdk/` → build in Xcode on iOS 15+ simulator
- [ ] Fill `Credentials.swift`, run demo app:
  - Attachment button opens gallery/camera sheet; selected image shows preview above input
  - Send image → optimistic blue bubble with image thumbnail appears immediately
  - Agent image messages render from downloaded local path
  - Tap mic → recording UI shows with live waveform and MM:SS timer
  - Tap stop → voice bubble sent, appears right-aligned with play/pause + waveform + duration
  - Tap play → audio plays; tap again → pauses; finishes → button resets
  - Unsupported message types still show grey italic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)