### PR TITLE
feat(ios/android): M7 — ChatTheme + Markdown in agent messages + Flutter parity (FDE-150)

### DIFF
--- a/android-sdk/gradle/libs.versions.toml
+++ b/android-sdk/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ hilt = "2.56"
 junit = "4.13.2"
 coil = "3.0.4"
 protobuf = "4.29.3"
+markdownRenderer = "0.35.0"
 
 [libraries]
 # Compose
@@ -67,6 +68,10 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 # Coil — async image loading
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+
+# Markdown rendering — Compose-native CommonMark renderer (Apache 2.0 + MIT)
+markdown-renderer = { group = "com.mikepenz", name = "multiplatform-markdown-renderer", version.ref = "markdownRenderer" }
+markdown-renderer-m3 = { group = "com.mikepenz", name = "multiplatform-markdown-renderer-m3", version.ref = "markdownRenderer" }
 
 # Protobuf — generated data classes from sdk_message.proto (javalite = Android-optimised runtime)
 protobuf-kotlin-lite = { group = "com.google.protobuf", name = "protobuf-kotlin-lite", version.ref = "protobuf" }

--- a/android-sdk/sdk/build.gradle.kts
+++ b/android-sdk/sdk/build.gradle.kts
@@ -71,6 +71,11 @@ kotlin {
             // for HTTP/HTTPS URLs; coil-compose alone only handles local files and drawables).
             implementation(libs.coil.compose)
             implementation(libs.coil.network.okhttp)
+
+            // Markdown — Compose-native CommonMark renderer for agent messages.
+            // Mirrors flutter_markdown_plus used by the Flutter SDK's AssistantMessage widget.
+            implementation(libs.markdown.renderer)
+            implementation(libs.markdown.renderer.m3)
         }
 
         iosMain.dependencies {

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
@@ -71,7 +71,7 @@ internal fun ChatAppBar(
                     ) {
                         Text(
                             text = statusText,
-                            style = MaterialTheme.typography.bodySmall,
+                            style = theme.messageFooterStyle,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -37,6 +37,9 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import coil3.compose.AsyncImage
+import com.mikepenz.markdown.m3.Markdown
+import com.mikepenz.markdown.m3.markdownColor
+import com.mikepenz.markdown.m3.markdownTypography
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageType
@@ -103,10 +106,27 @@ internal fun MessageItem(
             Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                 when (message.type) {
                     MessageType.Text,
-                    MessageType.QuickReply -> Text(
-                        text = message.content,
-                        style = messageTextStyle,
-                    )
+                    MessageType.QuickReply -> if (isUser) {
+                        Text(
+                            text = message.content,
+                            style = messageTextStyle,
+                        )
+                    } else {
+                        // Agent messages render CommonMark — mirrors Flutter's flutter_markdown_plus.
+                        // Links open via LocalUriHandler (system browser), same as Flutter's
+                        // LaunchMode.externalApplication.
+                        Markdown(
+                            content = message.content,
+                            colors = markdownColor(
+                                text = messageTextStyle.color.takeOrElse { contentColor },
+                            ),
+                            typography = markdownTypography(
+                                paragraph = messageTextStyle,
+                                text = messageTextStyle,
+                            ),
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                     MessageType.Image -> AsyncImage(
                         // fileName holds the local file path for user-sent images (set by
                         // sendImageMessage). content holds the URL for agent/server images.

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -42,6 +42,7 @@ import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 import kotlinx.coroutines.Dispatchers
@@ -96,7 +97,18 @@ internal fun MessageItem(
             .fillMaxWidth()
             .padding(horizontal = 8.dp, vertical = 4.dp),
         horizontalArrangement = if (isUser) Arrangement.End else Arrangement.Start,
+        verticalAlignment = Alignment.Bottom,
     ) {
+        if (isUser && message.status == MessageStatus.ERROR) {
+            androidx.compose.material3.Icon(
+                imageVector = theme.errorIcon,
+                contentDescription = "Send failed",
+                tint = theme.errorColor,
+                modifier = Modifier
+                    .size(16.dp)
+                    .padding(end = 4.dp),
+            )
+        }
         Surface(
             shape = theme.bubbleShape,
             color = bubbleColor,
@@ -119,6 +131,7 @@ internal fun MessageItem(
                             content = message.content,
                             colors = markdownColor(
                                 text = messageTextStyle.color.takeOrElse { contentColor },
+                                linkText = theme.expandControlsStyle.color,
                             ),
                             typography = markdownTypography(
                                 paragraph = messageTextStyle,
@@ -176,6 +189,7 @@ private fun VideoMessageItem(
     message: ChatMessage,
     messageTextStyle: androidx.compose.ui.text.TextStyle,
 ) {
+    val theme = LocalChatTheme.current
     var thumbnail by remember { mutableStateOf<ImageBitmap?>(null) }
     var showPlayer by remember { mutableStateOf(false) }
 
@@ -227,7 +241,7 @@ private fun VideoMessageItem(
                     Box(
                         modifier = Modifier
                             .matchParentSize()
-                            .background(Color(0xFF1A1A1A)),
+                            .background(theme.imagePlaceholderBackgroundColor),
                     )
                 }
                 androidx.compose.material3.Icon(

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCard.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCard.kt
@@ -11,21 +11,25 @@ package com.yalo.chat.sdk.ui.chat
 // ProductVerticalCard — image top, details below (Column layout).
 //   Used by ProductCarouselMessage (horizontal carousel).
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
@@ -38,19 +42,26 @@ import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 @Composable
 private fun ProductPriceRow(product: Product) {
     val theme = LocalChatTheme.current
-    Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
-        androidx.compose.material3.Icon(
-            imageVector = theme.currencyIcon,
-            contentDescription = null,
-            tint = theme.currencyIconColor,
-            modifier = Modifier.size(16.dp),
-        )
-        val displayPrice = product.salePrice ?: product.price
-        Text(
-            text = formatPrice(displayPrice),
-            style = theme.productPriceStyle,
-            modifier = Modifier.padding(start = 2.dp),
-        )
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .background(theme.productPriceBackgroundColor, RoundedCornerShape(4.dp))
+                .padding(horizontal = 6.dp, vertical = 2.dp),
+        ) {
+            Icon(
+                imageVector = theme.currencyIcon,
+                contentDescription = null,
+                tint = theme.currencyIconColor,
+                modifier = Modifier.size(16.dp),
+            )
+            val displayPrice = product.salePrice ?: product.price
+            Text(
+                text = formatPrice(displayPrice),
+                style = theme.productPriceStyle,
+                modifier = Modifier.padding(start = 2.dp),
+            )
+        }
         if (product.salePrice != null) {
             Spacer(Modifier.width(4.dp))
             Text(
@@ -69,15 +80,27 @@ private fun ProductImage(
     modifier: Modifier = Modifier,
 ) {
     val theme = LocalChatTheme.current
-    AsyncImage(
-        model = imagesUrl.firstOrNull(),
-        contentDescription = "Product image",
-        contentScale = ContentScale.Crop,
-        modifier = modifier
-            .clip(RoundedCornerShape(8.dp)),
-        placeholder = ColorPainter(theme.imagePlaceholderBackgroundColor),
-        error = ColorPainter(theme.imagePlaceholderBackgroundColor),
-    )
+    Box(modifier = modifier.clip(RoundedCornerShape(8.dp))) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .fillMaxSize()
+                .background(theme.imagePlaceholderBackgroundColor),
+        ) {
+            Icon(
+                imageVector = theme.imagePlaceholderIcon,
+                contentDescription = null,
+                tint = theme.imagePlaceholderIconColor,
+                modifier = Modifier.size(32.dp),
+            )
+        }
+        AsyncImage(
+            model = imagesUrl.firstOrNull(),
+            contentDescription = "Product image",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.matchParentSize(),
+        )
+    }
 }
 
 // ── ProductHorizontalCard (image left | details right) ────────────────────────

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.filled.AttachMoney
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Error
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.Mic
 import androidx.compose.material.icons.filled.Pause
@@ -58,7 +59,7 @@ data class ChatTheme(
     val waveColor: Color = Color(0xFF5C5EE8),
     val actionIconColor: Color = Color(0xFF000000),
     val cancelRecordingIconColor: Color = Color(0xFF7C8086),
-    /** Close icon color in ImagePreview. Defaults to white for contrast on the dark scrim. */
+    /** Close icon color in ImagePreview — defaults to white for contrast on the 85% black scrim. */
     val closeModalIconColor: Color = Color(0xFFFFFFFF),
     val playAudioIconColor: Color = Color(0xFF7C8086),
     val pauseAudioIconColor: Color = Color(0xFF7C8086),
@@ -66,22 +67,23 @@ data class ChatTheme(
     val cameraIconColor: Color = Color(0xFF7C8086),
     val galleryIconColor: Color = Color(0xFF7C8086),
     val trashIconColor: Color = Color(0xFF7C8086),
-    val currencyIconColor: Color = Color(0xFF2207F1),
+    val currencyIconColor: Color = Color(0xFF186C54),
     val numericControlIconColor: Color = Color(0xFF7C8086),
     val imagePlaceholderIconColor: Color = Color(0xFF7C8086),
     val imagePlaceholderBackgroundColor: Color = Color(0xFFF9FAFC),
     /** Background of product cards in the product carousel. */
     val cardBackgroundColor: Color = Color(0xFFFFFFFF),
     /** Border color of product cards. */
-    val cardBorderColor: Color = Color(0xFFE8E8E8),
+    val cardBorderColor: Color = Color(0xFFDDE4EC),
     /** Background of the attachment picker bottom sheet. */
     val attachmentPickerBackgroundColor: Color = Color(0xFFF1F5FC),
     /** Background color for sale/discount price chips on product cards. */
-    val productPriceBackgroundColor: Color = Color(0xFFEEF0FF),
+    val productPriceBackgroundColor: Color = Color(0xFFECFDF5),
     /** Text color for the per-subunit price label on product cards. */
     val pricePerSubunitColor: Color = Color(0xFF7C8086),
     /** Color for message timestamps and footer text — mirrors Flutter's messageFooterColor. */
     val messageFooterColor: Color = Color(0xFF7C8086),
+    val errorColor: Color = Color(0xFFE53935),
     /** Border color of the picker buttons in the attachment sheet. */
     val pickerButtonBorderColor: Color = Color(0xFFE8E8E8),
     /** Background of quick reply chip buttons. */
@@ -117,7 +119,7 @@ data class ChatTheme(
     val buttonsMessageButtonTextStyle: TextStyle = TextStyle(color = Color(0xFF111111)),
     val productTitleStyle: TextStyle = TextStyle(color = Color(0xFF000000), fontSize = 16.sp, fontWeight = FontWeight.Bold),
     val productSubunitsStyle: TextStyle = TextStyle(color = Color(0xFF7C8086), fontSize = 12.sp),
-    val productPriceStyle: TextStyle = TextStyle(color = Color(0xFF2207F1), fontWeight = FontWeight.Bold),
+    val productPriceStyle: TextStyle = TextStyle(color = Color(0xFF186C54), fontWeight = FontWeight.Bold),
     val productSalePriceStrikeStyle: TextStyle = TextStyle(color = Color(0xFFBEBEBE), textDecoration = TextDecoration.LineThrough),
     val pricePerSubunitStyle: TextStyle = TextStyle(color = Color(0xFF7C8086)),
     val expandControlsStyle: TextStyle = TextStyle(color = Color(0xFF2207F1)),
@@ -144,6 +146,7 @@ data class ChatTheme(
     val galleryIcon: ImageVector = Icons.Filled.Image,
     val trashIcon: ImageVector = Icons.Filled.Delete,
     val imagePlaceholderIcon: ImageVector = Icons.Filled.Image,
+    val errorIcon: ImageVector = Icons.Filled.Error,
     val shopIcon: ImageVector = Icons.Filled.Storefront,
     val cartIcon: ImageVector = Icons.Filled.ShoppingCart,
     val currencyIcon: ImageVector = Icons.Filled.AttachMoney,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/theme/ChatTheme.kt
@@ -80,6 +80,8 @@ data class ChatTheme(
     val productPriceBackgroundColor: Color = Color(0xFFEEF0FF),
     /** Text color for the per-subunit price label on product cards. */
     val pricePerSubunitColor: Color = Color(0xFF7C8086),
+    /** Color for message timestamps and footer text — mirrors Flutter's messageFooterColor. */
+    val messageFooterColor: Color = Color(0xFF7C8086),
     /** Border color of the picker buttons in the attachment sheet. */
     val pickerButtonBorderColor: Color = Color(0xFFE8E8E8),
     /** Background of quick reply chip buttons. */

--- a/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
+++ b/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
@@ -7,19 +7,21 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05EC6220E4CB1538B732F344 /* ProductCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A15C5E70CA427D78455A0813 /* ProductCarouselView.swift */; };
+		1CA7117B4899F43F28A9826F /* ChatAppBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6D254CEAF7AAB2C559BD85 /* ChatAppBar.swift */; };
 		1F144E784B4B0E906FE68740 /* ChatInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23407D6589CAA8A5F7913634 /* ChatInput.swift */; };
-		A1B2C3D4E5F601020304A5B6 /* QuickRepliesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F601020304A5B6A1 /* QuickRepliesView.swift */; };
-		C3D4E5F601020304A5B6A1B2 /* ProductQuantityStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F601020304A5B6A1B2C3 /* ProductQuantityStepper.swift */; };
-		E5F601020304A5B6A1B2C3D4 /* ProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F601020304A5B6A1B2C3D4E5 /* ProductCard.swift */; };
-		A7B8C9D001020304A5B6C3D4 /* ProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C9D001020304A5B6C3D4A7 /* ProductListView.swift */; };
-		C9D001020304A5B6C3D4A7B8 /* ProductCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D001020304A5B6C3D4A7B8C9 /* ProductCarouselView.swift */; };
 		293282042EBD6BFA90E3A048 /* ChatSdk.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */; };
+		298C9277BFCC3894687B6572 /* ProductCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EF71DFCB68275F5614937DD /* ProductCard.swift */; };
 		322A00049C2FC71AD22F25E1 /* MessagesObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F820AEACBF2AB583B73D583F /* MessagesObservable.swift */; };
 		3B6D0B8DF56C3C234BB333F7 /* ChatSdk.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4C742AB16C89C1739033D236 /* ProductListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D263572F6DC2DB3526C49426 /* ProductListView.swift */; };
+		545EDBDC5656A750127042E0 /* ProductQuantityStepper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F7447D495754EA6F9EF3ED /* ProductQuantityStepper.swift */; };
 		674DB9AB8BB94548B4659911 /* YaloChatDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */; };
 		68B260F91753D81C4891F80D /* MessageList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDF775B29AF50036FBF2DD96 /* MessageList.swift */; };
 		6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C966BE803A724D942922CAA /* YaloChat.swift */; };
+		7DBD15E184CA198AD1FCA13C /* QuickRepliesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 76EFDDD9FA2A601F6106103B /* QuickRepliesView.swift */; };
 		839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D563B68F202040D37D6212 /* MessageItem.swift */; };
+		A81CB6A93AB6D6DADE6559DD /* ChatTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4128F8CE7D0D35F336D2DAC2 /* ChatTheme.swift */; };
 		AA69F96977B9913EF39272DD /* ImageObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 192FC4739922F8D122901DB5 /* ImageObservable.swift */; };
 		D26FBEBB44B22F7370ED0CFF /* ImagePreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3435CA5533A84581B92E052 /* ImagePreview.swift */; };
 		E2F2085FD79C697C9C902DC8 /* WaveformRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */; };
