### PR TITLE
Error message behavior flutter

### DIFF
--- a/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_bloc.dart
+++ b/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_bloc.dart
@@ -60,6 +60,7 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
     on<ChatSendVoiceMessage>(_handleSendVoiceMessage);
     on<ChatSendImageMessage>(_handleSendImageMessage);
     on<ChatClearMessages>(_handleClearMessages);
+    on<ChatRetryMessage>(_handleRetryMessage);
     on<ChatUpdateProductQuantity>(_handleUpdateProductQuantity);
     on<ChatToggleMessageExpand>(_handleToggleMessageExpand);
     on<ChatClearQuickReplies>(_handleClearQuickReplies);
@@ -414,6 +415,62 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
           'Unable to persist error status for message ${message.id}',
           persistResult.error,
         );
+        break;
+    }
+  }
+
+  // Retries delivery of a previously failed user message. Only messages with
+  // MessageStatus.error are retried; other statuses are ignored.
+  Future<void> _handleRetryMessage(
+    ChatRetryMessage event,
+    Emitter<MessagesState> emit,
+  ) async {
+    final int index = state.messages.indexWhere((m) => m.id == event.messageId);
+    if (index == -1) {
+      log.warning('Unable to find message ${event.messageId} to retry');
+      return;
+    }
+    final ChatMessage message = state.messages[index];
+    if (message.status != MessageStatus.error) {
+      log.fine(
+        'Skipping retry for message ${event.messageId}, status ${message.status}',
+      );
+      return;
+    }
+
+    final ChatMessage retrying = message.copyWith(
+      status: MessageStatus.inProgress,
+    );
+    final List<ChatMessage> newMessages = [...state.messages];
+    newMessages[index] = retrying;
+    emit(state.copyWith(messages: newMessages));
+
+    final persistResult = await _chatMessageRepository.replaceChatMessage(
+      retrying,
+    );
+    switch (persistResult) {
+      case Ok():
+        log.info('Persisted retry status for message ${event.messageId}');
+        break;
+      case Error():
+        log.severe(
+          'Unable to persist retry status for message ${event.messageId}',
+          persistResult.error,
+        );
+        break;
+    }
+
+    final sendResult = await _yaloMessageRepository.sendMessage(retrying);
+    switch (sendResult) {
+      case Ok():
+        log.info('Retry succeeded for message ${event.messageId}');
+        break;
+      case Error():
+        log.severe(
+          'Retry failed for message ${event.messageId}',
+          sendResult.error,
+        );
+        await _markMessageAsError(retrying, emit);
         break;
     }
   }

