### PR TITLE
feat: Product messages command implementation

### DIFF
--- a/web-sdk/src/chat.ts
+++ b/web-sdk/src/chat.ts
@@ -2,4 +2,9 @@
 
 export { default as YaloChatClient } from './data/services/client/yalo-chat-client';
 export type { YaloChatClientConfig } from './domain/config/chat-config';
+export {
+  ChatCommands,
+  type ChatCommand,
+  type ChatCommandCallback,
+} from './domain/models/command/chat-command';
 export { YaloChatWindow } from './ui/chat/chat-window/yalo-chat-window';

--- a/web-sdk/src/data/services/client/yalo-chat-client.test.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
 import type { YaloChatWindow } from '@ui/chat/chat-window/yalo-chat-window';
+import type { ChatCommand } from '@domain/models/command/chat-command';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import YaloChatClient from './yalo-chat-client';
 
@@ -118,6 +119,61 @@ describe('YaloChatClient', () => {
       );
       client.open();
       expect(targetEl.classList.contains('open')).toBe(true);
+    });
+  });
+
+  describe('registerCommand', () => {
+    it('stores the command and passes it to the chat window after init', async () => {
+      const client = new YaloChatClient(baseConfig);
+      const callback = vi.fn();
+      client.registerCommand('addToCart', callback);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      expect(getChatWindow().commands.get('addToCart')).toBe(callback);
+    });
+
+    it('updates the chat window when registering after init', async () => {
+      const client = new YaloChatClient(baseConfig);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      const callback = vi.fn();
+      client.registerCommand('removeFromCart', callback);
+      expect(getChatWindow().commands.get('removeFromCart')).toBe(callback);
+    });
+
+    it('allows registering multiple commands', async () => {
+      const client = new YaloChatClient(baseConfig);
+      const addCallback = vi.fn();
+      const removeCallback = vi.fn();
+      client.registerCommand('addToCart', addCallback);
+      client.registerCommand('removeFromCart', removeCallback);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      expect(getChatWindow().commands).toMatchObject(
+        new Map<ChatCommand, unknown>([
+          ['addToCart', addCallback],
+          ['removeFromCart', removeCallback],
+        ])
+      );
+    });
+
+    it('overwrites a previously registered command', async () => {
+      const client = new YaloChatClient(baseConfig);
+      const first = vi.fn();
+      const second = vi.fn();
+      client.registerCommand('clearCart', first);
+      client.registerCommand('clearCart', second);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      expect(getChatWindow().commands.get('clearCart')).toBe(second);
     });
   });
 

--- a/web-sdk/src/data/services/client/yalo-chat-client.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.ts
@@ -6,11 +6,16 @@ import {
   defaultIcons,
   type YaloChatClientConfig,
 } from '@domain/config/chat-config';