@@ -47,28 +49,30 @@
 
 /* Begin PBXFileReference section */
 		05D563B68F202040D37D6212 /* MessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageItem.swift; sourceTree = "<group>"; };
+		0EF71DFCB68275F5614937DD /* ProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCard.swift; sourceTree = "<group>"; };
 		192FC4739922F8D122901DB5 /* ImageObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageObservable.swift; sourceTree = "<group>"; };
 		23407D6589CAA8A5F7913634 /* ChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInput.swift; sourceTree = "<group>"; };
 		34E80F747F4EC2822662317B /* YaloChatDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = YaloChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4128F8CE7D0D35F336D2DAC2 /* ChatTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTheme.swift; sourceTree = "<group>"; };
 		43FDB5E608E371946FE0DFC6 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
 		49B107D91D1AC4FB50301691 /* ChatSdk.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = ChatSdk.xcframework; path = "../android-sdk/sdk/build/XCFrameworks/release/ChatSdk.xcframework"; sourceTree = "<group>"; };
+		4D6D254CEAF7AAB2C559BD85 /* ChatAppBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatAppBar.swift; sourceTree = "<group>"; };
 		6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformRecorder.swift; sourceTree = "<group>"; };
 		6C966BE803A724D942922CAA /* YaloChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChat.swift; sourceTree = "<group>"; };
+		75F7447D495754EA6F9EF3ED /* ProductQuantityStepper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductQuantityStepper.swift; sourceTree = "<group>"; };
+		76EFDDD9FA2A601F6106103B /* QuickRepliesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickRepliesView.swift; sourceTree = "<group>"; };
 		83913A0C24BC4B8FD220EB07 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		8FCF82F16CCFF7E3A3D06DB5 /* Credentials.swift.example */ = {isa = PBXFileReference; path = Credentials.swift.example; sourceTree = "<group>"; };
+		A15C5E70CA427D78455A0813 /* ProductCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCarouselView.swift; sourceTree = "<group>"; };
 		A3502AF3994D977BB2687443 /* YaloChatDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChatDemoApp.swift; sourceTree = "<group>"; };
 		B4AE3EAFF0C8C544F642946C /* WaveformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformView.swift; sourceTree = "<group>"; };
 		BA6524E179EB88397E204954 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		BF05C7967323A2B01F9565F3 /* AudioObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioObservable.swift; sourceTree = "<group>"; };
 		CDF775B29AF50036FBF2DD96 /* MessageList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageList.swift; sourceTree = "<group>"; };
+		D263572F6DC2DB3526C49426 /* ProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListView.swift; sourceTree = "<group>"; };
 		D3435CA5533A84581B92E052 /* ImagePreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePreview.swift; sourceTree = "<group>"; };
 		EAE541740117006132C1A380 /* Credentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Credentials.swift; sourceTree = "<group>"; };
 		F820AEACBF2AB583B73D583F /* MessagesObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesObservable.swift; sourceTree = "<group>"; };
-		B2C3D4E5F601020304A5B6A1 /* QuickRepliesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickRepliesView.swift; sourceTree = "<group>"; };
-		D4E5F601020304A5B6A1B2C3 /* ProductQuantityStepper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductQuantityStepper.swift; sourceTree = "<group>"; };
-		F601020304A5B6A1B2C3D4E5 /* ProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCard.swift; sourceTree = "<group>"; };
-		B8C9D001020304A5B6C3D4A7 /* ProductListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListView.swift; sourceTree = "<group>"; };
-		D001020304A5B6C3D4A7B8C9 /* ProductCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCarouselView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,7 +116,9 @@
 			isa = PBXGroup;
 			children = (
 				BF05C7967323A2B01F9565F3 /* AudioObservable.swift */,
+				4D6D254CEAF7AAB2C559BD85 /* ChatAppBar.swift */,
 				23407D6589CAA8A5F7913634 /* ChatInput.swift */,
+				4128F8CE7D0D35F336D2DAC2 /* ChatTheme.swift */,
 				43FDB5E608E371946FE0DFC6 /* ChatView.swift */,
 				BA6524E179EB88397E204954 /* ContentView.swift */,
 				EAE541740117006132C1A380 /* Credentials.swift */,
@@ -123,11 +129,11 @@
 				05D563B68F202040D37D6212 /* MessageItem.swift */,
 				CDF775B29AF50036FBF2DD96 /* MessageList.swift */,
 				F820AEACBF2AB583B73D583F /* MessagesObservable.swift */,
-				B2C3D4E5F601020304A5B6A1 /* QuickRepliesView.swift */,
-				D4E5F601020304A5B6A1B2C3 /* ProductQuantityStepper.swift */,
-				F601020304A5B6A1B2C3D4E5 /* ProductCard.swift */,
-				B8C9D001020304A5B6C3D4A7 /* ProductListView.swift */,
-				D001020304A5B6C3D4A7B8C9 /* ProductCarouselView.swift */,
+				0EF71DFCB68275F5614937DD /* ProductCard.swift */,
+				A15C5E70CA427D78455A0813 /* ProductCarouselView.swift */,
+				D263572F6DC2DB3526C49426 /* ProductListView.swift */,
+				75F7447D495754EA6F9EF3ED /* ProductQuantityStepper.swift */,
+				76EFDDD9FA2A601F6106103B /* QuickRepliesView.swift */,
 				6050C732AE9CA9075FBE4A23 /* WaveformRecorder.swift */,
 				B4AE3EAFF0C8C544F642946C /* WaveformView.swift */,
 				6C966BE803A724D942922CAA /* YaloChat.swift */,
@@ -210,7 +216,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				F3A87F41CBA199E01A739311 /* AudioObservable.swift in Sources */,
+				1CA7117B4899F43F28A9826F /* ChatAppBar.swift in Sources */,
 				1F144E784B4B0E906FE68740 /* ChatInput.swift in Sources */,
+				A81CB6A93AB6D6DADE6559DD /* ChatTheme.swift in Sources */,
 				EFC453D69C9FCE945A1CE6B7 /* ChatView.swift in Sources */,
 				E65E5168702C7E1DFC950C7C /* ContentView.swift in Sources */,
 				E87B26E53C6C69473298A5A5 /* Credentials.swift in Sources */,
@@ -219,11 +227,11 @@
 				839B1BF06817BB1B18B8356C /* MessageItem.swift in Sources */,
 				68B260F91753D81C4891F80D /* MessageList.swift in Sources */,
 				322A00049C2FC71AD22F25E1 /* MessagesObservable.swift in Sources */,
-				A1B2C3D4E5F601020304A5B6 /* QuickRepliesView.swift in Sources */,
-				C3D4E5F601020304A5B6A1B2 /* ProductQuantityStepper.swift in Sources */,
-				E5F601020304A5B6A1B2C3D4 /* ProductCard.swift in Sources */,
-				A7B8C9D001020304A5B6C3D4 /* ProductListView.swift in Sources */,
-				C9D001020304A5B6C3D4A7B8 /* ProductCarouselView.swift in Sources */,
+				298C9277BFCC3894687B6572 /* ProductCard.swift in Sources */,
+				05EC6220E4CB1538B732F344 /* ProductCarouselView.swift in Sources */,
+				4C742AB16C89C1739033D236 /* ProductListView.swift in Sources */,
+				545EDBDC5656A750127042E0 /* ProductQuantityStepper.swift in Sources */,
+				7DBD15E184CA198AD1FCA13C /* QuickRepliesView.swift in Sources */,
 				E2F2085FD79C697C9C902DC8 /* WaveformRecorder.swift in Sources */,
 				F0D47773279173F7C3093CA2 /* WaveformView.swift in Sources */,
 				6F5A5B00189F413AC54EB39E /* YaloChat.swift in Sources */,