--- a/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_bloc.dart
+++ b/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_bloc.dart
@@ -231,14 +231,6 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
     switch (result) {
       case Ok<ChatMessage>():
         log.info('Text message inserted successfully, id ${result.result.id}');
-        _yaloMessageRepository.sendMessage(result.result).then((sendResult) {
-          switch (sendResult) {
-            case Ok():
-              log.info('Text message sent successfully');
-            case Error():
-              log.severe('Failed to send text message', sendResult.error);
-          }
-        });
         emit(
           state.copyWith(
             // FIXME: Create a new way to track big message list copies
@@ -246,6 +238,16 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
             userMessage: '',
           ),
         );
+        final sendResult = await _yaloMessageRepository.sendMessage(
+          result.result,
+        );
+        switch (sendResult) {
+          case Ok():
+            log.info('Text message sent successfully');
+          case Error():
+            log.severe('Failed to send text message', sendResult.error);
+            await _markMessageAsError(result.result, emit);
+        }
         break;
       case Error<ChatMessage>():
         log.severe('Unable to insert text message', result.error);
@@ -283,15 +285,17 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
     switch (result) {
       case Ok<ChatMessage>():
         log.info('Voice message inserted successfully, id ${result.result.id}');
-        _yaloMessageRepository.sendMessage(result.result).then((sendResult) {
-          switch (sendResult) {
-            case Ok():
-              log.info('Voice message sent successfully');
-            case Error():
-              log.severe('Failed to send voice message', sendResult.error);
-          }
-        });
         emit(state.copyWith(messages: [result.result, ...state.messages]));
+        final sendResult = await _yaloMessageRepository.sendMessage(
+          result.result,
+        );
+        switch (sendResult) {
+          case Ok():
+            log.info('Voice message sent successfully');
+          case Error():
+            log.severe('Failed to send voice message', sendResult.error);
+            await _markMessageAsError(result.result, emit);
+        }
         break;
       case Error<ChatMessage>():
         log.severe('Failed to insert voice message', result.error);
@@ -334,14 +338,6 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
     switch (result) {
       case Ok<ChatMessage>():
         log.info('Image message inserted successfully, id ${result.result.id}');
-        _yaloMessageRepository.sendMessage(result.result).then((sendResult) {
-          switch (sendResult) {
-            case Ok():
-              log.info('Image message sent successfully');
-            case Error():
-              log.severe('Failed to send image message', sendResult.error);
-          }
-        });
         emit(
           state.copyWith(
             messages: [result.result, ...state.messages],
@@ -359,6 +355,16 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
           case Error():
             log.severe('Unable to clean image from cache');
         }
+        final sendResult = await _yaloMessageRepository.sendMessage(
+          result.result,
+        );
+        switch (sendResult) {
+          case Ok():
+            log.info('Image message sent successfully');
+          case Error():
+            log.severe('Failed to send image message', sendResult.error);
+            await _markMessageAsError(result.result, emit);
+        }
         break;
       case Error<ChatMessage>():
         log.severe('Failed to insert voice message', result.error);
@@ -374,6 +380,40 @@ class MessagesBloc extends Bloc<MessagesEvent, MessagesState>
             break;
         }
         emit(state.copyWith(chatStatus: ChatStatus.failedMessageSent));
+        break;
+    }
+  }
+
+  // Flags a previously inserted user message as failed to deliver, both in
+  // memory and in the local data source so the error survives reloads.
+  Future<void> _markMessageAsError(
+    ChatMessage message,
+    Emitter<MessagesState> emit,
+  ) async {
+    final int index = state.messages.indexWhere((m) => m.id == message.id);
+    if (index == -1) {
+      log.warning('Unable to find message ${message.id} to mark as error');
+      return;
+    }
+    final ChatMessage updatedMessage = state.messages[index].copyWith(
+      status: MessageStatus.error,
+    );
+    final List<ChatMessage> newMessages = [...state.messages];
+    newMessages[index] = updatedMessage;
+    emit(state.copyWith(messages: newMessages));
+
+    final persistResult = await _chatMessageRepository.replaceChatMessage(
+      updatedMessage,
+    );
+    switch (persistResult) {
+      case Ok():
+        log.info('Persisted error status for message ${message.id}');
+        break;
+      case Error():
+        log.severe(
+          'Unable to persist error status for message ${message.id}',
+          persistResult.error,
+        );
         break;
     }
   }

--- a/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_event.dart
+++ b/flutter-sdk/lib/src/ui/chat/view_models/messages/messages_event.dart
@@ -115,3 +115,13 @@ final class ChatClearMessages extends MessagesEvent with EquatableMixin {
   @override
   List<Object?> get props => [];
 }
+
+// Event to retry sending a user message that previously failed to deliver.
+final class ChatRetryMessage extends MessagesEvent with EquatableMixin {
+  final int messageId;
+
+  ChatRetryMessage({required this.messageId});
+
+  @override
+  List<Object?> get props => [messageId];
+}

--- a/flutter-sdk/lib/src/ui/chat/widgets/message_list/user_message.dart
+++ b/flutter-sdk/lib/src/ui/chat/widgets/message_list/user_message.dart
@@ -2,6 +2,8 @@
 
 import 'package:yalo_chat_flutter_sdk/src/common/translation.dart';
 import 'package:yalo_chat_flutter_sdk/src/domain/models/chat_message/chat_message.dart';
+import 'package:yalo_chat_flutter_sdk/src/ui/chat/view_models/messages/messages_bloc.dart';
+import 'package:yalo_chat_flutter_sdk/src/ui/chat/view_models/messages/messages_event.dart';
 import 'package:yalo_chat_flutter_sdk/src/ui/chat/widgets/message_list/user_voice_message.dart';
 import 'package:yalo_chat_flutter_sdk/src/ui/theme/view_models/theme_cubit.dart';
 import 'package:yalo_chat_flutter_sdk/ui/theme/constants.dart';
@@ -61,43 +63,50 @@ class UserMessage extends StatelessWidget {
             return bubble;
           }
 
-          return Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.end,
-            children: [
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Icon(
-                    Icons.error,
-                    key: const Key('user_message_error_icon'),
-                    color: Theme.of(context).colorScheme.error,
-                  ),
-                  SizedBox(width: SdkConstants.rowItemSpace),
-                  Flexible(child: bubble),
-                ],
-              ),
-              SizedBox(height: SdkConstants.columnItemSpace / 2),
-              Text.rich(
-                TextSpan(
+          return GestureDetector(
+            key: const Key('user_message_retry'),
+            behavior: HitTestBehavior.opaque,
+            onTap: () => context.read<MessagesBloc>().add(
+              ChatRetryMessage(messageId: message.id!),
+            ),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Row(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
-                    TextSpan(text: '${context.translate.notDelivered} '),
-                    TextSpan(
-                      text: context.translate.retry,
-                      style: const TextStyle(
-                        decoration: TextDecoration.underline,
-                        fontWeight: FontWeight.bold,
-                      ),
+                    Icon(
+                      Icons.error,
+                      key: const Key('user_message_error_icon'),
+                      color: Theme.of(context).colorScheme.error,
                     ),
+                    SizedBox(width: SdkConstants.rowItemSpace),
+                    Flexible(child: bubble),
                   ],
                 ),
-                style: TextStyle(
-                  fontSize: SdkConstants.statusFontSize,
-                  color: Theme.of(context).colorScheme.error,
+                SizedBox(height: SdkConstants.columnItemSpace / 2),
+                Text.rich(
+                  TextSpan(
+                    children: [
+                      TextSpan(text: '${context.translate.notDelivered} '),
+                      TextSpan(
+                        text: context.translate.retry,
+                        style: const TextStyle(
+                          decoration: TextDecoration.underline,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ],
+                  ),
+                  style: TextStyle(
+                    fontSize: SdkConstants.statusFontSize,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
                 ),
-              ),
-            ],
+              ],
+            ),
           );
         },
       ),

