### PR TITLE
feat: Added embedded mode for web-sdk

### DIFF
--- a/web-sdk/README.md
+++ b/web-sdk/README.md
@@ -17,7 +17,7 @@ If you provide custom icons for every icon key via the `icons` config option, th
 
 ## Quick start
 
-Add the icon font, the SDK script, and initialize the client:
+Add the icon font, place a sized container on your page, and initialize the client pointing at that container's id:
 
 ```html
 <!doctype html>
@@ -30,10 +30,15 @@ Add the icon font, the SDK script, and initialize the client:
       href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,arrow_forward,close,description,error,mic,pause,play_arrow,send,stop"
       rel="stylesheet"
     />
+    <style>
+      #yalo-chat {
+        width: 400px;
+        height: 600px;
+      }
+    </style>
   </head>
   <body>
-    <!-- The button or element the chat widget attaches to -->
-    <button type="button" id="yalo-chat">Open chat</button>
+    <div id="yalo-chat"></div>
 
     <script src="https://chat-sdk-staging.yalochat.com/v0.0.1/sdk.js"></script>
     <script>
@@ -44,13 +49,63 @@ Add the icon font, the SDK script, and initialize the client:
         target: 'yalo-chat',
       });
       client.init();
+      client.open();
     </script>
   </body>
 </html>
 ```
 
-`target` is the `id` of an HTML element on the page. The chat window will render next to that element.
+`target` is the `id` of an HTML element on the page. The chat renders inside that element and fills it. You own the container's size and position, so the SDK does not impose floating-popup behavior, anchors, or click handlers.
 
+The chat is hidden until you call `client.open()`. Use `client.close()` to hide it.
+
+### Floating popup pattern
+
+If you want a classic FAB-and-popup, wrap the chat container and a toggle button in a shared parent. Putting the size on `yalo-chat-window` (rather than the container `div`) lets the container collapse to zero when the chat is hidden, so the FAB sits at the corner alone until the user opens the chat:
+
+```html
+<style>
+  .chat-widget {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 8px;
+    z-index: 1000;
+  }
+  yalo-chat-window {
+    --yalo-chat-width: 400px;
+    --yalo-chat-height: 600px;
+  }
+</style>
+
+<div class="chat-widget">
+  <div id="yalo-chat"></div>
+  <button type="button" id="chat-fab">Chat with us</button>
+</div>
+
+<script>
+  var client = new YaloChatSdk.YaloChatClient({
+    channelId: 'your-channel-id',
+    organizationId: 'your-organization-id',
+    channelName: 'Support',
+    target: 'yalo-chat',
+  });
+  client.init();
+
+  document.getElementById('chat-fab').addEventListener('click', () => {
+    if (client.chatWindowEl?.open) {
+      client.close();
+    } else {
+      client.open();
+    }
+  });
+</script>
+```
+
+The chat container is listed first inside `.chat-widget` so column-flex places it above the FAB. When `yalo-chat-window` is hidden, the wrapper collapses around the button alone; when open, the chat appears above the button.
 
 ## Configuration
 
@@ -59,12 +114,13 @@ Add the icon font, the SDK script, and initialize the client:
 | `channelId`          | `string`   | Yes      | Your channel identifier                       |
 | `organizationId`     | `string`   | Yes      | Your organization identifier                  |
 | `channelName`        | `string`   | Yes      | Name displayed in the chat header             |
-| `target`             | `string`   | Yes      | ID of the HTML element the widget attaches to |
+| `target`             | `string`   | Yes      | ID of the HTML element the chat renders inside |
 | `image`              | `string`   | No       | URL for the channel avatar image              |
 | `locale`             | `string`   | No       | Locale for the chat UI (e.g. `"es"`, `"en"`)  |
 | `icons`              | `SdkIcons` | No       | Custom icon overrides (see below)             |
 | `audioWaveformColor` | `string`   | No       | Color for the audio waveform visualization    |
 | `userId`             | `string`   | No       | Your own user identifier. When provided, the chat session is linked to your user. |
+| `openContext`        | `string`   | No       | Context describing where the chat is being opened from. Can be a structured value such as an SKU like `"123"`, or natural language like `"product page of product 123"`. Fixed for the lifetime of the chat instance. |
 
 ### Custom icons
 