--- a/ios-sdk/YaloChatDemo/ChatAppBar.swift
+++ b/ios-sdk/YaloChatDemo/ChatAppBar.swift
@@ -30,11 +30,11 @@ struct ChatAppBar: View {
                 Text(channelName)
                     .font(.headline)
                     .fontWeight(.semibold)
-                    .foregroundColor(theme.agentBubbleTextColor)
+                    .foregroundColor(theme.actionIconColor)
 
                 if isTyping && !typingStatusText.isEmpty {
                     Text(typingStatusText)
-                        .font(.caption)
+                        .font(theme.messageFooterFont)
                         .foregroundColor(theme.messageFooterColor)
                         .transition(.opacity.combined(with: .move(edge: .top)))
                 }

--- a/ios-sdk/YaloChatDemo/ChatAppBar.swift
+++ b/ios-sdk/YaloChatDemo/ChatAppBar.swift
@@ -1,0 +1,66 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+// Port of android-sdk ChatAppBar.kt and Flutter ChatAppBar widget.
+// Shows channel avatar (optional), channel name, animated typing status,
+// and optional shop/cart action buttons.
+
+import SwiftUI
+
+struct ChatAppBar: View {
+
+    let channelName: String
+    let typingStatusText: String
+    let isTyping: Bool
+    var onShopPressed: (() -> Void)? = nil
+    var onCartPressed: (() -> Void)? = nil
+
+    @Environment(\.chatTheme) private var theme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            if let iconImage = theme.chatIconImage {
+                iconImage
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: 40, height: 40)
+                    .clipShape(Circle())
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(channelName)
+                    .font(.headline)
+                    .fontWeight(.semibold)
+                    .foregroundColor(theme.agentBubbleTextColor)
+
+                if isTyping && !typingStatusText.isEmpty {
+                    Text(typingStatusText)
+                        .font(.caption)
+                        .foregroundColor(theme.messageFooterColor)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .animation(.easeInOut(duration: 0.25), value: isTyping)
+
+            Spacer()
+
+            if let onShop = onShopPressed {
+                Button(action: onShop) {
+                    Image(systemName: theme.shopIconName)
+                        .foregroundColor(theme.actionIconColor)
+                }
+            }
+
+            if let onCart = onCartPressed {
+                Button(action: onCart) {
+                    Image(systemName: theme.cartIconName)
+                        .foregroundColor(theme.actionIconColor)
+                }
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .frame(maxWidth: .infinity)
+        .background(theme.appBarBackgroundColor)
+        .shadow(color: Color.black.opacity(0.06), radius: 1, x: 0, y: 1)
+    }
+}

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -12,6 +12,8 @@ struct ChatInput: View {
     @ObservedObject var imageObservable: ImageObservable
     @ObservedObject var audioObservable: AudioObservable
 
+    @Environment(\.chatTheme) private var theme
+
     private var isBlank: Bool {
         messagesObservable.userMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -40,16 +42,20 @@ struct ChatInput: View {
                     Button {
                         imageObservable.showSourceSheet = true
                     } label: {
-                        Image(systemName: "paperclip")
-                            .foregroundColor(.secondary)
+                        Image(systemName: theme.attachIconName)
+                            .foregroundColor(theme.messageFooterColor)
                             .padding(.leading, 4)
                     }
 
                     TextField("Type a message…", text: $messagesObservable.userMessage)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)
-                        .background(Color(.systemGray6))
+                        .background(theme.inputBackgroundColor)
                         .cornerRadius(25)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 25)
+                                .stroke(theme.inputBorderColor, lineWidth: 1)
+                        )
                         .onSubmit { messagesObservable.sendMessage() }
 
                     actionButton
@@ -78,18 +84,18 @@ struct ChatInput: View {
     private var actionButton: some View {
         if hasImage || !isBlank {
             Button(action: sendAction) {
-                Image(systemName: "paperplane.fill")
-                    .foregroundColor(.white)
+                Image(systemName: theme.sendIconName)
+                    .foregroundColor(theme.sendButtonIconColor)
                     .padding(10)
-                    .background(Color.accentColor)
+                    .background(theme.sendButtonColor)
                     .clipShape(Circle())
             }
         } else {
             Button(action: audioObservable.startRecording) {
-                Image(systemName: "mic.fill")
-                    .foregroundColor(.white)
+                Image(systemName: theme.micIconName)
+                    .foregroundColor(theme.sendButtonIconColor)
                     .padding(10)
-                    .background(Color.accentColor)
+                    .background(theme.sendButtonColor)
                     .clipShape(Circle())
             }
         }

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -43,7 +43,7 @@ struct ChatInput: View {
                         imageObservable.showSourceSheet = true
                     } label: {
                         Image(systemName: theme.attachIconName)
-                            .foregroundColor(theme.messageFooterColor)
+                            .foregroundColor(theme.attachIconColor)
                             .padding(.leading, 4)
                     }
 

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -1,0 +1,222 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+// Mirrors Flutter's ChatTheme and Android's ChatTheme.
+// Inject via .environment(\.chatTheme, theme) at ChatView root;
+// consume via @Environment(\.chatTheme) in child views.
+// Default values match Flutter SDK's light theme color constants (SdkColors).
+
+import SwiftUI
+
+public struct ChatTheme {
+
+    // MARK: - Backgrounds
+    public var backgroundColor: Color
+    public var appBarBackgroundColor: Color
+
+    // MARK: - User message bubble
+    public var userBubbleColor: Color
+    public var userBubbleTextColor: Color
+
+    // MARK: - Agent message bubble
+    public var agentBubbleColor: Color
+    public var agentBubbleTextColor: Color
+
+    // MARK: - Input bar
+    public var inputBackgroundColor: Color
+    public var inputBorderColor: Color
+
+    // MARK: - Send / mic action button
+    public var sendButtonColor: Color
+    public var sendButtonIconColor: Color
+
+    // MARK: - Audio waveform
+    public var waveformColor: Color
+
+    // MARK: - Quick reply chips
+    public var quickReplyBackgroundColor: Color
+    public var quickReplyBorderColor: Color
+    public var quickReplyTextColor: Color
+
+    // MARK: - Product / message cards
+    public var cardBackgroundColor: Color
+    public var cardBorderColor: Color
+
+    // MARK: - Product pricing
+    public var productPriceColor: Color
+    public var productSalePriceColor: Color
+    public var productPriceBackgroundColor: Color
+    public var pricePerSubunitColor: Color
+    public var imagePlaceholderColor: Color
+
+    // MARK: - CTA message buttons
+    public var ctaButtonColor: Color
+    public var ctaButtonBorderColor: Color
+    public var ctaButtonTextColor: Color
+
+    // MARK: - Buttons message buttons
+    public var buttonsButtonColor: Color
+    public var buttonsButtonBorderColor: Color
+    public var buttonsButtonTextColor: Color
+
+    // MARK: - Icons / footer
+    public var actionIconColor: Color
+    public var messageFooterColor: Color
+    public var expandControlColor: Color
+    public var errorColor: Color
+
+    // MARK: - Fonts
+    public var userMessageFont: Font
+    public var agentMessageFont: Font
+    public var productTitleFont: Font
+    public var productSubunitsFont: Font
+    public var productPriceFont: Font
+    public var messageHeaderFont: Font
+    public var messageFooterFont: Font
+
+    // MARK: - Icon names (SF Symbols)
+    public var sendIconName: String
+    public var micIconName: String
+    public var attachIconName: String
+    public var shopIconName: String
+    public var cartIconName: String
+    public var cancelRecordingIconName: String
+    public var playIconName: String
+    public var pauseIconName: String
+    public var addIconName: String
+    public var removeIconName: String
+    public var ctaArrowIconName: String
+
+    // MARK: - Optional branding
+    public var chatIconImage: Image?
+
+    public init(
+        backgroundColor: Color          = Color(.systemBackground),
+        appBarBackgroundColor: Color     = Color(sdkHex: 0xF1F5FC),
+        userBubbleColor: Color           = Color(sdkHex: 0xF9FAFC),
+        userBubbleTextColor: Color       = Color(.label),
+        agentBubbleColor: Color          = Color(.systemGray5),
+        agentBubbleTextColor: Color      = Color(.label),
+        inputBackgroundColor: Color      = Color(.systemBackground),
+        inputBorderColor: Color          = Color(sdkHex: 0xE8E8E8),
+        sendButtonColor: Color           = Color(sdkHex: 0x2207F1),
+        sendButtonIconColor: Color       = Color(sdkHex: 0xEFF4FF),
+        waveformColor: Color             = Color(sdkHex: 0x5C5EE8),
+        quickReplyBackgroundColor: Color = .clear,
+        quickReplyBorderColor: Color     = Color(sdkHex: 0xECEDEF),
+        quickReplyTextColor: Color       = Color(sdkHex: 0x2207F1),
+        cardBackgroundColor: Color       = Color(.secondarySystemBackground),
+        cardBorderColor: Color           = Color(sdkHex: 0xDDE4EC),
+        productPriceColor: Color         = Color(sdkHex: 0x186C54),
+        productSalePriceColor: Color     = Color(sdkHex: 0x0B996D),
+        productPriceBackgroundColor: Color = Color(sdkHex: 0xECFDF5),
+        pricePerSubunitColor: Color      = Color(sdkHex: 0x334155),
+        imagePlaceholderColor: Color     = Color(sdkHex: 0xF9FAFC),
+        ctaButtonColor: Color            = .clear,
+        ctaButtonBorderColor: Color      = Color(sdkHex: 0xDDE4EC),
+        ctaButtonTextColor: Color        = Color(sdkHex: 0x111111),
+        buttonsButtonColor: Color        = .clear,
+        buttonsButtonBorderColor: Color  = Color(sdkHex: 0xDDE4EC),
+        buttonsButtonTextColor: Color    = Color(sdkHex: 0x111111),
+        actionIconColor: Color           = Color(.label),
+        messageFooterColor: Color        = Color(sdkHex: 0x7C8086),
+        expandControlColor: Color        = Color(sdkHex: 0x2207F1),
+        errorColor: Color                = .red,
+        userMessageFont: Font            = .body,
+        agentMessageFont: Font           = .body,
+        productTitleFont: Font           = .subheadline,
+        productSubunitsFont: Font        = .caption,
+        productPriceFont: Font           = .subheadline,
+        messageHeaderFont: Font          = .subheadline,
+        messageFooterFont: Font          = .caption,
+        sendIconName: String             = "paperplane.fill",
+        micIconName: String              = "mic.fill",
+        attachIconName: String           = "paperclip",
+        shopIconName: String             = "storefront",
+        cartIconName: String             = "cart",
+        cancelRecordingIconName: String  = "xmark.circle.fill",
+        playIconName: String             = "play.fill",
+        pauseIconName: String            = "pause.fill",
+        addIconName: String              = "plus",
+        removeIconName: String           = "minus",
+        ctaArrowIconName: String         = "arrow.right",
+        chatIconImage: Image?            = nil
+    ) {
+        self.backgroundColor = backgroundColor
+        self.appBarBackgroundColor = appBarBackgroundColor
+        self.userBubbleColor = userBubbleColor
+        self.userBubbleTextColor = userBubbleTextColor
+        self.agentBubbleColor = agentBubbleColor
+        self.agentBubbleTextColor = agentBubbleTextColor
+        self.inputBackgroundColor = inputBackgroundColor
+        self.inputBorderColor = inputBorderColor
+        self.sendButtonColor = sendButtonColor
+        self.sendButtonIconColor = sendButtonIconColor
+        self.waveformColor = waveformColor
+        self.quickReplyBackgroundColor = quickReplyBackgroundColor
+        self.quickReplyBorderColor = quickReplyBorderColor
+        self.quickReplyTextColor = quickReplyTextColor
+        self.cardBackgroundColor = cardBackgroundColor
+        self.cardBorderColor = cardBorderColor
+        self.productPriceColor = productPriceColor
+        self.productSalePriceColor = productSalePriceColor
+        self.productPriceBackgroundColor = productPriceBackgroundColor
+        self.pricePerSubunitColor = pricePerSubunitColor
+        self.imagePlaceholderColor = imagePlaceholderColor
+        self.ctaButtonColor = ctaButtonColor
+        self.ctaButtonBorderColor = ctaButtonBorderColor
+        self.ctaButtonTextColor = ctaButtonTextColor
+        self.buttonsButtonColor = buttonsButtonColor
+        self.buttonsButtonBorderColor = buttonsButtonBorderColor
+        self.buttonsButtonTextColor = buttonsButtonTextColor
+        self.actionIconColor = actionIconColor
+        self.messageFooterColor = messageFooterColor
+        self.expandControlColor = expandControlColor
+        self.errorColor = errorColor
+        self.userMessageFont = userMessageFont
+        self.agentMessageFont = agentMessageFont
+        self.productTitleFont = productTitleFont
+        self.productSubunitsFont = productSubunitsFont
+        self.productPriceFont = productPriceFont
+        self.messageHeaderFont = messageHeaderFont
+        self.messageFooterFont = messageFooterFont
+        self.sendIconName = sendIconName
+        self.micIconName = micIconName
+        self.attachIconName = attachIconName
+        self.shopIconName = shopIconName
+        self.cartIconName = cartIconName
+        self.cancelRecordingIconName = cancelRecordingIconName
+        self.playIconName = playIconName
+        self.pauseIconName = pauseIconName
+        self.addIconName = addIconName
+        self.removeIconName = removeIconName
+        self.ctaArrowIconName = ctaArrowIconName
+        self.chatIconImage = chatIconImage
+    }
+}
+
+// MARK: - SwiftUI environment plumbing
+
+struct ChatThemeKey: EnvironmentKey {
+    static let defaultValue = ChatTheme()
+}
+
+extension EnvironmentValues {
+    var chatTheme: ChatTheme {
+        get { self[ChatThemeKey.self] }
+        set { self[ChatThemeKey.self] = newValue }
+    }
+}
+
+// MARK: - Hex color helper (internal — used by ChatTheme defaults and views)
+
+extension Color {
+    // Converts a 24-bit RGB hex value (e.g. 0x2207F1) to a SwiftUI Color.
+    // Named sdkHex to avoid colliding with other hex extensions in consumer apps.
+    init(sdkHex hex: UInt32) {
+        self.init(
+            red:   Double((hex >> 16) & 0xFF) / 255,
+            green: Double((hex >> 8)  & 0xFF) / 255,
+            blue:  Double( hex        & 0xFF) / 255
+        )
+    }
+}

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -212,7 +212,7 @@ extension EnvironmentValues {
 extension Color {
     // Converts a 24-bit RGB hex value (e.g. 0x2207F1) to a SwiftUI Color.
     // Named sdkHex to avoid colliding with other hex extensions in consumer apps.
-    init(sdkHex hex: UInt32) {
+    public init(sdkHex hex: UInt32) {
         self.init(
             red:   Double((hex >> 16) & 0xFF) / 255,
             green: Double((hex >> 8)  & 0xFF) / 255,

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -66,6 +66,9 @@ public struct ChatTheme {
     public var expandControlColor: Color
     public var errorColor: Color
 
+    // MARK: - Recording timer
+    public var timerColor: Color
+
     // MARK: - Action icon colors
     public var cancelRecordingIconColor: Color
     public var closeModalIconColor: Color
@@ -107,6 +110,8 @@ public struct ChatTheme {
     public var addIconName: String
     public var removeIconName: String
     public var ctaArrowIconName: String
+    public var stopRecordingIconName: String
+    public var currencyIconName: String
     public var cameraIconName: String
     public var galleryIconName: String
     public var trashIconName: String
@@ -150,6 +155,7 @@ public struct ChatTheme {
         messageFooterColor: Color             = Color(sdkHex: 0x7C8086),
         expandControlColor: Color             = Color(sdkHex: 0x2207F1),
         errorColor: Color                     = .red,
+        timerColor: Color                     = Color(sdkHex: 0x7C8086),
         cancelRecordingIconColor: Color       = Color(sdkHex: 0x7C8086),
         closeModalIconColor: Color            = Color(sdkHex: 0x7C8086),
         playAudioIconColor: Color             = Color(sdkHex: 0x7C8086),
@@ -182,6 +188,8 @@ public struct ChatTheme {
         addIconName: String                   = "plus",
         removeIconName: String                = "minus",
         ctaArrowIconName: String              = "arrow.right",
+        stopRecordingIconName: String         = "stop.circle.fill",
+        currencyIconName: String              = "dollarsign",
         cameraIconName: String                = "camera",
         galleryIconName: String               = "photo",
         trashIconName: String                 = "trash",
@@ -222,6 +230,7 @@ public struct ChatTheme {
         self.messageFooterColor = messageFooterColor
         self.expandControlColor = expandControlColor
         self.errorColor = errorColor
+        self.timerColor = timerColor
         self.cancelRecordingIconColor = cancelRecordingIconColor
         self.closeModalIconColor = closeModalIconColor
         self.playAudioIconColor = playAudioIconColor
@@ -254,6 +263,8 @@ public struct ChatTheme {
         self.addIconName = addIconName
         self.removeIconName = removeIconName
         self.ctaArrowIconName = ctaArrowIconName
+        self.stopRecordingIconName = stopRecordingIconName
+        self.currencyIconName = currencyIconName
         self.cameraIconName = cameraIconName
         self.galleryIconName = galleryIconName
         self.trashIconName = trashIconName

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -136,7 +136,7 @@ public struct ChatTheme {
         waveformColor: Color                  = Color(sdkHex: 0x5C5EE8),
         quickReplyBackgroundColor: Color      = .clear,
         quickReplyBorderColor: Color          = Color(sdkHex: 0xECEDEF),
-        quickReplyTextColor: Color            = Color(sdkHex: 0x2207F1),
+        quickReplyTextColor: Color            = Color(sdkHex: 0x111111),
         cardBackgroundColor: Color            = Color(.secondarySystemBackground),
         cardBorderColor: Color                = Color(sdkHex: 0xDDE4EC),
         productPriceColor: Color              = Color(sdkHex: 0x186C54),

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -91,9 +91,9 @@ public struct ChatTheme {
 
     public init(
         backgroundColor: Color          = Color(.systemBackground),
-        appBarBackgroundColor: Color     = Color(sdkHex: 0xF1F5FC),
+        appBarBackgroundColor: Color     = Color(.systemBackground),
         userBubbleColor: Color           = Color(sdkHex: 0xF9FAFC),
-        userBubbleTextColor: Color       = Color(.label),
+        userBubbleTextColor: Color       = Color(sdkHex: 0x111111),
         agentBubbleColor: Color          = Color(.systemGray5),
         agentBubbleTextColor: Color      = Color(.label),
         inputBackgroundColor: Color      = Color(.systemBackground),

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -24,6 +24,7 @@ public struct ChatTheme {
     // MARK: - Input bar
     public var inputBackgroundColor: Color
     public var inputBorderColor: Color
+    public var inputHintColor: Color
 
     // MARK: - Send / mic action button
     public var sendButtonColor: Color
@@ -47,6 +48,7 @@ public struct ChatTheme {
     public var productPriceBackgroundColor: Color
     public var pricePerSubunitColor: Color
     public var imagePlaceholderColor: Color
+    public var currencyIconColor: Color
 
     // MARK: - CTA message buttons
     public var ctaButtonColor: Color
@@ -58,11 +60,27 @@ public struct ChatTheme {
     public var buttonsButtonBorderColor: Color
     public var buttonsButtonTextColor: Color
 
-    // MARK: - Icons / footer
+    // MARK: - Icons / footer / controls
     public var actionIconColor: Color
     public var messageFooterColor: Color
     public var expandControlColor: Color
     public var errorColor: Color
+
+    // MARK: - Action icon colors
+    public var cancelRecordingIconColor: Color
+    public var closeModalIconColor: Color
+    public var playAudioIconColor: Color
+    public var pauseAudioIconColor: Color
+    public var attachIconColor: Color
+    public var cameraIconColor: Color
+    public var galleryIconColor: Color
+    public var trashIconColor: Color
+    public var numericControlIconColor: Color
+    public var imagePlaceholderIconColor: Color
+
+    // MARK: - Attachment picker
+    public var attachmentPickerBackgroundColor: Color
+    public var pickerButtonBorderColor: Color
 
     // MARK: - Fonts
     public var userMessageFont: Font
@@ -73,6 +91,9 @@ public struct ChatTheme {
     public var messageHeaderFont: Font
     public var messageFooterFont: Font
 
+    // MARK: - Layout
+    public var bubbleCornerRadius: CGFloat
+
     // MARK: - Icon names (SF Symbols)
     public var sendIconName: String
     public var micIconName: String
@@ -80,66 +101,93 @@ public struct ChatTheme {
     public var shopIconName: String
     public var cartIconName: String
     public var cancelRecordingIconName: String
+    public var closeModalIconName: String
     public var playIconName: String
     public var pauseIconName: String
     public var addIconName: String
     public var removeIconName: String
     public var ctaArrowIconName: String
+    public var cameraIconName: String
+    public var galleryIconName: String
+    public var trashIconName: String
+    public var imagePlaceholderIconName: String
+    public var errorIconName: String
 
     // MARK: - Optional branding
     public var chatIconImage: Image?
 
     public init(
-        backgroundColor: Color          = Color(.systemBackground),
-        appBarBackgroundColor: Color     = Color(.systemBackground),
-        userBubbleColor: Color           = Color(sdkHex: 0xF9FAFC),
-        userBubbleTextColor: Color       = Color(sdkHex: 0x111111),
-        agentBubbleColor: Color          = Color(.systemGray5),
-        agentBubbleTextColor: Color      = Color(.label),
-        inputBackgroundColor: Color      = Color(.systemBackground),
-        inputBorderColor: Color          = Color(sdkHex: 0xE8E8E8),
-        sendButtonColor: Color           = Color(sdkHex: 0x2207F1),
-        sendButtonIconColor: Color       = Color(sdkHex: 0xEFF4FF),
-        waveformColor: Color             = Color(sdkHex: 0x5C5EE8),
-        quickReplyBackgroundColor: Color = .clear,
-        quickReplyBorderColor: Color     = Color(sdkHex: 0xECEDEF),
-        quickReplyTextColor: Color       = Color(sdkHex: 0x2207F1),
-        cardBackgroundColor: Color       = Color(.secondarySystemBackground),
-        cardBorderColor: Color           = Color(sdkHex: 0xDDE4EC),
-        productPriceColor: Color         = Color(sdkHex: 0x186C54),
-        productSalePriceColor: Color     = Color(sdkHex: 0x0B996D),
-        productPriceBackgroundColor: Color = Color(sdkHex: 0xECFDF5),
-        pricePerSubunitColor: Color      = Color(sdkHex: 0x334155),
-        imagePlaceholderColor: Color     = Color(sdkHex: 0xF9FAFC),
-        ctaButtonColor: Color            = .clear,
-        ctaButtonBorderColor: Color      = Color(sdkHex: 0xDDE4EC),
-        ctaButtonTextColor: Color        = Color(sdkHex: 0x111111),
-        buttonsButtonColor: Color        = .clear,
-        buttonsButtonBorderColor: Color  = Color(sdkHex: 0xDDE4EC),
-        buttonsButtonTextColor: Color    = Color(sdkHex: 0x111111),
-        actionIconColor: Color           = Color(.label),
-        messageFooterColor: Color        = Color(sdkHex: 0x7C8086),
-        expandControlColor: Color        = Color(sdkHex: 0x2207F1),
-        errorColor: Color                = .red,
-        userMessageFont: Font            = .body,
-        agentMessageFont: Font           = .body,
-        productTitleFont: Font           = .subheadline,
-        productSubunitsFont: Font        = .caption,
-        productPriceFont: Font           = .subheadline,
-        messageHeaderFont: Font          = .subheadline,
-        messageFooterFont: Font          = .caption,
-        sendIconName: String             = "paperplane.fill",
-        micIconName: String              = "mic.fill",
-        attachIconName: String           = "paperclip",
-        shopIconName: String             = "storefront",
-        cartIconName: String             = "cart",
-        cancelRecordingIconName: String  = "xmark.circle.fill",
-        playIconName: String             = "play.fill",
-        pauseIconName: String            = "pause.fill",
-        addIconName: String              = "plus",
-        removeIconName: String           = "minus",
-        ctaArrowIconName: String         = "arrow.right",
-        chatIconImage: Image?            = nil
+        backgroundColor: Color               = Color(.systemBackground),
+        appBarBackgroundColor: Color          = Color(.systemBackground),
+        userBubbleColor: Color                = Color(sdkHex: 0xF9FAFC),
+        userBubbleTextColor: Color            = Color(sdkHex: 0x111111),
+        agentBubbleColor: Color               = Color(.systemGray5),
+        agentBubbleTextColor: Color           = Color(.label),
+        inputBackgroundColor: Color           = Color(.systemBackground),
+        inputBorderColor: Color               = Color(sdkHex: 0xE8E8E8),
+        inputHintColor: Color                 = Color(sdkHex: 0xBEBEBE),
+        sendButtonColor: Color                = Color(sdkHex: 0x2207F1),
+        sendButtonIconColor: Color            = Color(sdkHex: 0xEFF4FF),
+        waveformColor: Color                  = Color(sdkHex: 0x5C5EE8),
+        quickReplyBackgroundColor: Color      = .clear,
+        quickReplyBorderColor: Color          = Color(sdkHex: 0xECEDEF),
+        quickReplyTextColor: Color            = Color(sdkHex: 0x2207F1),
+        cardBackgroundColor: Color            = Color(.secondarySystemBackground),
+        cardBorderColor: Color                = Color(sdkHex: 0xDDE4EC),
+        productPriceColor: Color              = Color(sdkHex: 0x186C54),
+        productSalePriceColor: Color          = Color(sdkHex: 0x0B996D),
+        productPriceBackgroundColor: Color    = Color(sdkHex: 0xECFDF5),
+        pricePerSubunitColor: Color           = Color(sdkHex: 0x334155),
+        imagePlaceholderColor: Color          = Color(sdkHex: 0xF9FAFC),
+        currencyIconColor: Color              = Color(sdkHex: 0x186C54),
+        ctaButtonColor: Color                 = .clear,
+        ctaButtonBorderColor: Color           = Color(sdkHex: 0xDDE4EC),
+        ctaButtonTextColor: Color             = Color(sdkHex: 0x111111),
+        buttonsButtonColor: Color             = .clear,
+        buttonsButtonBorderColor: Color       = Color(sdkHex: 0xDDE4EC),
+        buttonsButtonTextColor: Color         = Color(sdkHex: 0x111111),
+        actionIconColor: Color                = Color(.label),
+        messageFooterColor: Color             = Color(sdkHex: 0x7C8086),
+        expandControlColor: Color             = Color(sdkHex: 0x2207F1),
+        errorColor: Color                     = .red,
+        cancelRecordingIconColor: Color       = Color(sdkHex: 0x7C8086),
+        closeModalIconColor: Color            = Color(sdkHex: 0x7C8086),
+        playAudioIconColor: Color             = Color(sdkHex: 0x7C8086),
+        pauseAudioIconColor: Color            = Color(sdkHex: 0x7C8086),
+        attachIconColor: Color                = Color(sdkHex: 0x7C8086),
+        cameraIconColor: Color                = Color(sdkHex: 0x7C8086),
+        galleryIconColor: Color               = Color(sdkHex: 0x7C8086),
+        trashIconColor: Color                 = Color(sdkHex: 0x7C8086),
+        numericControlIconColor: Color        = Color(sdkHex: 0x7C8086),
+        imagePlaceholderIconColor: Color      = Color(sdkHex: 0x7C8086),
+        attachmentPickerBackgroundColor: Color = Color(sdkHex: 0xF1F5FC),
+        pickerButtonBorderColor: Color        = Color(sdkHex: 0xE6E6E6),
+        userMessageFont: Font                 = .body,
+        agentMessageFont: Font                = .body,
+        productTitleFont: Font                = .subheadline,
+        productSubunitsFont: Font             = .caption,
+        productPriceFont: Font                = .subheadline,
+        messageHeaderFont: Font               = .subheadline,
+        messageFooterFont: Font               = .caption,
+        bubbleCornerRadius: CGFloat           = 16,
+        sendIconName: String                  = "paperplane.fill",
+        micIconName: String                   = "mic.fill",
+        attachIconName: String                = "paperclip",
+        shopIconName: String                  = "storefront",
+        cartIconName: String                  = "cart",
+        cancelRecordingIconName: String       = "xmark.circle.fill",
+        closeModalIconName: String            = "xmark",
+        playIconName: String                  = "play.circle.fill",
+        pauseIconName: String                 = "pause.circle.fill",
+        addIconName: String                   = "plus",
+        removeIconName: String                = "minus",
+        ctaArrowIconName: String              = "arrow.right",
+        cameraIconName: String                = "camera",
+        galleryIconName: String               = "photo",
+        trashIconName: String                 = "trash",
+        imagePlaceholderIconName: String      = "photo",
+        errorIconName: String                 = "exclamationmark.circle.fill",
+        chatIconImage: Image?                 = nil
     ) {
         self.backgroundColor = backgroundColor
         self.appBarBackgroundColor = appBarBackgroundColor
@@ -149,6 +197,7 @@ public struct ChatTheme {
         self.agentBubbleTextColor = agentBubbleTextColor
         self.inputBackgroundColor = inputBackgroundColor
         self.inputBorderColor = inputBorderColor
+        self.inputHintColor = inputHintColor
         self.sendButtonColor = sendButtonColor
         self.sendButtonIconColor = sendButtonIconColor
         self.waveformColor = waveformColor
@@ -162,6 +211,7 @@ public struct ChatTheme {
         self.productPriceBackgroundColor = productPriceBackgroundColor
         self.pricePerSubunitColor = pricePerSubunitColor
         self.imagePlaceholderColor = imagePlaceholderColor
+        self.currencyIconColor = currencyIconColor
         self.ctaButtonColor = ctaButtonColor
         self.ctaButtonBorderColor = ctaButtonBorderColor
         self.ctaButtonTextColor = ctaButtonTextColor
@@ -172,6 +222,18 @@ public struct ChatTheme {
         self.messageFooterColor = messageFooterColor
         self.expandControlColor = expandControlColor
         self.errorColor = errorColor
+        self.cancelRecordingIconColor = cancelRecordingIconColor
+        self.closeModalIconColor = closeModalIconColor
+        self.playAudioIconColor = playAudioIconColor
+        self.pauseAudioIconColor = pauseAudioIconColor
+        self.attachIconColor = attachIconColor
+        self.cameraIconColor = cameraIconColor
+        self.galleryIconColor = galleryIconColor
+        self.trashIconColor = trashIconColor
+        self.numericControlIconColor = numericControlIconColor
+        self.imagePlaceholderIconColor = imagePlaceholderIconColor
+        self.attachmentPickerBackgroundColor = attachmentPickerBackgroundColor
+        self.pickerButtonBorderColor = pickerButtonBorderColor
         self.userMessageFont = userMessageFont
         self.agentMessageFont = agentMessageFont
         self.productTitleFont = productTitleFont
@@ -179,17 +241,24 @@ public struct ChatTheme {
         self.productPriceFont = productPriceFont
         self.messageHeaderFont = messageHeaderFont
         self.messageFooterFont = messageFooterFont
+        self.bubbleCornerRadius = bubbleCornerRadius
         self.sendIconName = sendIconName
         self.micIconName = micIconName
         self.attachIconName = attachIconName
         self.shopIconName = shopIconName
         self.cartIconName = cartIconName
         self.cancelRecordingIconName = cancelRecordingIconName
+        self.closeModalIconName = closeModalIconName
         self.playIconName = playIconName
         self.pauseIconName = pauseIconName
         self.addIconName = addIconName
         self.removeIconName = removeIconName
         self.ctaArrowIconName = ctaArrowIconName
+        self.cameraIconName = cameraIconName
+        self.galleryIconName = galleryIconName
+        self.trashIconName = trashIconName
+        self.imagePlaceholderIconName = imagePlaceholderIconName
+        self.errorIconName = errorIconName
         self.chatIconImage = chatIconImage
     }
 }
@@ -207,7 +276,7 @@ extension EnvironmentValues {
     }
 }
 
-// MARK: - Hex color helper (internal — used by ChatTheme defaults and views)
+// MARK: - Hex color helper
 
 extension Color {
     // Converts a 24-bit RGB hex value (e.g. 0x2207F1) to a SwiftUI Color.

--- a/ios-sdk/YaloChatDemo/ChatView.swift
+++ b/ios-sdk/YaloChatDemo/ChatView.swift
@@ -38,6 +38,7 @@ struct ChatView: View {
                 audioObservable: audioObservable
             )
         }
+        .background(YaloChat.theme.backgroundColor)
         .environment(\.chatTheme, YaloChat.theme)
         .onAppear {
             guard !hasStarted else { return }

--- a/ios-sdk/YaloChatDemo/ChatView.swift
+++ b/ios-sdk/YaloChatDemo/ChatView.swift
@@ -14,24 +14,31 @@ struct ChatView: View {
     @State private var hasStarted = false
 
     var body: some View {
-        NavigationView {
-            VStack(spacing: 0) {
-                MessageList(observable: observable, audioObservable: audioObservable)
-                Divider()
-                QuickRepliesView(
-                    quickReplies: observable.quickReplies,
-                    onChipTap: { label in observable.sendTextMessage(text: label) }
-                )
-                ChatInput(
-                    messagesObservable: observable,
-                    imageObservable: imageObservable,
-                    audioObservable: audioObservable
-                )
-            }
-            .navigationTitle(YaloChatSdk.shared.config?.channelName ?? "Chat")
-            .navigationBarTitleDisplayMode(.inline)
+        VStack(spacing: 0) {
+            ChatAppBar(
+                channelName: YaloChatSdk.shared.config?.channelName ?? "Chat",
+                typingStatusText: observable.typingStatusText,
+                isTyping: observable.isTyping,
+                onShopPressed: YaloChat.onShopPressed,
+                onCartPressed: YaloChat.onCartPressed
+            )
+
+            MessageList(observable: observable, audioObservable: audioObservable)
+
+            Divider()
+
+            QuickRepliesView(
+                quickReplies: observable.quickReplies,
+                onChipTap: { label in observable.sendTextMessage(text: label) }
+            )
+
+            ChatInput(
+                messagesObservable: observable,
+                imageObservable: imageObservable,
+                audioObservable: audioObservable
+            )
         }
-        .navigationViewStyle(.stack)
+        .environment(\.chatTheme, YaloChat.theme)
         .onAppear {
             guard !hasStarted else { return }
             hasStarted = true
@@ -46,7 +53,6 @@ struct ChatView: View {
             case .background:
                 observable.onDisappear()
                 // hasStarted intentionally stays true so .active can restart on foreground resume.
-                // (.onAppear does not re-fire for views already in the hierarchy.)
             case .active:
                 // .onAppear handles the very first start; this handles foreground resume.
                 if hasStarted {

--- a/ios-sdk/YaloChatDemo/ImagePreview.swift
+++ b/ios-sdk/YaloChatDemo/ImagePreview.swift
@@ -11,6 +11,8 @@ struct ImagePreview: View {
     let onCancel: () -> Void
     let onSend: () -> Void
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         HStack(spacing: 12) {
             Image(uiImage: image)
@@ -23,21 +25,21 @@ struct ImagePreview: View {
             Spacer()
 
             Button(action: onCancel) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
+                Image(systemName: theme.cancelRecordingIconName)
+                    .foregroundColor(theme.messageFooterColor)
                     .font(.title2)
             }
 
             Button(action: onSend) {
-                Image(systemName: "paperplane.fill")
-                    .foregroundColor(.white)
+                Image(systemName: theme.sendIconName)
+                    .foregroundColor(theme.sendButtonIconColor)
                     .padding(8)
-                    .background(Color.accentColor)
+                    .background(theme.sendButtonColor)
                     .clipShape(Circle())
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .background(Color(.systemBackground))
+        .background(theme.inputBackgroundColor)
     }
 }

--- a/ios-sdk/YaloChatDemo/ImagePreview.swift
+++ b/ios-sdk/YaloChatDemo/ImagePreview.swift
@@ -25,8 +25,8 @@ struct ImagePreview: View {
             Spacer()
 
             Button(action: onCancel) {
-                Image(systemName: theme.cancelRecordingIconName)
-                    .foregroundColor(theme.messageFooterColor)
+                Image(systemName: theme.closeModalIconName)
+                    .foregroundColor(theme.closeModalIconColor)
                     .font(.title2)
             }
 

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -14,6 +14,8 @@ struct MessageItem: View {
     var onUpdateQuantity: (Int64, String, Bool, Double) -> Void = { _, _, _, _ in }
     var isExpanded: Bool = false
 
+    @Environment(\.chatTheme) private var theme
+
     private var isUser: Bool { message.role === MessageRole.user }
 
     // Product messages render their own card borders — bypass the bubble HStack layout.
@@ -42,7 +44,7 @@ struct MessageItem: View {
     private var errorIndicator: some View {
         if isUser && message.status === MessageStatus.error {
             Image(systemName: "exclamationmark.circle.fill")
-                .foregroundColor(.red)
+                .foregroundColor(theme.errorColor)
                 .font(.caption)
         }
     }
@@ -96,7 +98,8 @@ struct MessageItem: View {
     private var bubbleContent: some View {
         if message.type is MessageType.Text || message.type is MessageType.QuickReply {
             Text(message.content)
-                .foregroundColor(isUser ? .white : .primary)
+                .font(isUser ? theme.userMessageFont : theme.agentMessageFont)
+                .foregroundColor(isUser ? theme.userBubbleTextColor : theme.agentBubbleTextColor)
         } else if message.type is MessageType.Voice {
             voiceContent
         } else if message.type is MessageType.Buttons {
@@ -107,7 +110,7 @@ struct MessageItem: View {
             Text("Unsupported message type")
                 .font(.caption)
                 .italic()
-                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .foregroundColor(isUser ? theme.userBubbleTextColor.opacity(0.8) : theme.messageFooterColor)
         }
     }
 
@@ -117,7 +120,7 @@ struct MessageItem: View {
             LocalFileImage(path: path, fallbackColor: bubbleColor)
         } else {
             Label("Image unavailable", systemImage: "photo")
-                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .foregroundColor(isUser ? theme.userBubbleTextColor.opacity(0.8) : theme.messageFooterColor)
                 .font(.caption)
                 .padding(12)
                 .background(bubbleColor)
@@ -129,18 +132,19 @@ struct MessageItem: View {
         VStack(alignment: .leading, spacing: 4) {
             if let header = message.header, !header.isEmpty {
                 Text(header)
-                    .font(.caption)
+                    .font(theme.messageHeaderFont)
                     .fontWeight(.semibold)
-                    .foregroundColor(.primary)
+                    .foregroundColor(theme.agentBubbleTextColor)
             }
             if !message.content.isEmpty {
                 Text(message.content)
-                    .foregroundColor(.primary)
+                    .font(theme.agentMessageFont)
+                    .foregroundColor(theme.agentBubbleTextColor)
             }
             if let footer = message.footer, !footer.isEmpty {
                 Text(footer)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(theme.messageFooterFont)
+                    .foregroundColor(theme.messageFooterColor)
             }
             let labels = message.buttons
             if !labels.isEmpty {
@@ -151,13 +155,14 @@ struct MessageItem: View {
                                 .font(.subheadline)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 8)
+                                .background(theme.buttonsButtonColor)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 8)
-                                        .stroke(Color.accentColor, lineWidth: 1)
+                                        .stroke(theme.buttonsButtonBorderColor, lineWidth: 1)
                                 )
                         }
                         .buttonStyle(.plain)
-                        .foregroundColor(.accentColor)
+                        .foregroundColor(theme.buttonsButtonTextColor)
                     }
                 }
                 .padding(.top, 4)
@@ -170,18 +175,19 @@ struct MessageItem: View {
         VStack(alignment: .leading, spacing: 4) {
             if let header = message.header, !header.isEmpty {
                 Text(header)
-                    .font(.caption)
+                    .font(theme.messageHeaderFont)
                     .fontWeight(.semibold)
-                    .foregroundColor(.primary)
+                    .foregroundColor(theme.agentBubbleTextColor)
             }
             if !message.content.isEmpty {
                 Text(message.content)
-                    .foregroundColor(.primary)
+                    .font(theme.agentMessageFont)
+                    .foregroundColor(theme.agentBubbleTextColor)
             }
             if let footer = message.footer, !footer.isEmpty {
                 Text(footer)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(theme.messageFooterFont)
+                    .foregroundColor(theme.messageFooterColor)
             }
             let buttons = message.ctaButtons
             if !buttons.isEmpty {
@@ -196,17 +202,18 @@ struct MessageItem: View {
                                 Text(button.text)
                                     .font(.subheadline)
                                     .frame(maxWidth: .infinity, alignment: .leading)
-                                Image(systemName: "link")
+                                Image(systemName: theme.ctaArrowIconName)
                                     .font(.caption)
                             }
                             .padding(.vertical, 8)
+                            .background(theme.ctaButtonColor)
                             .overlay(
                                 RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color.accentColor, lineWidth: 1)
+                                    .stroke(theme.ctaButtonBorderColor, lineWidth: 1)
                             )
                         }
                         .buttonStyle(.plain)
-                        .foregroundColor(.accentColor)
+                        .foregroundColor(theme.ctaButtonTextColor)
                     }
                 }
                 .padding(.top, 4)
@@ -220,7 +227,7 @@ struct MessageItem: View {
             StableVideoPlayer(path: path)
         } else {
             Label("Video unavailable", systemImage: "video")
-                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .foregroundColor(isUser ? theme.userBubbleTextColor.opacity(0.8) : theme.messageFooterColor)
                 .font(.caption)
                 .padding(12)
                 .background(bubbleColor)
@@ -239,20 +246,20 @@ struct MessageItem: View {
             } label: {
                 Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
                     .font(.title2)
-                    .foregroundColor(isUser ? .white : .accentColor)
+                    .foregroundColor(isUser ? theme.userBubbleTextColor : theme.waveformColor)
             }
             .disabled(message.fileName == nil || messageId == nil)
 
             WaveformView(
                 amplitudes: resolvedAmplitudes,
-                color: isUser ? .white.opacity(0.7) : .accentColor
+                color: isUser ? theme.userBubbleTextColor.opacity(0.7) : theme.waveformColor
             )
             .frame(width: 100, height: 28)
 
             Text(voiceDuration)
                 .monospacedDigit()
                 .font(.caption)
-                .foregroundColor(isUser ? .white.opacity(0.8) : .secondary)
+                .foregroundColor(isUser ? theme.userBubbleTextColor.opacity(0.8) : theme.messageFooterColor)
         }
     }
 
@@ -268,7 +275,7 @@ struct MessageItem: View {
     }
 
     private var bubbleColor: Color {
-        isUser ? .accentColor : Color(.systemGray5)
+        isUser ? theme.userBubbleColor : theme.agentBubbleColor
     }
 }
 

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -97,9 +97,16 @@ struct MessageItem: View {
     @ViewBuilder
     private var bubbleContent: some View {
         if message.type is MessageType.Text || message.type is MessageType.QuickReply {
-            Text(message.content)
-                .font(isUser ? theme.userMessageFont : theme.agentMessageFont)
-                .foregroundColor(isUser ? theme.userBubbleTextColor : theme.agentBubbleTextColor)
+            if isUser {
+                Text(message.content)
+                    .font(theme.userMessageFont)
+                    .foregroundColor(theme.userBubbleTextColor)
+            } else {
+                // foregroundColor is baked into the AttributedString for non-link runs so that
+                // links retain their distinct tint color and remain visually distinguishable.
+                Text(agentAttributed(message.content, color: theme.agentBubbleTextColor))
+                    .font(theme.agentMessageFont)
+            }
         } else if message.type is MessageType.Voice {
             voiceContent
         } else if message.type is MessageType.Buttons {
@@ -276,6 +283,19 @@ struct MessageItem: View {
 
     private var bubbleColor: Color {
         isUser ? theme.userBubbleColor : theme.agentBubbleColor
+    }
+
+    // Parses inline CommonMark via iOS 15 native AttributedString.
+    // Sets textColor on non-link runs so links keep their distinct tint color.
+    // Falls back to plain AttributedString on parse failure.
+    private func agentAttributed(_ content: String, color: Color) -> AttributedString {
+        var attributed = (try? AttributedString(markdown: content)) ?? AttributedString(content)
+        for run in attributed.runs {
+            if attributed[run.range].link == nil {
+                attributed[run.range].swiftUI.foregroundColor = color
+            }
+        }
+        return attributed
     }
 }
 

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -43,7 +43,7 @@ struct MessageItem: View {
     @ViewBuilder
     private var errorIndicator: some View {
         if isUser && message.status === MessageStatus.error {
-            Image(systemName: "exclamationmark.circle.fill")
+            Image(systemName: theme.errorIconName)
                 .foregroundColor(theme.errorColor)
                 .font(.caption)
         }
@@ -81,15 +81,15 @@ struct MessageItem: View {
         Group {
             if message.type is MessageType.Image {
                 imageContent
-                    .cornerRadius(16)
+                    .cornerRadius(theme.bubbleCornerRadius)
             } else if message.type is MessageType.Video {
                 videoContent
-                    .cornerRadius(16)
+                    .cornerRadius(theme.bubbleCornerRadius)
             } else {
                 bubbleContent
                     .padding(12)
                     .background(bubbleColor)
-                    .cornerRadius(16)
+                    .cornerRadius(theme.bubbleCornerRadius)
             }
         }
     }
@@ -119,7 +119,7 @@ struct MessageItem: View {
         if let path = message.fileName {
             LocalFileImage(path: path, fallbackColor: bubbleColor)
         } else {
-            Label("Image unavailable", systemImage: "photo")
+            Label("Image unavailable", systemImage: theme.imagePlaceholderIconName)
                 .foregroundColor(isUser ? theme.userBubbleTextColor.opacity(0.8) : theme.messageFooterColor)
                 .font(.caption)
                 .padding(12)
@@ -244,9 +244,9 @@ struct MessageItem: View {
                 guard let mid = messageId, let path = message.fileName else { return }
                 audioObservable.togglePlayback(messageId: mid, fileName: path)
             } label: {
-                Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                Image(systemName: isPlaying ? theme.pauseIconName : theme.playIconName)
                     .font(.title2)
-                    .foregroundColor(isUser ? theme.userBubbleTextColor : theme.waveformColor)
+                    .foregroundColor(isUser ? theme.userBubbleTextColor : (isPlaying ? theme.pauseAudioIconColor : theme.playAudioIconColor))
             }
             .disabled(message.fileName == nil || messageId == nil)
 

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -43,10 +43,6 @@ struct MessageList: View {
                             )
                         }
 
-                        if observable.isTyping {
-                            TypingIndicatorBubble()
-                                .id("typing")
-                        }
                     }
                     Color.clear.frame(height: 1).id("bottom")
                 }
@@ -54,13 +50,6 @@ struct MessageList: View {
                 .padding(.vertical, 8)
             }
             .onChange(of: observable.messages.count) { _ in
-                DispatchQueue.main.async {
-                    withAnimation(.linear(duration: 0.15)) {
-                        proxy.scrollTo("bottom", anchor: .bottom)
-                    }
-                }
-            }
-            .onChange(of: observable.isTyping) { _ in
                 DispatchQueue.main.async {
                     withAnimation(.linear(duration: 0.15)) {
                         proxy.scrollTo("bottom", anchor: .bottom)
@@ -85,36 +74,3 @@ extension ChatMessage {
     }
 }
 
-// Animated three-dot typing bubble — mirrors Flutter ChatTypingMessage.
-private struct TypingIndicatorBubble: View {
-
-    @State private var animating = false
-    @Environment(\.chatTheme) private var theme
-
-    var body: some View {
-        HStack(alignment: .bottom, spacing: 0) {
-            HStack(spacing: 4) {
-                ForEach(0..<3) { index in
-                    Circle()
-                        .fill(theme.messageFooterColor)
-                        .frame(width: 8, height: 8)
-                        .scaleEffect(animating ? 1.0 : 0.5)
-                        .animation(
-                            .easeInOut(duration: 0.5)
-                                .repeatForever()
-                                .delay(Double(index) * 0.15),
-                            value: animating
-                        )
-                }
-            }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(theme.agentBubbleColor)
-            .cornerRadius(16)
-
-            Spacer(minLength: 48)
-        }
-        .onAppear { animating = true }
-        .onDisappear { animating = false }
-    }
-}

--- a/ios-sdk/YaloChatDemo/MessageList.swift
+++ b/ios-sdk/YaloChatDemo/MessageList.swift
@@ -8,6 +8,8 @@ struct MessageList: View {
     @ObservedObject var observable: MessagesObservable
     @ObservedObject var audioObservable: AudioObservable
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
@@ -18,7 +20,7 @@ struct MessageList: View {
                                 .padding(.top, 32)
                         } else {
                             Text("No messages yet")
-                                .foregroundColor(.secondary)
+                                .foregroundColor(theme.messageFooterColor)
                                 .padding(.top, 32)
                         }
                     } else {
@@ -87,13 +89,14 @@ extension ChatMessage {
 private struct TypingIndicatorBubble: View {
 
     @State private var animating = false
+    @Environment(\.chatTheme) private var theme
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
             HStack(spacing: 4) {
                 ForEach(0..<3) { index in
                     Circle()
-                        .fill(Color(.systemGray3))
+                        .fill(theme.messageFooterColor)
                         .frame(width: 8, height: 8)
                         .scaleEffect(animating ? 1.0 : 0.5)
                         .animation(
@@ -106,7 +109,7 @@ private struct TypingIndicatorBubble: View {
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
-            .background(Color(.systemGray5))
+            .background(theme.agentBubbleColor)
             .cornerRadius(16)
 
             Spacer(minLength: 48)

--- a/ios-sdk/YaloChatDemo/ProductCard.swift
+++ b/ios-sdk/YaloChatDemo/ProductCard.swift
@@ -133,12 +133,23 @@ private struct ProductPriceRow: View {
 
     var body: some View {
         HStack(spacing: 4) {
+            HStack(spacing: 2) {
+                Image(systemName: theme.currencyIconName)
+                    .font(.caption)
+                    .foregroundColor(theme.currencyIconColor)
+                let salePrice = product.salePrice?.doubleValue
+                let displayPrice = salePrice ?? product.price
+                Text(formatPrice(displayPrice))
+                    .font(theme.productPriceFont)
+                    .fontWeight(.semibold)
+                    .foregroundColor(theme.productPriceColor)
+            }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(theme.productPriceBackgroundColor)
+            .cornerRadius(4)
+
             let salePrice = product.salePrice?.doubleValue
-            let displayPrice = salePrice ?? product.price
-            Text(formatPrice(displayPrice))
-                .font(theme.productPriceFont)
-                .fontWeight(.semibold)
-                .foregroundColor(theme.productPriceColor)
             if salePrice != nil {
                 Text(formatPrice(product.price))
                     .font(.caption)
@@ -154,6 +165,14 @@ private struct ProductImage: View {
 
     @Environment(\.chatTheme) private var theme
 
+    private var placeholderContent: some View {
+        ZStack {
+            theme.imagePlaceholderColor
+            Image(systemName: theme.imagePlaceholderIconName)
+                .foregroundColor(theme.imagePlaceholderIconColor)
+        }
+    }
+
     var body: some View {
         Group {
             if let urlString, let url = URL(string: urlString) {
@@ -162,11 +181,11 @@ private struct ProductImage: View {
                     case .success(let image):
                         image.resizable().scaledToFill()
                     default:
-                        theme.imagePlaceholderColor
+                        placeholderContent
                     }
                 }
             } else {
-                theme.imagePlaceholderColor
+                placeholderContent
             }
         }
     }

--- a/ios-sdk/YaloChatDemo/ProductCard.swift
+++ b/ios-sdk/YaloChatDemo/ProductCard.swift
@@ -132,14 +132,13 @@ private struct ProductPriceRow: View {
     @Environment(\.chatTheme) private var theme
 
     var body: some View {
+        let salePrice = product.salePrice?.doubleValue
         HStack(spacing: 4) {
             HStack(spacing: 2) {
                 Image(systemName: theme.currencyIconName)
                     .font(.caption)
                     .foregroundColor(theme.currencyIconColor)
-                let salePrice = product.salePrice?.doubleValue
-                let displayPrice = salePrice ?? product.price
-                Text(formatPrice(displayPrice))
+                Text(formatPrice(salePrice ?? product.price))
                     .font(theme.productPriceFont)
                     .fontWeight(.semibold)
                     .foregroundColor(theme.productPriceColor)
@@ -149,7 +148,6 @@ private struct ProductPriceRow: View {
             .background(theme.productPriceBackgroundColor)
             .cornerRadius(4)
 
-            let salePrice = product.salePrice?.doubleValue
             if salePrice != nil {
                 Text(formatPrice(product.price))
                     .font(.caption)

--- a/ios-sdk/YaloChatDemo/ProductCard.swift
+++ b/ios-sdk/YaloChatDemo/ProductCard.swift
@@ -19,6 +19,8 @@ struct ProductHorizontalCard: View {
     var onAddSubunit: () -> Void = {}
     var onRemoveSubunit: () -> Void = {}
 
+    @Environment(\.chatTheme) private var theme
+
     private var hasSubunits: Bool {
         product.subunits > 1.0 && product.subunitName != nil
     }
@@ -32,14 +34,15 @@ struct ProductHorizontalCard: View {
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(product.name)
-                    .font(.subheadline)
+                    .font(theme.productTitleFont)
                     .fontWeight(.medium)
                     .lineLimit(2)
+                    .foregroundColor(theme.agentBubbleTextColor)
 
                 if hasSubunits, let subunitName = product.subunitName {
                     Text("\(formatQuantity(product.subunits)) \(formatIcuUnit(product.subunits, subunitName))")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+                        .font(theme.productSubunitsFont)
+                        .foregroundColor(theme.pricePerSubunitColor)
                 }
 
                 ProductPriceRow(product: product)
@@ -74,6 +77,8 @@ struct ProductVerticalCard: View {
     var onAddSubunit: () -> Void = {}
     var onRemoveSubunit: () -> Void = {}
 
+    @Environment(\.chatTheme) private var theme
+
     private var hasSubunits: Bool {
         product.subunits > 1.0 && product.subunitName != nil
     }
@@ -90,14 +95,15 @@ struct ProductVerticalCard: View {
 
             if hasSubunits, let subunitName = product.subunitName {
                 Text("\(formatQuantity(product.subunits)) \(formatIcuUnit(product.subunits, subunitName))")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+                    .font(theme.productSubunitsFont)
+                    .foregroundColor(theme.pricePerSubunitColor)
             }
 
             Text(product.name)
-                .font(.subheadline)
+                .font(theme.productTitleFont)
                 .fontWeight(.medium)
                 .lineLimit(2)
+                .foregroundColor(theme.agentBubbleTextColor)
 
             ProductQuantityStepper(
                 value: product.unitsAdded,
@@ -123,19 +129,21 @@ struct ProductVerticalCard: View {
 private struct ProductPriceRow: View {
     let product: Product
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         HStack(spacing: 4) {
             let salePrice = product.salePrice?.doubleValue
             let displayPrice = salePrice ?? product.price
             Text(formatPrice(displayPrice))
-                .font(.subheadline)
+                .font(theme.productPriceFont)
                 .fontWeight(.semibold)
-                .foregroundColor(.accentColor)
+                .foregroundColor(theme.productPriceColor)
             if salePrice != nil {
                 Text(formatPrice(product.price))
                     .font(.caption)
                     .strikethrough()
-                    .foregroundColor(.secondary)
+                    .foregroundColor(theme.productSalePriceColor)
             }
         }
     }
@@ -143,6 +151,8 @@ private struct ProductPriceRow: View {
 
 private struct ProductImage: View {
     let urlString: String?
+
+    @Environment(\.chatTheme) private var theme
 
     var body: some View {
         Group {
@@ -152,11 +162,11 @@ private struct ProductImage: View {
                     case .success(let image):
                         image.resizable().scaledToFill()
                     default:
-                        Color(.systemGray5)
+                        theme.imagePlaceholderColor
                     }
                 }
             } else {
-                Color(.systemGray5)
+                theme.imagePlaceholderColor
             }
         }
     }

--- a/ios-sdk/YaloChatDemo/ProductCarouselView.swift
+++ b/ios-sdk/YaloChatDemo/ProductCarouselView.swift
@@ -74,7 +74,7 @@ struct ProductCarouselView: View {
             GeometryReader { geo in
                 Color.clear
                     .onAppear { containerWidth = geo.size.width }
-                    .onChange(of: geo.size.width) { containerWidth = $0 }
+                    .onChange(of: geo.size.width) { newValue in containerWidth = newValue }
             }
         )
     }

--- a/ios-sdk/YaloChatDemo/ProductCarouselView.swift
+++ b/ios-sdk/YaloChatDemo/ProductCarouselView.swift
@@ -15,11 +15,13 @@ struct ProductCarouselView: View {
     var onToggleExpand: () -> Void = {}
     var onUpdateQuantity: (String, Bool, Double) -> Void = { _, _, _ in }
 
+    @State private var containerWidth: CGFloat = 0
+    @Environment(\.chatTheme) private var theme
+
     private var products: [Product] {
         message.products
     }
 
-    @State private var containerWidth: CGFloat = 0
     private var cardWidth: CGFloat { containerWidth > 0 ? containerWidth * 0.6 : 180 }
 
     var body: some View {
@@ -46,11 +48,11 @@ struct ProductCarouselView: View {
                     )
                     .padding(12)
                     .frame(width: cardWidth)
-                    .background(Color(.secondarySystemBackground))
+                    .background(theme.cardBackgroundColor)
                     .cornerRadius(12)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color(.systemGray4), lineWidth: 1)
+                            .stroke(theme.cardBorderColor, lineWidth: 1)
                     )
                 }
 
@@ -58,7 +60,7 @@ struct ProductCarouselView: View {
                     Button(action: onToggleExpand) {
                         Text(isExpanded ? "Show less" : "Show more")
                             .font(.subheadline)
-                            .foregroundColor(.accentColor)
+                            .foregroundColor(theme.expandControlColor)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 8)
                             .frame(width: 80)

--- a/ios-sdk/YaloChatDemo/ProductListView.swift
+++ b/ios-sdk/YaloChatDemo/ProductListView.swift
@@ -70,7 +70,7 @@ struct ProductListView: View {
             GeometryReader { geo in
                 Color.clear
                     .onAppear { cardContentWidth = geo.size.width - 24 }
-                    .onChange(of: geo.size.width) { cardContentWidth = $0 - 24 }
+                    .onChange(of: geo.size.width) { newValue in cardContentWidth = newValue - 24 }
             }
         )
     }

--- a/ios-sdk/YaloChatDemo/ProductListView.swift
+++ b/ios-sdk/YaloChatDemo/ProductListView.swift
@@ -16,6 +16,7 @@ struct ProductListView: View {
     var onUpdateQuantity: (String, Bool, Double) -> Void = { _, _, _ in }
 
     @State private var cardContentWidth: CGFloat = 0
+    @Environment(\.chatTheme) private var theme
 
     private var products: [Product] {
         message.products
@@ -45,11 +46,11 @@ struct ProductListView: View {
                 )
                 .padding(12)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.secondarySystemBackground))
+                .background(theme.cardBackgroundColor)
                 .cornerRadius(12)
                 .overlay(
                     RoundedRectangle(cornerRadius: 12)
-                        .stroke(Color(.systemGray4), lineWidth: 1)
+                        .stroke(theme.cardBorderColor, lineWidth: 1)
                 )
             }
 
@@ -57,7 +58,7 @@ struct ProductListView: View {
                 Button(action: onToggleExpand) {
                     Text(isExpanded ? "Show less" : "Show more")
                         .font(.subheadline)
-                        .foregroundColor(.accentColor)
+                        .foregroundColor(theme.expandControlColor)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 4)
                 }

--- a/ios-sdk/YaloChatDemo/ProductQuantityStepper.swift
+++ b/ios-sdk/YaloChatDemo/ProductQuantityStepper.swift
@@ -21,7 +21,7 @@ struct ProductQuantityStepper: View {
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
-            .foregroundColor(value > 0 ? theme.expandControlColor : theme.messageFooterColor)
+            .foregroundColor(value > 0 ? theme.numericControlIconColor : theme.messageFooterColor)
             .disabled(value <= 0)
 
             Text("\(formatQuantity(value)) \(unitName)")
@@ -34,7 +34,7 @@ struct ProductQuantityStepper: View {
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
-            .foregroundColor(theme.expandControlColor)
+            .foregroundColor(theme.numericControlIconColor)
         }
     }
 }

--- a/ios-sdk/YaloChatDemo/ProductQuantityStepper.swift
+++ b/ios-sdk/YaloChatDemo/ProductQuantityStepper.swift
@@ -11,15 +11,17 @@ struct ProductQuantityStepper: View {
     var onAdd: () -> Void = {}
     var onRemove: () -> Void = {}
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         HStack(spacing: 0) {
             Button(action: onRemove) {
-                Image(systemName: "minus")
+                Image(systemName: theme.removeIconName)
                     .font(.caption)
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
-            .foregroundColor(value > 0 ? .accentColor : Color(.systemGray4))
+            .foregroundColor(value > 0 ? theme.expandControlColor : theme.messageFooterColor)
             .disabled(value <= 0)
 
             Text("\(formatQuantity(value)) \(unitName)")
@@ -27,12 +29,12 @@ struct ProductQuantityStepper: View {
                 .padding(.horizontal, 4)
 
             Button(action: onAdd) {
-                Image(systemName: "plus")
+                Image(systemName: theme.addIconName)
                     .font(.caption)
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
-            .foregroundColor(.accentColor)
+            .foregroundColor(theme.expandControlColor)
         }
     }
 }

--- a/ios-sdk/YaloChatDemo/QuickRepliesView.swift
+++ b/ios-sdk/YaloChatDemo/QuickRepliesView.swift
@@ -31,19 +31,22 @@ private struct QuickReplyChip: View {
     let text: String
     var onTap: () -> Void = {}
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         Button(action: onTap) {
             Text(text)
                 .font(.subheadline)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
+                .background(theme.quickReplyBackgroundColor)
                 .overlay(
                     RoundedRectangle(cornerRadius: 20)
-                        .stroke(Color.accentColor, lineWidth: 1)
+                        .stroke(theme.quickReplyBorderColor, lineWidth: 1)
                 )
         }
         .buttonStyle(.plain)
-        .foregroundColor(.accentColor)
+        .foregroundColor(theme.quickReplyTextColor)
         .frame(maxWidth: UIScreen.main.bounds.width * 0.5)
     }
 }

--- a/ios-sdk/YaloChatDemo/QuickRepliesView.swift
+++ b/ios-sdk/YaloChatDemo/QuickRepliesView.swift
@@ -47,6 +47,6 @@ private struct QuickReplyChip: View {
         }
         .buttonStyle(.plain)
         .foregroundColor(theme.quickReplyTextColor)
-        .frame(maxWidth: UIScreen.main.bounds.width * 0.5)
+        .frame(maxWidth: 220)
     }
 }

--- a/ios-sdk/YaloChatDemo/WaveformRecorder.swift
+++ b/ios-sdk/YaloChatDemo/WaveformRecorder.swift
@@ -10,20 +10,22 @@ struct WaveformRecorder: View {
     // Called with (fileName, amplitudes, durationMs) when the user taps send.
     let onSend: (String, [Double], Int64) -> Void
 
+    @Environment(\.chatTheme) private var theme
+
     var body: some View {
         HStack(spacing: 12) {
             Button(action: audioObservable.cancelRecording) {
-                Image(systemName: "xmark.circle.fill")
-                    .foregroundColor(.secondary)
+                Image(systemName: theme.cancelRecordingIconName)
+                    .foregroundColor(theme.messageFooterColor)
                     .font(.title2)
             }
 
             Text(audioObservable.durationText)
                 .monospacedDigit()
-                .foregroundColor(.red)
+                .foregroundColor(theme.errorColor)
                 .frame(width: 48, alignment: .leading)
 
-            WaveformView(amplitudes: audioObservable.recordingAmplitudes, color: .red)
+            WaveformView(amplitudes: audioObservable.recordingAmplitudes, color: theme.errorColor)
                 .frame(height: 32)
 
             Button {
@@ -32,10 +34,10 @@ struct WaveformRecorder: View {
                 }
             } label: {
                 Image(systemName: "stop.circle.fill")
-                    .foregroundColor(.white)
+                    .foregroundColor(theme.sendButtonIconColor)
                     .font(.title2)
                     .padding(6)
-                    .background(Color.accentColor)
+                    .background(theme.sendButtonColor)
                     .clipShape(Circle())
             }
         }

--- a/ios-sdk/YaloChatDemo/WaveformRecorder.swift
+++ b/ios-sdk/YaloChatDemo/WaveformRecorder.swift
@@ -22,10 +22,10 @@ struct WaveformRecorder: View {
 
             Text(audioObservable.durationText)
                 .monospacedDigit()
-                .foregroundColor(theme.errorColor)
+                .foregroundColor(theme.timerColor)
                 .frame(width: 48, alignment: .leading)
 
-            WaveformView(amplitudes: audioObservable.recordingAmplitudes, color: theme.errorColor)
+            WaveformView(amplitudes: audioObservable.recordingAmplitudes, color: theme.waveformColor)
                 .frame(height: 32)
 
             Button {
@@ -33,7 +33,7 @@ struct WaveformRecorder: View {
                     onSend(data.fileName, data.amplitudes, data.durationMs)
                 }
             } label: {
-                Image(systemName: "stop.circle.fill")
+                Image(systemName: theme.stopRecordingIconName)
                     .foregroundColor(theme.sendButtonIconColor)
                     .font(.title2)
                     .padding(6)

--- a/ios-sdk/YaloChatDemo/WaveformRecorder.swift
+++ b/ios-sdk/YaloChatDemo/WaveformRecorder.swift
@@ -16,7 +16,7 @@ struct WaveformRecorder: View {
         HStack(spacing: 12) {
             Button(action: audioObservable.cancelRecording) {
                 Image(systemName: theme.cancelRecordingIconName)
-                    .foregroundColor(theme.messageFooterColor)
+                    .foregroundColor(theme.cancelRecordingIconColor)
                     .font(.title2)
             }
 

--- a/ios-sdk/YaloChatDemo/YaloChat.swift
+++ b/ios-sdk/YaloChatDemo/YaloChat.swift
@@ -11,18 +11,30 @@ import ChatSdk
 //       channelName: "My Channel",
 //       channelId: "your-channel-id",
 //       organizationId: "your-org-id",
-//       environment: .staging
+//       environment: .staging,
+//       theme: ChatTheme(sendButtonColor: .purple),
+//       onShopPressed: { print("shop tapped") }
 //   )
 public final class YaloChat {
 
     private init() {}
 
+    private(set) static var theme: ChatTheme = ChatTheme()
+    private(set) static var onShopPressed: (() -> Void)? = nil
+    private(set) static var onCartPressed: (() -> Void)? = nil
+
     public static func initialize(
         channelName: String,
         channelId: String,
         organizationId: String,
-        environment: YaloChatEnvironment = .production
+        environment: YaloChatEnvironment = .production,
+        theme: ChatTheme = ChatTheme(),
+        onShopPressed: (() -> Void)? = nil,
+        onCartPressed: (() -> Void)? = nil
     ) {
+        YaloChat.theme = theme
+        YaloChat.onShopPressed = onShopPressed
+        YaloChat.onCartPressed = onCartPressed
         let config = YaloChatConfig(
             channelName: channelName,
             channelId: channelId,

--- a/ios-sdk/YaloChatDemo/YaloChatDemoApp.swift
+++ b/ios-sdk/YaloChatDemo/YaloChatDemoApp.swift
@@ -7,12 +7,33 @@ import SwiftUI
 struct YaloChatDemoApp: App {
 
     init() {
+        // TEST 1 — Default theme: uncomment the block below and comment out TEST 2.
         YaloChat.initialize(
             channelName: Credentials.channelName,
             channelId: Credentials.channelId,
             organizationId: Credentials.organizationId,
             environment: Credentials.environment
         )
+
+        // TEST 2 — Custom theme: swap the comment above/below to verify theming works.
+        // YaloChat.initialize(
+        //     channelName: Credentials.channelName,
+        //     channelId: Credentials.channelId,
+        //     organizationId: Credentials.organizationId,
+        //     environment: Credentials.environment,
+        //     theme: ChatTheme(
+        //         appBarBackgroundColor: .purple,
+        //         userBubbleColor: .green,
+        //         sendButtonColor: .orange,
+        //         waveformColor: .pink,
+        //         quickReplyBorderColor: .orange,
+        //         quickReplyTextColor: .orange,
+        //         productPriceColor: .red,
+        //         expandControlColor: .orange
+        //     ),
+        //     onShopPressed: { print("shop tapped") },
+        //     onCartPressed: { print("cart tapped") }
+        // )
     }
 
     var body: some Scene {


### PR DESCRIPTION
## Summary

### Theming (M7)

- **\`ChatTheme.swift\`** — new struct with 74 properties (45 colors, 7 fonts, 19 SF Symbol strings, 1 corner radius, 1 optional image) injected via SwiftUI \`EnvironmentKey\`. Defaults match Flutter SDK's \`SdkColors\` light theme hex values.
- **\`ChatAppBar.swift\`** — new view mirroring Flutter's \`ChatAppBar\` and Android's \`ChatAppBar.kt\`: optional circular avatar, channel name, animated typing status text (slide+fade), shop/cart action buttons.
- **\`YaloChat.initialize()\`** — now accepts \`theme: ChatTheme\`, \`onShopPressed\`, and \`onCartPressed\`.
- **All 12 existing iOS views** updated to consume \`@Environment(\.chatTheme)\` — zero hardcoded colors/fonts remain.
- **Typing indicator standardized** — removed the iOS-only dot bubble; all platforms now show typing status only in the app bar header (matches Flutter + Android).
- **Dark mode fixes** — \`appBarBackgroundColor\` defaults to \`Color(.systemBackground)\` (adaptive); \`userBubbleTextColor\` uses fixed \`0x111111\` since the user bubble is always a light branded color.
- **Flutter theme parity** — full property set covering per-icon colors, product pricing chip, image placeholder icon, recording timer, waveform, and all SF Symbol name overrides.
- **Android** — \`messageFooterColor\`, \`errorColor\`, \`errorIcon\`, \`productPriceBackgroundColor\` and corrected default values added to \`ChatTheme.kt\` to reach Flutter/iOS parity.

### Markdown in agent messages

- **iOS** — agent Text/QuickReply messages rendered via native \`AttributedString(markdown:)\` (iOS 15, zero dependencies). Inline CommonMark: **bold**, *italic*, \`code\`, ~~strikethrough~~, tappable links (open in Safari). User messages stay plain text. Link runs keep their natural tint color — visually distinguishable from body text.
- **Android** — agent Text/QuickReply messages rendered via \`com.mikepenz:multiplatform-markdown-renderer\` (CommonMark). Mirrors Flutter's \`flutter_markdown_plus\`. Links open via \`LocalUriHandler\` (system browser). Link color uses \`theme.expandControlsStyle.color\`.

### Code review fixes

- iOS: \`ChatAppBar\` title uses \`actionIconColor\` (not \`agentBubbleTextColor\`); typing status uses \`theme.messageFooterFont\`
- iOS: \`quickReplyTextColor\` default corrected to \`0x111111\` (was \`0x2207F1\`, matches Flutter)
- iOS: removed \`UIScreen.main\` deprecation from \`QuickRepliesView\`; fixed deprecated \`onChange\` closure in \`ProductListView\` + \`ProductCarouselView\`
- iOS: removed duplicate \`salePrice\` computation in \`ProductPriceRow\`
- Android: send-error indicator added to \`MessageItem\` for \`MessageStatus.ERROR\` — mirrors iOS + Flutter
- Android: \`VideoMessageItem\` video placeholder uses \`theme.imagePlaceholderBackgroundColor\`; typing status uses \`theme.messageFooterStyle\`
- Android: default colors corrected to match Flutter/iOS — \`currencyIconColor\`, \`productPriceStyle\`, \`productPriceBackgroundColor\`, \`cardBorderColor\`

## Test plan

- [ ] Default theme: build and run — UI looks identical to before (no visual regressions)
- [ ] Custom theme: set \`ChatTheme(appBarBackgroundColor: .purple, userBubbleColor: .green, sendButtonColor: .orange)\` — colors change accordingly
- [ ] Dark mode: toggle in simulator — app bar and bubbles adapt; user bubble text remains readable
- [ ] Typing indicator: trigger typing — status text appears below channel name in app bar only (no dot bubble in message list)
- [ ] iOS markdown: send agent message with \`**bold** and a [link](https://yalo.com)\` — bold renders, link is tappable and opens browser, link is a visually different color from body text
- [ ] Android markdown: same test — bold text and tappable link in agent bubble
- [ ] Android: \`./gradlew :sdk:testDebugUnitTest\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)