### PR TITLE
feat: Error handling web-sdk

### DIFF
--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -114,6 +114,7 @@ export default class YaloChatWindowController implements ReactiveController {
         this.host.logger.error('Unable to send message to Yalo', {
           error: yaloResult.error,
         });
+        await this._markMessageAsError(localResult.value);
       }
     } else {
       this.host.logger.error('Unable to insert message locally', {
@@ -149,6 +150,7 @@ export default class YaloChatWindowController implements ReactiveController {
         this.host.logger.error('Unable to send voice message to Yalo', {
           error: yaloResult.error,
         });
+        await this._markMessageAsError(localResult.value);
       }
     } else {
       this.host.logger.error('Unable to insert voice message locally', {
@@ -186,6 +188,7 @@ export default class YaloChatWindowController implements ReactiveController {
         this.host.logger.error('Unable to send attachment message to Yalo', {
           error: yaloResult.error,
         });
+        await this._markMessageAsError(localResult.value);
       }
     } else {
       this.host.logger.error('Unable to insert attachment message locally', {
@@ -221,6 +224,7 @@ export default class YaloChatWindowController implements ReactiveController {
         this.host.logger.error('Unable to send image message to Yalo', {
           error: yaloResult.error,
         });
+        await this._markMessageAsError(localResult.value);
       }
     } else {
       this.host.logger.error('Unable to insert image message locally', {
@@ -234,6 +238,54 @@ export default class YaloChatWindowController implements ReactiveController {
       this.isWriting = false;
       this.host.requestUpdate();
     }, this._writingTimeoutMs);
+  }
+
+  async retryMessage(e: CustomEvent) {
+    const message = e.detail as ChatMessage;
+    if (message.id === undefined) return;
+
+    const retrying = new ChatMessage({ ...message, status: 'IN_PROGRESS' });
+    const localResult =
+      await this.host.chatMessageRepository.replaceChatMessage(retrying);
+    if (!localResult.ok) {
+      this.host.logger.error('Unable to update message for retry', {
+        error: localResult.error,
+      });
+      return;
+    }
+
+    const index = this.chatMessages.findIndex((m) => m.id === retrying.id);
+    if (index !== -1) {
+      this.chatMessages = [...this.chatMessages];
+      this.chatMessages[index] = retrying;
+      this.host.requestUpdate();
+    }
+
+    const yaloResult =
+      await this.host.yaloMessageRepository.insertMessage(retrying);
+    if (!yaloResult.ok) {
+      this.host.logger.error('Unable to retry sending message to Yalo', {
+        error: yaloResult.error,
+      });
+      await this._markMessageAsError(retrying);
+    }
+  }
+
+  private async _markMessageAsError(message: ChatMessage): Promise<void> {
+    const errored = new ChatMessage({ ...message, status: 'ERROR' });
+    const result =
+      await this.host.chatMessageRepository.replaceChatMessage(errored);
+    if (!result.ok) {
+      this.host.logger.error('Unable to persist error status locally', {
+        error: result.error,
+      });
+      return;
+    }
+    const index = this.chatMessages.findIndex((m) => m.id === errored.id);
+    if (index === -1) return;
+    this.chatMessages = [...this.chatMessages];
+    this.chatMessages[index] = errored;
+    this.host.requestUpdate();
   }
 
   async updateProductQuantity(e: CustomEvent) {

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import './yalo-chat-window';
 import type { YaloChatWindow } from './yalo-chat-window';
 import type { ChatMessage } from '@domain/models/chat-message/chat-message';
+import { Err, Ok } from '@domain/common/result';
 
 const baseConfig = {
   channelId: 'channel-1',
@@ -208,6 +209,173 @@ describe('YaloChatWindow', () => {
       );
 
       expect(emitted).toBe(false);
+    });
+  });
+
+  describe('error display', () => {
+    it('marks message as ERROR when remote insert fails', async () => {
+      vi.spyOn(el.yaloMessageRepository, 'insertMessage').mockResolvedValue(
+        new Err(new Error('network down'))
+      );
+
+      const footer = getFooter(el);
+      await footer.updateComplete;
+
+      const textarea = getTextarea(el);
+      textarea.value = 'Will fail';
+      textarea.dispatchEvent(
+        new Event('input', { bubbles: true, composed: true })
+      );
+      await footer.updateComplete;
+
+      getSendButton(el).click();
+
+      await vi.waitUntil(() => {
+        const messages = el.shadowRoot
+          ?.querySelector('chat-message-list') as unknown as {
+          chatMessages: ChatMessage[];
+        };
+        return messages?.chatMessages?.[0]?.status === 'ERROR';
+      });
+
+      const list = el.shadowRoot?.querySelector(
+        'chat-message-list'
+      ) as unknown as { chatMessages: ChatMessage[] };
+
+      expect(list.chatMessages[0]).toMatchObject({
+        content: 'Will fail',
+        status: 'ERROR',
+      });
+
+      const persisted = await el.chatMessageRepository.getChatMessagePageDesc(
+        null,
+        10
+      );
+      expect(persisted.ok && persisted.value.data[0]).toMatchObject({
+        content: 'Will fail',
+        status: 'ERROR',
+      });
+    });
+
+    const findById = (
+      list: { chatMessages: ChatMessage[] },
+      id: number | undefined
+    ): ChatMessage | undefined =>
+      list.chatMessages.find((m) => m.id === id);
+
+    it('retries an errored message and clears the error on success', async () => {
+      const insertSpy = vi
+        .spyOn(el.yaloMessageRepository, 'insertMessage')
+        .mockResolvedValueOnce(new Err(new Error('network down')));
+
+      const footer = getFooter(el);
+      await footer.updateComplete;
+
+      const textarea = getTextarea(el);
+      textarea.value = 'Retry me';
+      textarea.dispatchEvent(
+        new Event('input', { bubbles: true, composed: true })
+      );
+      await footer.updateComplete;
+      getSendButton(el).click();
+
+      const list = el.shadowRoot?.querySelector(
+        'chat-message-list'
+      ) as unknown as { chatMessages: ChatMessage[] };
+
+      await vi.waitUntil(() =>
+        list.chatMessages.some(
+          (m) => m.content === 'Retry me' && m.status === 'ERROR'
+        )
+      );
+      const errored = list.chatMessages.find(
+        (m) => m.content === 'Retry me' && m.status === 'ERROR'
+      ) as ChatMessage;
+      const erroredId = errored.id;
+
+      insertSpy.mockResolvedValueOnce(new Ok(errored));
+
+      el.shadowRoot
+        ?.querySelector('chat-message-list')
+        ?.dispatchEvent(
+          new CustomEvent('yalo-chat-retry-message', {
+            detail: errored,
+            bubbles: true,
+            composed: true,
+          })
+        );
+
+      await vi.waitUntil(
+        () => findById(list, erroredId)?.status === 'IN_PROGRESS'
+      );
+
+      expect(insertSpy).toHaveBeenCalledTimes(2);
+      expect(findById(list, erroredId)).toMatchObject({
+        id: erroredId,
+        content: 'Retry me',
+        status: 'IN_PROGRESS',
+      });
+
+      const persisted = await el.chatMessageRepository.getChatMessagePageDesc(
+        null,
+        100
+      );
+      const persistedMessage =
+        persisted.ok && persisted.value.data.find((m) => m.id === erroredId);
+      expect(persistedMessage).toMatchObject({
+        id: erroredId,
+        content: 'Retry me',
+        status: 'IN_PROGRESS',
+      });
+    });
+
+    it('keeps the message in ERROR when retry fails again', async () => {
+      const insertSpy = vi
+        .spyOn(el.yaloMessageRepository, 'insertMessage')
+        .mockResolvedValue(new Err(new Error('still down')));
+
+      const footer = getFooter(el);
+      await footer.updateComplete;
+
+      const textarea = getTextarea(el);
+      textarea.value = 'Stays errored';
+      textarea.dispatchEvent(
+        new Event('input', { bubbles: true, composed: true })
+      );
+      await footer.updateComplete;
+      getSendButton(el).click();
+
+      const list = el.shadowRoot?.querySelector(
+        'chat-message-list'
+      ) as unknown as { chatMessages: ChatMessage[] };
+
+      await vi.waitUntil(() =>
+        list.chatMessages.some(
+          (m) => m.content === 'Stays errored' && m.status === 'ERROR'
+        )
+      );
+      const errored = list.chatMessages.find(
+        (m) => m.content === 'Stays errored' && m.status === 'ERROR'
+      ) as ChatMessage;
+      const erroredId = errored.id;
+
+      el.shadowRoot
+        ?.querySelector('chat-message-list')
+        ?.dispatchEvent(
+          new CustomEvent('yalo-chat-retry-message', {
+            detail: errored,
+            bubbles: true,
+            composed: true,
+          })
+        );
+
+      await vi.waitUntil(() => insertSpy.mock.calls.length >= 2);
+      await vi.waitUntil(() => findById(list, erroredId)?.status === 'ERROR');
+
+      expect(findById(list, erroredId)).toMatchObject({
+        id: erroredId,
+        status: 'ERROR',
+      });
     });
   });
 

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
@@ -119,6 +119,8 @@ export class YaloChatWindow extends LitElement {
               this._chatWindowController.fetchNextPage()}
             @yalo-chat-send-text-message=${(e: CustomEvent) =>
               this._chatWindowController.sendTextMessage(e)}
+            @yalo-chat-retry-message=${(e: CustomEvent) =>
+              this._chatWindowController.retryMessage(e)}
             @yalo-chat-product-quantity-change=${(e: CustomEvent) =>
               this._chatWindowController.updateProductQuantity(e)}
           >


### PR DESCRIPTION
- Adds retrial of error messages to web-sdk
- Updates messages when they're not able to be sent.