@@ -93,34 +149,7 @@ The widget can be fully customized with CSS custom properties. See the [Theming 
 
 | Method | Description |
 |--------|-------------|
-| `client.init()` | Initializes the chat widget and attaches it to the target element |
-| `client.open(openContext?)` | Opens the chat window. Accepts an optional `openContext` string describing where the chat is being opened from. It can be a structured value such as an SKU like `"123"`, or natural language like `"product page of product 123"` |
-| `client.close()` | Closes the chat window |
+| `client.init()` | Initializes the chat widget and attaches it inside the target element. The chat starts hidden. |
+| `client.open()` | Shows the chat window. Uses the `openContext` from the config. |
+| `client.close()` | Hides the chat window. |
 | `client.registerCommand(command, callback)` | Registers a callback for a client-to-channel command (see [Commands](doc/commands.md)) |
-
-## Full example
-
-```html
-<link
-  href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,arrow_forward,close,description,error,mic,pause,play_arrow,send,stop"
-  rel="stylesheet"
-/>
-
-<button type="button" id="support-chat">Need help?</button>
-
-<script src="https://chat-sdk-staging.yalochat.com/v0.0.1/sdk.js"></script>
-<script>
-  var client = new YaloChatSdk.YaloChatClient({
-    channelId: 'your-channel-id',
-    organizationId: 'your-organization-id',
-    channelName: 'Support',
-    target: 'support-chat',
-    image: '/avatar.png',
-    locale: 'es',
-  });
-  client.init();
-
-  // Optionally open the chat automatically
-  client.open();
-</script>
-```

--- a/web-sdk/doc/theming.md
+++ b/web-sdk/doc/theming.md
@@ -33,6 +33,14 @@ Every variable includes a built-in fallback, so the widget renders correctly eve
   /* Font family used across the entire chat widget.
      Set this to match your site typography. */
   --yalo-chat-font: sans-serif;
+
+  /* Width of the chat window. Accepts any CSS length
+     (px, rem, %, vw, etc.). */
+  --yalo-chat-width: 500px;
+
+  /* Height of the chat window. Accepts any CSS length
+     (px, rem, %, vh, etc.). */
+  --yalo-chat-height: 720px;
 }
 ```
 
@@ -310,20 +318,6 @@ Buttons attached to assistant messages, rendered below the body.
 
   /* Font size for the numeric input text. */
   --yalo-chat-numeric-font-size: 0.875rem;
-}
-```
-
-### Positioning
-
-These variables are set automatically at runtime based on the target element's position. You generally do not need to override them, but you can if you want to place the widget at a fixed location.
-
-```css
-:root {
-  /* Distance from the bottom edge of the viewport to the chat window. */
-  --yalo-chat-inset-bottom: 80px;
-
-  /* Distance from the right edge of the viewport to the chat window. */
-  --yalo-chat-inset-right: 24px;
 }
 ```
 

--- a/web-sdk/index.html
+++ b/web-sdk/index.html
@@ -12,21 +12,24 @@
   </head>
   <body>
     <img class="logo" src="yalo-logo.svg" alt="Yalo" />
-    <button type="button" class="fab" id="yalo-chat" aria-label="Open chat">
-      <svg
-        viewBox="0 0 24 24"
-        fill="none"
-        stroke="currentColor"
-        stroke-width="2"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-      >
-        <title>Chat button</title>
-        <path
-          d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
-        ></path>
-      </svg>
-    </button>
+    <div class="chat-widget">
+      <div id="yalo-chat"></div>
+      <button type="button" class="fab" id="chat-fab" aria-label="Open chat">
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <title>Chat button</title>
+          <path
+            d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"
+          ></path>
+        </svg>
+      </button>
+    </div>
 
     <script type="module">
       import { YaloChatClient } from '/src/chat.ts';
@@ -36,10 +39,21 @@
         organizationId: '', // Your organization id
         channelName: 'Chat Demo', // Your channel name that will appear in the bot chat
         image: '/oris-icon.svg',
-        target: 'yalo-chat', // The target element to render over
+        target: 'yalo-chat',
+        userId: 'test-user-1', // Optional: identify the user with your own ID
       });
       client.init();
-      client.open();
+
+      const fab = document.getElementById('chat-fab');
+      fab.addEventListener('click', () => {
+        if (client.chatWindowEl?.open) {
+          client.close();
+          fab.classList.remove('open');
+        } else {
+          client.open();
+          fab.classList.add('open');
+        }
+      });
     </script>
   </body>
 </html>

--- a/web-sdk/public/styles.css
+++ b/web-sdk/public/styles.css
@@ -23,10 +23,18 @@ body {
   height: auto;
 }
 
