### PR TITLE
fix: Use last message timestamp for since parameter

### DIFF
--- a/web-sdk/src/data/repositories/yalo-message/yalo-message-repository-remote.test.ts
+++ b/web-sdk/src/data/repositories/yalo-message/yalo-message-repository-remote.test.ts
@@ -1090,6 +1090,72 @@ describe('YaloMessageRepositoryRemote', () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
+    it('uses Date.now() - 5000 for since on the first poll', async () => {
+      const fetchSpy = mockOkFetch([]);
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+
+      const repo = new YaloMessageRepositoryRemote(
+        'https://api.example.com',
+        baseConfig,
+        mockTokenRepository(token),
+        mockMediaService()
+      );
+      repo.subscribeToMessages(vi.fn());
+
+      await flushPoll();
+
+      const url = new URL(fetchSpy.mock.calls[0][0] as string);
+      expect(url.searchParams.get('since')).toBe(String(Date.now() - 5000));
+    });
+
+    it('uses the last received message timestamp for since on subsequent polls', async () => {
+      const firstBatch = [
+        makePollItem('msg-1', 'older', new Date('2026-06-01T12:00:00Z')),
+        makePollItem('msg-2', 'newest', new Date('2026-06-01T12:00:05Z')),
+      ];
+      const fetchSpy = mockOkFetch(firstBatch);
+      vi.stubGlobal('fetch', fetchSpy);
+
+      const repo = new YaloMessageRepositoryRemote(
+        'https://api.example.com',
+        baseConfig,
+        mockTokenRepository(token),
+        mockMediaService()
+      );
+      repo.subscribeToMessages(vi.fn());
+
+      await flushPoll();
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const secondUrl = new URL(fetchSpy.mock.calls[1][0] as string);
+      expect(secondUrl.searchParams.get('since')).toBe(
+        String(new Date('2026-06-01T12:00:05Z').getTime())
+      );
+    });
+
+    it('falls back to Date.now() - 5000 when polled items have no date', async () => {
+      const items = [makePollItem('msg-1', 'no date')];
+      const fetchSpy = mockOkFetch(items);
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.setSystemTime(new Date('2026-06-01T00:00:00Z'));
+
+      const repo = new YaloMessageRepositoryRemote(
+        'https://api.example.com',
+        baseConfig,
+        mockTokenRepository(token),
+        mockMediaService()
+      );
+      repo.subscribeToMessages(vi.fn());
+
+      await flushPoll();
+      await vi.advanceTimersByTimeAsync(2000);
+
+      const secondSince = new URL(fetchSpy.mock.calls[1][0] as string)
+        .searchParams.get('since');
+      expect(secondSince).toBe(String(Date.now() - 5000));
+    });
+
     it('schedules the next poll after the interval', async () => {
       const fetchSpy = mockOkFetch([]);
       vi.stubGlobal('fetch', fetchSpy);
@@ -1345,6 +1411,33 @@ describe('YaloMessageRepositoryRemote', () => {
       // Advance well past the poll interval — no timer should fire
       await vi.advanceTimersByTimeAsync(10_000);
       expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets the since watermark after unsubscribe', async () => {
+      const items = [
+        makePollItem('msg-1', 'Hi', new Date('2026-06-01T12:00:00Z')),
+      ];
+      const fetchSpy = mockOkFetch(items);
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.setSystemTime(new Date('2026-06-02T00:00:00Z'));
+
+      const repo = new YaloMessageRepositoryRemote(
+        'https://api.example.com',
+        baseConfig,
+        mockTokenRepository(token),
+        mockMediaService()
+      );
+      repo.subscribeToMessages(vi.fn());
+      await flushPoll();
+
+      repo.unsubscribeMessages();
+      repo.subscribeToMessages(vi.fn());
+      await flushPoll();
+
+      const lastUrl = new URL(
+        fetchSpy.mock.calls[fetchSpy.mock.calls.length - 1][0] as string
+      );
+      expect(lastUrl.searchParams.get('since')).toBe(String(Date.now() - 5000));
     });
 
     it('clears seen IDs so resubscribing picks up old messages', async () => {

--- a/web-sdk/src/data/repositories/yalo-message/yalo-message-repository-remote.ts
+++ b/web-sdk/src/data/repositories/yalo-message/yalo-message-repository-remote.ts
@@ -30,6 +30,7 @@ export class YaloMessageRepositoryRemote implements YaloMessageRepository {
   private readonly _mediaService: YaloMediaService;
   private _pollTimeout?: ReturnType<typeof setTimeout>;
   private _seenIds = new Set<string>();
+  private _lastMessageTimestamp?: Date;
   private _pollInterval = 2000;
 
   constructor(
@@ -491,9 +492,10 @@ export class YaloMessageRepositoryRemote implements YaloMessageRepository {
       const userId = this._decodeUserId(token);
 
       try {
-        const params = new URLSearchParams({
-          since: String(Math.floor(Date.now() - 5000)),
-        });
+        const since = Math.floor(
+          this._lastMessageTimestamp?.getTime() ?? Date.now() - 5000
+        );
+        const params = new URLSearchParams({ since: String(since) });
         const response = await fetch(
           `${this._baseUrl}/webchat/messages?${params}`,
           {
@@ -511,6 +513,16 @@ export class YaloMessageRepositoryRemote implements YaloMessageRepository {
 
         const json = (await response.json()) as Array<unknown>;
         const data = json.map((item) => PollMessageItem.fromJSON(item));
+
+        for (const item of data) {
+          if (
+            item.date &&
+            (!this._lastMessageTimestamp ||
+              item.date > this._lastMessageTimestamp)
+          ) {
+            this._lastMessageTimestamp = item.date;
+          }
+        }
 
         const newMessages = data
           .filter((item) => !this._seenIds.has(item.id) && item.message != null)
@@ -535,6 +547,7 @@ export class YaloMessageRepositoryRemote implements YaloMessageRepository {
     clearTimeout(this._pollTimeout);
     this._pollTimeout = undefined;
     this._seenIds.clear();
+    this._lastMessageTimestamp = undefined;
   }
 
   private _toDomainProduct(p: ProtoProduct): Product {


### PR DESCRIPTION
- Use last message timestamp for since parameter instead of fetching last 5s to prevent skipping messages in between.