+import type {
+  ChatCommand,
+  ChatCommandCallback,
+} from '@domain/models/command/chat-command';
 
 export default class YaloChatClient {
   private config: YaloChatClientConfig;
   chatWindowEl: YaloChatWindow | null = null;
   private targetEl: HTMLElement | null = null;
+  private _commands = new Map<ChatCommand, ChatCommandCallback>();
 
   constructor(config: YaloChatClientConfig) {
     this.config = {
@@ -27,6 +32,7 @@ export default class YaloChatClient {
       'yalo-chat-window'
     ) as YaloChatWindow;
     this.chatWindowEl.config = this.config;
+    this.chatWindowEl.commands = new Map(this._commands);
     document.body.appendChild(this.chatWindowEl);
 
     this.targetEl = document.getElementById(this.config.target);
@@ -79,5 +85,12 @@ export default class YaloChatClient {
   close(): void {
     if (this.chatWindowEl) this.chatWindowEl.open = false;
     this.targetEl?.classList.remove('open');
+  }
+
+  registerCommand(command: ChatCommand, callback: ChatCommandCallback): void {
+    this._commands.set(command, callback);
+    if (this.chatWindowEl) {
+      this.chatWindowEl.commands = new Map(this._commands);
+    }
   }
 }

--- a/web-sdk/src/domain/models/command/chat-command.ts
+++ b/web-sdk/src/domain/models/command/chat-command.ts
@@ -1,0 +1,14 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+// Client -> Channel commands
+export const ChatCommands = [
+  'addToCart',
+  'removeFromCart',
+  'clearCart',
+  'guidanceCard',
+  'addPromotion',
+] as const;
+
+export type ChatCommand = (typeof ChatCommands)[number];
+
+export type ChatCommandCallback = (payload: unknown) => void;

--- a/web-sdk/src/ui/chat/chat-message-list/chat-message-list.test.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/chat-message-list.test.ts
@@ -688,6 +688,178 @@ describe('ChatMessageList', () => {
     });
   });
 
+  describe('product quantity commands', () => {
+    it('clicking + emits a positive delta mapped to addToCart', async () => {
+      const list = await renderList([
+        ChatMessage.product({
+          id: 60,
+          role: 'AGENT',
+          timestamp,
+          products: [buildProduct({ sku: 'beer-sku', unitsAdded: 2 })],
+        }),
+      ]);
+
+      const listener = vi.fn();
+      list.addEventListener('yalo-chat-product-quantity-change', listener);
+
+      const card = await getProductCard(list);
+      const input =
+        card.shadowRoot!.querySelector<LitElement>('numeric-input')!;
+      await input.updateComplete;
+      const buttons =
+        input.shadowRoot!.querySelectorAll<HTMLButtonElement>('button');
+
+      buttons[1].click(); // +
+
+      const detail = (listener.mock.calls[0][0] as CustomEvent).detail;
+      expect(detail).toMatchObject({
+        sku: 'beer-sku',
+        unitType: 'unit',
+        value: 3,
+      });
+      // delta = 3 - 2 = 1 > 0 → addToCart
+      expect(detail.value).toBeGreaterThan(2);
+    });
+
+    it('clicking - emits a negative delta mapped to removeFromCart', async () => {
+      const list = await renderList([
+        ChatMessage.product({
+          id: 61,
+          role: 'AGENT',
+          timestamp,
+          products: [buildProduct({ sku: 'beer-sku', unitsAdded: 3 })],
+        }),
+      ]);
+
+      const listener = vi.fn();
+      list.addEventListener('yalo-chat-product-quantity-change', listener);
+
+      const card = await getProductCard(list);
+      const input =
+        card.shadowRoot!.querySelector<LitElement>('numeric-input')!;
+      await input.updateComplete;
+      const buttons =
+        input.shadowRoot!.querySelectorAll<HTMLButtonElement>('button');
+
+      buttons[0].click(); // -
+
+      const detail = (listener.mock.calls[0][0] as CustomEvent).detail;
+      expect(detail).toMatchObject({
+        sku: 'beer-sku',
+        unitType: 'unit',
+        value: 2,
+      });
+      // delta = 2 - 3 = -1 < 0 → removeFromCart
+      expect(detail.value).toBeLessThan(3);
+    });
+
+    it('clicking - at zero does not emit, resulting in no command', async () => {
+      const list = await renderList([
+        ChatMessage.product({
+          id: 62,
+          role: 'AGENT',
+          timestamp,
+          products: [buildProduct({ sku: 'beer-sku', unitsAdded: 0 })],
+        }),
+      ]);
+
+      const listener = vi.fn();
+      list.addEventListener('yalo-chat-product-quantity-change', listener);
+
+      const card = await getProductCard(list);
+      const input =
+        card.shadowRoot!.querySelector<LitElement>('numeric-input')!;
+      await input.updateComplete;
+      const buttons =
+        input.shadowRoot!.querySelectorAll<HTMLButtonElement>('button');
+
+      buttons[0].click(); // -
+
+      // No event emitted → delta = 0 → no command triggered
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('clicking + on subunits emits a positive delta mapped to addToCart', async () => {
+      const list = await renderList([
+        ChatMessage.product({
+          id: 63,
+          role: 'AGENT',
+          timestamp,
+          products: [
+            buildProduct({
+              sku: 'beer-sku',
+              unitsAdded: 1,
+              subunits: 6,
+              subunitsAdded: 2,
+              subunitName: '{amount, plural, one {bottle} other {bottles}}',
+            }),
+          ],
+        }),
+      ]);
+
+      const listener = vi.fn();
+      list.addEventListener('yalo-chat-product-quantity-change', listener);
+
+      const card = await getProductCard(list);
+      const inputs =
+        card.shadowRoot!.querySelectorAll<LitElement>('numeric-input');
+      await inputs[1].updateComplete;
+      const subunitButtons =
+        inputs[1].shadowRoot!.querySelectorAll<HTMLButtonElement>('button');
+
+      subunitButtons[1].click(); // + on subunits
+
+      const detail = (listener.mock.calls[0][0] as CustomEvent).detail;
+      expect(detail).toMatchObject({
+        sku: 'beer-sku',
+        unitType: 'subunit',
+        value: 3,
+      });
+      // delta = 3 - 2 = 1 > 0 → addToCart
+      expect(detail.value).toBeGreaterThan(2);
+    });
+
+    it('clicking - on subunits emits a negative delta mapped to removeFromCart', async () => {
+      const list = await renderList([
+        ChatMessage.product({
+          id: 64,
+          role: 'AGENT',
+          timestamp,
+          products: [
+            buildProduct({
+              sku: 'beer-sku',
+              unitsAdded: 1,
+              subunits: 6,
+              subunitsAdded: 3,
+              subunitName: '{amount, plural, one {bottle} other {bottles}}',
+            }),
+          ],
+        }),
+      ]);
+
+      const listener = vi.fn();
+      list.addEventListener('yalo-chat-product-quantity-change', listener);
+
+      const card = await getProductCard(list);
+      const inputs =
+        card.shadowRoot!.querySelectorAll<LitElement>('numeric-input');
+      await inputs[1].updateComplete;
+      const subunitButtons =
+        inputs[1].shadowRoot!.querySelectorAll<HTMLButtonElement>('button');
+
+      subunitButtons[0].click(); // - on subunits
+
+      const detail = (listener.mock.calls[0][0] as CustomEvent).detail;
+      expect(detail).toMatchObject({
+        sku: 'beer-sku',
+        unitType: 'subunit',
+        value: 2,
+      });
+      // delta = 2 - 3 = -1 < 0 → removeFromCart
+      expect(detail.value).toBeLessThan(3);
+    });
+  });
+
   describe('buttons interaction', () => {
     it('dispatches yalo-chat-send-text-message with button text when clicked', async () => {
       const list = await renderList([

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -4,6 +4,7 @@ import type { ReactiveController } from 'lit';
 import type { YaloChatWindow } from './yalo-chat-window';
 import { ChatMessage } from '@domain/models/chat-message/chat-message';
 import type { ChangeQuantity } from '@domain/models/chat-events/change-quantity';
+import type { ChatCommand } from '@domain/models/command/chat-command';
 import type { PageInfo } from '@domain/common/page';
 import { ChatMessageRepositoryLocal } from '@data/repositories/chat-message/chat-message-repository-local';
 import { YaloMessageRepositoryRemote } from '@data/repositories/yalo-message/yalo-message-repository-remote';
@@ -266,14 +267,41 @@ export default class YaloChatWindowController implements ReactiveController {
 
     const result =
       await this.host.chatMessageRepository.replaceChatMessage(updatedMessage);
-    if (result.ok) {
-      this.chatMessages = [...this.chatMessages];
-      this.chatMessages[messageIndex] = updatedMessage;
-      this.host.requestUpdate();
-    } else {
+    if (!result.ok) {
       this.host.logger.error('Unable to update product quantity', {
         error: result.error,
       });
+      return;
+    }
+
+    this.chatMessages = [...this.chatMessages];
+    this.chatMessages[messageIndex] = updatedMessage;
+    this.host.requestUpdate();
+
+    const previousValue =
+      unitType === 'unit' ? product.unitsAdded : product.subunitsAdded;
+    const newValue = Math.max(value, 0);
+    const delta = newValue - previousValue;
+
+    if (delta > 0) {
+      const addToCart = this.host.commands.get('addToCart');
+      if (addToCart) {
+        this.host.logger.debug('Executing addToCart command', { sku, quantity: delta });
+        addToCart({ sku, quantity: delta });
+      } else {
+        this.host.logger.debug('Sending addToCart to repository', { sku, quantity: delta });
+        await this.host.yaloMessageRepository.addToCart(sku, delta);
+      }
+    } else if (delta < 0) {
+      const quantity = Math.abs(delta);
+      const removeFromCart = this.host.commands.get('removeFromCart');
+      if (removeFromCart) {
+        this.host.logger.debug('Executing removeFromCart command', { sku, quantity });
+        removeFromCart({ sku, quantity });
+      } else {
+        this.host.logger.debug('Sending removeFromCart to repository', { sku, quantity });
+        await this.host.yaloMessageRepository.removeFromCart(sku, quantity);
+      }
     }
   }
 
@@ -318,6 +346,15 @@ export default class YaloChatWindowController implements ReactiveController {
       this.host.requestUpdate();
     }
   };
+
+  executeCommand(command: ChatCommand, payload: unknown): void {
+    const callback = this.host.commands.get(command);
+    if (callback) {
+      callback(payload);
+    } else {
+      this.host.logger.warn(`No handler registered for command: ${command}`);
+    }
+  }
 
   hostDisconnected() {
     clearTimeout(this._writingTimeout);

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
@@ -1,6 +1,10 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
 import type { YaloChatClientConfig } from '@domain/config/chat-config';
+import type {
+  ChatCommand,
+  ChatCommandCallback,
+} from '@domain/models/command/chat-command';
 import { css, html, LitElement } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
@@ -85,6 +89,9 @@ export class YaloChatWindow extends LitElement {
 
   @provide({ context: yaloMediaServiceContext })
   yaloMediaService!: YaloMediaService;
+
+  @property({ attribute: false })
+  commands = new Map<ChatCommand, ChatCommandCallback>();
 
   private _chatWindowController = new YaloChatWindowController(this);
 


### PR DESCRIPTION
- Product messages now send commands to adapter. If a client registers their own command, their registered command takes precedence over the one defined in yalo-message-repository.