-.fab {
+.chat-widget {
   position: fixed;
   bottom: 24px;
   right: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  z-index: 1000;
+}
+
+.fab {
   width: 56px;
   height: 56px;
   border-radius: 50%;
@@ -39,7 +47,6 @@ body {
   align-items: center;
   justify-content: center;
   transition: transform 0.2s ease;
-  z-index: 1000;
 }
 
 .fab:hover {
@@ -58,4 +65,9 @@ body {
 
 .fab.open svg {
   transform: rotate(90deg);
+}
+
+yalo-chat-window {
+  --yalo-chat-width: 400px;
+  --yalo-chat-height: 600px;
 }

--- a/web-sdk/src/data/services/client/yalo-chat-client.test.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.test.ts
@@ -30,13 +30,22 @@ describe('YaloChatClient', () => {
   });
 
   describe('init', () => {
-    it('appends yalo-chat-window to the document body', async () => {
+    it('appends the chat window inside the target element', async () => {
       const client = new YaloChatClient(baseConfig);
       client.init();
       await vi.waitUntil(
         () => client.chatWindowEl?.yaloMessageRepository != null
       );
-      expect(getChatWindow()).not.toBeNull();
+      expect(targetEl.querySelector('yalo-chat-window')).not.toBeNull();
+    });
+
+    it('does not open the chat window automatically', async () => {
+      const client = new YaloChatClient(baseConfig);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      expect(getChatWindow().open).toBe(false);
     });
 
     it('sets config on the chat window element', async () => {
@@ -67,23 +76,12 @@ describe('YaloChatClient', () => {
       );
     });
 
-    it('opens chat when target is clicked and chat is closed', async () => {
+    it('does not bind a click handler to the target element', async () => {
       const client = new YaloChatClient(baseConfig);
       client.init();
       await vi.waitUntil(
         () => client.chatWindowEl?.yaloMessageRepository != null
       );
-      targetEl.click();
-      expect(getChatWindow().open).toBe(true);
-    });
-
-    it('closes chat when target is clicked and chat is open', async () => {
-      const client = new YaloChatClient(baseConfig);
-      client.init();
-      await vi.waitUntil(
-        () => client.chatWindowEl?.yaloMessageRepository != null
-      );
-      client.open();
       targetEl.click();
       expect(getChatWindow().open).toBe(false);
     });
@@ -111,27 +109,20 @@ describe('YaloChatClient', () => {
       expect(getChatWindow().open).toBe(true);
     });
 
-    it('adds open class to target element', async () => {
-      const client = new YaloChatClient(baseConfig);
+    it('forwards the configured openContext to the chat window', async () => {
+      const client = new YaloChatClient({
+        ...baseConfig,
+        openContext: 'product-page',
+      });
       client.init();
       await vi.waitUntil(
         () => client.chatWindowEl?.yaloMessageRepository != null
       );
       client.open();
-      expect(targetEl.classList.contains('open')).toBe(true);
-    });
-
-    it('forwards the openContext to the chat window when provided', async () => {
-      const client = new YaloChatClient(baseConfig);
-      client.init();
-      await vi.waitUntil(
-        () => client.chatWindowEl?.yaloMessageRepository != null
-      );
-      client.open('product-page');
       expect(getChatWindow().openContext).toBe('product-page');
     });
 
-    it('leaves openContext undefined when not provided', async () => {
+    it('leaves openContext undefined when not configured', async () => {
       const client = new YaloChatClient(baseConfig);
       client.init();
       await vi.waitUntil(
@@ -207,17 +198,6 @@ describe('YaloChatClient', () => {
       client.open();
       client.close();
       expect(getChatWindow().open).toBe(false);
-    });
-
-    it('removes open class from target element', async () => {
-      const client = new YaloChatClient(baseConfig);
-      client.init();
-      await vi.waitUntil(
-        () => client.chatWindowEl?.yaloMessageRepository != null
-      );
-      client.open();
-      client.close();
-      expect(targetEl.classList.contains('open')).toBe(false);
     });
   });
 });

--- a/web-sdk/src/data/services/client/yalo-chat-client.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.ts
@@ -33,9 +33,11 @@ export default class YaloChatClient {
     ) as YaloChatWindow;
     this.chatWindowEl.config = this.config;
     this.chatWindowEl.commands = new Map(this._commands);
-    document.body.appendChild(this.chatWindowEl);
 
     this.targetEl = document.getElementById(this.config.target);
+
+    const mountInto = this.targetEl ?? document.body;
+    mountInto.appendChild(this.chatWindowEl);
 
     if (!this.targetEl) {
       console.warn(
@@ -44,50 +46,18 @@ export default class YaloChatClient {
       return;
     }
 
-    new ResizeObserver(() => this._updatePosition()).observe(this.targetEl);
-    window.addEventListener('resize', () => this._updatePosition());
-    this._updatePosition();
-
-    this.targetEl.addEventListener('click', () => {
-      if (this.chatWindowEl?.open) {
-        this.close();
-      } else {
-        this.open();
-      }
-    });
-
-    this.chatWindowEl.addEventListener('yalo-chat-close', () => {
-      this.close();
-    });
+    this.chatWindowEl.addEventListener('yalo-chat-close', () => this.close());
   }
 
-  private _updatePosition(): void {
-    if (!this.targetEl || !this.chatWindowEl) return;
-    const rect = this.targetEl.getBoundingClientRect();
-    const gap = 8;
-    const bottom = window.innerHeight - rect.top + gap;
-    const right = window.innerWidth - rect.right;
-    this.chatWindowEl.style.setProperty(
-      '--yalo-chat-inset-bottom',
-      `${bottom}px`
-    );
-    this.chatWindowEl.style.setProperty(
-      '--yalo-chat-inset-right',
-      `${right}px`
-    );
-  }
-
-  open(openContext?: string): void {
+  open(): void {
     if (this.chatWindowEl) {
-      this.chatWindowEl.openContext = openContext;
+      this.chatWindowEl.openContext = this.config.openContext;
       this.chatWindowEl.open = true;
     }
-    this.targetEl?.classList.add('open');
   }
 
   close(): void {
     if (this.chatWindowEl) this.chatWindowEl.open = false;
-    this.targetEl?.classList.remove('open');
   }
 
   registerCommand(command: ChatCommand, callback: ChatCommandCallback): void {

--- a/web-sdk/src/domain/config/chat-config.ts
+++ b/web-sdk/src/domain/config/chat-config.ts
@@ -22,6 +22,7 @@ export interface YaloChatClientConfig {
   icons?: SdkIcons;
   audioWaveformColor?: string;
   userId?: string;
+  openContext?: string;
 }
 
 export const defaultIcons: SdkIcons = {

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -379,6 +379,20 @@ describe('YaloChatWindow', () => {
     });
   });
 
+  describe('sizing', () => {
+    it('respects --yalo-chat-width and --yalo-chat-height overrides', async () => {
+      el.open = true;
+      el.style.setProperty('--yalo-chat-width', '320px');
+      el.style.setProperty('--yalo-chat-height', '600px');
+      await el.updateComplete;
+
+      expect(getComputedStyle(el)).toMatchObject({
+        width: '320px',
+        height: '600px',
+      });
+    });
+  });
+
   describe('chat-footer expansion', () => {
     it('sets overflow-y to scroll when text exceeds max height', async () => {
       el.open = true;

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
@@ -40,12 +40,12 @@ export class YaloChatWindow extends LitElement {
       --yalo-chat-font: sans-serif;
       --yalo-chat-column-item-space: 8px;
       --yalo-chat-row-item-space: 8px;
+      --yalo-chat-width: 100%;
+      --yalo-chat-height: 100%;
 
       display: none;
-      position: fixed;
-      bottom: var(--yalo-chat-inset-bottom, 80px);
-      right: var(--yalo-chat-inset-right, 24px);
-      z-index: 9999;
+      width: var(--yalo-chat-width);
+      height: var(--yalo-chat-height);
     }
 
     :host([open]) {
@@ -53,12 +53,11 @@ export class YaloChatWindow extends LitElement {
     }
 
     .chat-window {
-      width: 500px;
-      height: 720px;
+      width: 100%;
+      height: 100%;
       background: var(--yalo-chat-background);
       border-radius: var(--yalo-chat-corner-radius);
       font-family: var(--yalo-chat-font);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.18);
       display: flex;
       flex-direction: column;
       overflow: hidden;


### PR DESCRIPTION
- Remove floating mode from web-sdk since it can be replicated with the embedded one. Embedded is a more simpler since we don’t need to calculate boundaries and follow a target and just left it to the client (which should be easier for them to setup).
- Updates doc to have this changes documented.
- Moves open context from the open method to the constructor.