--- a/flutter-sdk/test/ui/chat/view_models/messages/messages_bloc_test.dart
+++ b/flutter-sdk/test/ui/chat/view_models/messages/messages_bloc_test.dart
@@ -2275,6 +2275,216 @@ void main() {
       );
     });
 
+    group('retry message', () {
+      final fixedClock = Clock.fixed(DateTime.now());
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should resend an errored message and leave it in progress on success',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(
+          messages: [
+            ChatMessage(
+              id: 1,
+              role: MessageRole.user,
+              type: MessageType.text,
+              status: MessageStatus.error,
+              content: 'Test message',
+              timestamp: fixedClock.now(),
+            ),
+          ],
+        ),
+        act: (bloc) {
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.ok(Unit()));
+          bloc.add(ChatRetryMessage(messageId: 1));
+        },
+        expect: () => [
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'status flips to inProgress',
+            equals(MessageStatus.inProgress),
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => yaloMessageRepository.sendMessage(
+              any(
+                that: isA<ChatMessage>().having(
+                  (m) => m.id,
+                  'id',
+                  equals(1),
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should mark the message as error again when the retry sendMessage fails',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(
+          messages: [
+            ChatMessage(
+              id: 1,
+              role: MessageRole.user,
+              type: MessageType.text,
+              status: MessageStatus.error,
+              content: 'Test message',
+              timestamp: fixedClock.now(),
+            ),
+          ],
+        ),
+        act: (bloc) {
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('send failed')));
+          bloc.add(ChatRetryMessage(messageId: 1));
+        },
+        expect: () => [
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'status flips to inProgress',
+            equals(MessageStatus.inProgress),
+          ),
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'status flips back to error',
+            equals(MessageStatus.error),
+          ),
+        ],
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should not emit when the message id is unknown',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(
+          messages: [
+            ChatMessage(
+              id: 1,
+              role: MessageRole.user,
+              type: MessageType.text,
+              status: MessageStatus.error,
+              content: 'Test message',
+              timestamp: fixedClock.now(),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(ChatRetryMessage(messageId: 999)),
+        expect: () => [],
+        verify: (_) {
+          verifyNever(() => yaloMessageRepository.sendMessage(any()));
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should not retry messages whose status is not error',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(
+          messages: [
+            ChatMessage(
+              id: 1,
+              role: MessageRole.user,
+              type: MessageType.text,
+              status: MessageStatus.inProgress,
+              content: 'Test message',
+              timestamp: fixedClock.now(),
+            ),
+          ],
+        ),
+        act: (bloc) => bloc.add(ChatRetryMessage(messageId: 1)),
+        expect: () => [],
+        verify: (_) {
+          verifyNever(() => yaloMessageRepository.sendMessage(any()));
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should keep the errored message in its original position',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(
+          messages: [
+            ChatMessage(
+              id: 3,
+              role: MessageRole.assistant,
+              type: MessageType.text,
+              content: 'Other 3',
+              timestamp: fixedClock.now(),
+            ),
+            ChatMessage(
+              id: 2,
+              role: MessageRole.user,
+              type: MessageType.text,
+              status: MessageStatus.error,
+              content: 'Failing message',
+              timestamp: fixedClock.now(),
+            ),
+            ChatMessage(
+              id: 1,
+              role: MessageRole.user,
+              type: MessageType.text,
+              content: 'Other 1',
+              timestamp: fixedClock.now(),
+            ),
+          ],
+        ),
+        act: (bloc) {
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.ok(Unit()));
+          bloc.add(ChatRetryMessage(messageId: 2));
+        },
+        expect: () => [
+          isA<MessagesState>()
+              .having(
+                (state) => state.messages.map((m) => m.id).toList(),
+                'preserved order',
+                equals([3, 2, 1]),
+              )
+              .having(
+                (state) => state.messages[1].status,
+                'middle message status',
+                equals(MessageStatus.inProgress),
+              ),
+        ],
+      );
+    });
+
     group('clear messages', () {
       blocTest<MessagesBloc, MessagesState>(
         'should emit empty messages when chat cleared',

--- a/flutter-sdk/test/ui/chat/view_models/messages/messages_bloc_test.dart
+++ b/flutter-sdk/test/ui/chat/view_models/messages/messages_bloc_test.dart
@@ -812,6 +812,244 @@ void main() {
           ),
         ],
       );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should mark a text message as error when sending to yalo fails',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(userMessage: 'Test message'),
+        act: (bloc) {
+          final inserted = ChatMessage(
+            id: 1,
+            role: MessageRole.user,
+            type: MessageType.text,
+            content: 'Test message',
+            timestamp: fixedClock.now(),
+          );
+          when(
+            () => chatMessageRepository.insertChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(inserted));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('send failed')));
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          bloc.add(ChatSendTextMessage());
+        },
+        expect: () => [
+          isA<MessagesState>()
+              .having((state) => state.userMessage, 'userMessage', equals(''))
+              .having(
+                (state) => state.messages.first.status,
+                'inserted status',
+                equals(MessageStatus.inProgress),
+              ),
+          isA<MessagesState>().having(
+            (state) => state.messages.first,
+            'message marked as error',
+            equals(
+              ChatMessage(
+                id: 1,
+                role: MessageRole.user,
+                type: MessageType.text,
+                content: 'Test message',
+                status: MessageStatus.error,
+                timestamp: fixedClock.now(),
+              ),
+            ),
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => chatMessageRepository.replaceChatMessage(
+              any(
+                that: isA<ChatMessage>().having(
+                  (m) => m.status,
+                  'status',
+                  MessageStatus.error,
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should mark a voice message as error when sending to yalo fails',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        act: (bloc) {
+          final inserted = ChatMessage.voice(
+            id: 3,
+            role: MessageRole.user,
+            timestamp: fixedClock.now(),
+            fileName: 'test.wav',
+            amplitudes: [-13, -10, 0.0],
+            duration: 3,
+            byteCount: 0,
+            mediaType: 'audio/wav',
+          );
+          when(
+            () => chatMessageRepository.insertChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(inserted));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('send failed')));
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          bloc.add(
+            ChatSendVoiceMessage(
+              audioData: AudioData(
+                amplitudesFilePreview: [-13, -10, 0.0],
+                fileName: 'test.wav',
+                duration: 3,
+              ),
+            ),
+          );
+        },
+        expect: () => [
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'inserted status',
+            equals(MessageStatus.inProgress),
+          ),
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'marked as error',
+            equals(MessageStatus.error),
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => chatMessageRepository.replaceChatMessage(
+              any(
+                that: isA<ChatMessage>().having(
+                  (m) => m.status,
+                  'status',
+                  MessageStatus.error,
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should mark an image message as error when sending to yalo fails',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        act: (bloc) {
+          final stubData = ImageData(path: 'test.jpg', mimeType: 'image/jpeg');
+          final savedStub = ImageData(path: 'test2.png', mimeType: 'image/png');
+          when(
+            () => imageRepository.saveImage(stubData),
+          ).thenAnswer((_) async => Result.ok(savedStub));
+          when(
+            () => imageRepository.deleteImage(stubData),
+          ).thenAnswer((_) async => Result.ok(Unit()));
+          when(() => chatMessageRepository.insertChatMessage(any())).thenAnswer(
+            (_) async => Result.ok(
+              ChatMessage.image(
+                id: 7,
+                role: MessageRole.user,
+                timestamp: fixedClock.now(),
+                content: 'test',
+                fileName: 'test2.png',
+                byteCount: 0,
+                mediaType: 'image/png',
+              ),
+            ),
+          );
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('send failed')));
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(true));
+          bloc.add(ChatSendImageMessage(imageData: stubData, text: 'test'));
+        },
+        expect: () => [
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'inserted status',
+            equals(MessageStatus.inProgress),
+          ),
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'marked as error',
+            equals(MessageStatus.error),
+          ),
+        ],
+        verify: (_) {
+          verify(
+            () => chatMessageRepository.replaceChatMessage(
+              any(
+                that: isA<ChatMessage>().having(
+                  (m) => m.status,
+                  'status',
+                  MessageStatus.error,
+                ),
+              ),
+            ),
+          ).called(1);
+        },
+      );
+
+      blocTest<MessagesBloc, MessagesState>(
+        'should still emit the error state when persisting the error status fails',
+        build: () => MessagesBloc(
+          chatMessageRepository: chatMessageRepository,
+          imageRepository: imageRepository,
+          yaloMessageRepository: yaloMessageRepository,
+          clock: fixedClock,
+        ),
+        seed: () => MessagesState(userMessage: 'Test message'),
+        act: (bloc) {
+          final inserted = ChatMessage(
+            id: 1,
+            role: MessageRole.user,
+            type: MessageType.text,
+            content: 'Test message',
+            timestamp: fixedClock.now(),
+          );
+          when(
+            () => chatMessageRepository.insertChatMessage(any()),
+          ).thenAnswer((_) async => Result.ok(inserted));
+          when(
+            () => yaloMessageRepository.sendMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('send failed')));
+          when(
+            () => chatMessageRepository.replaceChatMessage(any()),
+          ).thenAnswer((_) async => Result.error(Exception('persist failed')));
+          bloc.add(ChatSendTextMessage());
+        },
+        expect: () => [
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'inserted status',
+            equals(MessageStatus.inProgress),
+          ),
+          isA<MessagesState>().having(
+            (state) => state.messages.first.status,
+            'marked as error',
+            equals(MessageStatus.error),
+          ),
+        ],
+      );
     });
 
     group('fetch messages', () {

--- a/flutter-sdk/test/ui/chat/widgets/message_list_test.dart
+++ b/flutter-sdk/test/ui/chat/widgets/message_list_test.dart
@@ -228,6 +228,62 @@ void main() {
       );
 
       testWidgets(
+        'should dispatch ChatRetryMessage when tapping an errored user message',
+        (tester) async {
+          when(() => chatBloc.state).thenReturn(
+            MessagesState(
+              messages: [
+                ChatMessage(
+                  id: 42,
+                  role: MessageRole.user,
+                  type: MessageType.text,
+                  status: MessageStatus.error,
+                  timestamp: clock.now(),
+                  content: 'failed user message',
+                ),
+              ],
+            ),
+          );
+
+          await tester.pumpWidget(TestWidget(blocs: blocs));
+
+          await tester.tap(find.byKey(const Key('user_message_retry')));
+          await tester.pumpAndSettle();
+
+          verify(
+            () => chatBloc.add(ChatRetryMessage(messageId: 42)),
+          ).called(1);
+        },
+      );
+
+      testWidgets(
+        'should not render the retry tap target when status is not error',
+        (tester) async {
+          when(() => chatBloc.state).thenReturn(
+            MessagesState(
+              messages: [
+                ChatMessage(
+                  id: 1,
+                  role: MessageRole.user,
+                  type: MessageType.text,
+                  status: MessageStatus.sent,
+                  timestamp: clock.now(),
+                  content: 'delivered message',
+                ),
+              ],
+            ),
+          );
+
+          await tester.pumpWidget(TestWidget(blocs: blocs));
+
+          expect(
+            find.byKey(const Key('user_message_retry')),
+            findsNothing,
+          );
+        },
+      );
+
+      testWidgets(
         'should not render error indicator when status is not error',
         (tester) async {
           when(() => chatBloc.state).thenReturn(


### PR DESCRIPTION
- Mark messages as errors when fails to send via yalo message.
- Add retry for error messages by tapping on the message.