### PR TITLE
feat(android): Proto 2.0 unified button schema + openContext parity (FDE-152)

### DIFF
--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
@@ -61,6 +61,9 @@ fun ChatScreen(
     onShopPressed: (() -> Unit)? = null,
     /** Called when the user taps the cart icon in the chat app bar. Mirrors Flutter's Chat(onCartPressed:). */
     onCartPressed: (() -> Unit)? = null,
+    /** Describes where the chat is being opened from. Mirrors Flutter's Chat(openContext:). */
+    @Suppress("UNUSED_PARAMETER")
+    openContext: String? = null,
 ) {
     val context = LocalContext.current
     val factory = YaloChat.getViewModelFactory()

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ButtonsMessage.kt
@@ -2,14 +2,10 @@
 
 package com.yalo.chat.sdk.ui.chat
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -17,8 +13,9 @@ import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
-// Renders optional header + body text + optional footer + outlined reply buttons inside
-// the agent bubble. Tapping a button fires SendTextMessage with the label as content.
+// Renders optional header + body text + optional footer + inline buttons inside the agent bubble.
+// Handles all proto 2.0 button types via MessageButton: POSTBACK fires SendTextMessage,
+// LINK opens the URL, REPLY is skipped (shown as quick-reply chips above ChatInput).
 @Composable
 internal fun ButtonsMessage(
     message: ChatMessage,
@@ -48,24 +45,8 @@ internal fun ButtonsMessage(
                 modifier = Modifier.padding(bottom = 8.dp),
             )
         }
-        message.buttons.forEach { label ->
-            OutlinedButton(
-                onClick = { onEvent(MessagesEvent.SendTextMessage(label)) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 6.dp),
-                shape = RoundedCornerShape(8.dp),
-                border = BorderStroke(1.dp, theme.buttonsMessageButtonBorderColor),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    containerColor = theme.buttonsMessageButtonColor,
-                    contentColor = theme.buttonsMessageButtonForegroundColor,
-                ),
-            ) {
-                Text(
-                    text = label,
-                    style = MaterialTheme.typography.bodyMedium.merge(theme.buttonsMessageButtonTextStyle),
-                )
-            }
+        message.buttons.forEach { button ->
+            MessageButton(button = button, onEvent = onEvent)
         }
     }
 }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -14,7 +14,7 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Renders optional header + body text + optional footer + CTA (LINK) buttons that open URLs.
-// Delegates button rendering to MessageButton, which dispatches on ButtonType.
+// Delegates button rendering to MessageButton, which dispatches on ChatButtonType.
 @Composable
 internal fun CtaMessage(
     message: ChatMessage,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/CtaMessage.kt
@@ -2,35 +2,25 @@
 
 package com.yalo.chat.sdk.ui.chat
 
-import android.content.Intent
-import android.net.Uri
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
-// Renders optional header + body text + optional footer + CTA buttons that open URLs.
-// Button layout: text on the left, arrow icon on the right.
-// URL opening uses Intent.ACTION_VIEW.
+// Renders optional header + body text + optional footer + CTA (LINK) buttons that open URLs.
+// Delegates button rendering to MessageButton, which dispatches on ButtonType.
 @Composable
-internal fun CtaMessage(message: ChatMessage) {
+internal fun CtaMessage(
+    message: ChatMessage,
+    onEvent: (MessagesEvent) -> Unit,
+) {
     val theme = LocalChatTheme.current
-    val context = LocalContext.current
 
     Column(modifier = Modifier.fillMaxWidth()) {
         if (!message.header.isNullOrEmpty()) {
@@ -54,46 +44,8 @@ internal fun CtaMessage(message: ChatMessage) {
                 modifier = Modifier.padding(bottom = 8.dp),
             )
         }
-        message.ctaButtons.forEach { button ->
-            OutlinedButton(
-                onClick = {
-                    val uri = Uri.parse(button.url)
-                    if (uri.scheme == "https" || uri.scheme == "http") {
-                        runCatching {
-                            context.startActivity(
-                                Intent(Intent.ACTION_VIEW, uri)
-                                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                            )
-                        }
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 6.dp),
-                shape = RoundedCornerShape(8.dp),
-                border = BorderStroke(1.dp, theme.ctaButtonBorderColor),
-                colors = ButtonDefaults.outlinedButtonColors(
-                    containerColor = theme.ctaButtonColor,
-                    contentColor = theme.ctaButtonForegroundColor,
-                ),
-            ) {
-                // Text left-aligned, arrow icon on the right.
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    Text(
-                        text = button.text,
-                        style = MaterialTheme.typography.bodyMedium.merge(theme.ctaButtonTextStyle),
-                        modifier = Modifier.weight(1f),
-                    )
-                    Icon(
-                        imageVector = theme.ctaArrowForwardIcon,
-                        contentDescription = null,
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
-            }
+        message.buttons.forEach { button ->
+            MessageButton(button = button, onEvent = onEvent)
         }
     }
 }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageButton.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageButton.kt
@@ -20,24 +20,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
-// Renders a single proto 2.0 Button. Mirrors Flutter's MessageButton widget:
+// Renders a single proto 2.0 ChatButton. Mirrors Flutter's MessageButton widget:
 //   POSTBACK → OutlinedButton that fires SendTextMessage(button.text)
 //   LINK     → OutlinedButton with arrow icon that opens button.url in the system browser
 //   REPLY    → renders nothing (surfaces as quick-reply chips above ChatInput)
 @Composable
 internal fun MessageButton(
-    button: Button,
+    button: ChatButton,
     onEvent: (MessagesEvent) -> Unit,
 ) {
     val theme = LocalChatTheme.current
     val context = LocalContext.current
 
     when (button.type) {
-        ButtonType.POSTBACK -> OutlinedButton(
+        ChatButtonType.POSTBACK -> OutlinedButton(
             onClick = { onEvent(MessagesEvent.SendTextMessage(button.text)) },
             modifier = Modifier
                 .fillMaxWidth()
@@ -55,7 +55,7 @@ internal fun MessageButton(
             )
         }
 
-        ButtonType.LINK -> OutlinedButton(
+        ChatButtonType.LINK -> OutlinedButton(
             onClick = {
                 val url = button.url ?: return@OutlinedButton
                 val uri = Uri.parse(url)
@@ -95,6 +95,6 @@ internal fun MessageButton(
             }
         }
 
-        ButtonType.REPLY -> Unit
+        ChatButtonType.REPLY -> Unit
     }
 }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageButton.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageButton.kt
@@ -1,0 +1,100 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.ui.chat
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.ui.theme.LocalChatTheme
+
+// Renders a single proto 2.0 Button. Mirrors Flutter's MessageButton widget:
+//   POSTBACK → OutlinedButton that fires SendTextMessage(button.text)
+//   LINK     → OutlinedButton with arrow icon that opens button.url in the system browser
+//   REPLY    → renders nothing (surfaces as quick-reply chips above ChatInput)
+@Composable
+internal fun MessageButton(
+    button: Button,
+    onEvent: (MessagesEvent) -> Unit,
+) {
+    val theme = LocalChatTheme.current
+    val context = LocalContext.current
+
+    when (button.type) {
+        ButtonType.POSTBACK -> OutlinedButton(
+            onClick = { onEvent(MessagesEvent.SendTextMessage(button.text)) },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, theme.buttonsMessageButtonBorderColor),
+            colors = ButtonDefaults.outlinedButtonColors(
+                containerColor = theme.buttonsMessageButtonColor,
+                contentColor = theme.buttonsMessageButtonForegroundColor,
+            ),
+        ) {
+            Text(
+                text = button.text,
+                style = MaterialTheme.typography.bodyMedium.merge(theme.buttonsMessageButtonTextStyle),
+            )
+        }
+
+        ButtonType.LINK -> OutlinedButton(
+            onClick = {
+                val url = button.url ?: return@OutlinedButton
+                val uri = Uri.parse(url)
+                if (uri.scheme == "https" || uri.scheme == "http") {
+                    runCatching {
+                        context.startActivity(
+                            Intent(Intent.ACTION_VIEW, uri)
+                                .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        )
+                    }
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 6.dp),
+            shape = RoundedCornerShape(8.dp),
+            border = BorderStroke(1.dp, theme.ctaButtonBorderColor),
+            colors = ButtonDefaults.outlinedButtonColors(
+                containerColor = theme.ctaButtonColor,
+                contentColor = theme.ctaButtonForegroundColor,
+            ),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(
+                    text = button.text,
+                    style = MaterialTheme.typography.bodyMedium.merge(theme.ctaButtonTextStyle),
+                    modifier = Modifier.weight(1f),
+                )
+                Icon(
+                    imageVector = theme.ctaArrowForwardIcon,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
+        }
+
+        ButtonType.REPLY -> Unit
+    }
+}

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -40,6 +40,7 @@ import coil3.compose.AsyncImage
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -118,27 +119,66 @@ internal fun MessageItem(
             Box(modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
                 when (message.type) {
                     MessageType.Text,
-                    MessageType.QuickReply -> if (isUser) {
-                        Text(
-                            text = message.content,
-                            style = messageTextStyle,
-                        )
-                    } else {
-                        // Agent messages render CommonMark — mirrors Flutter's flutter_markdown_plus.
-                        // Links open via LocalUriHandler (system browser), same as Flutter's
-                        // LaunchMode.externalApplication.
-                        Markdown(
-                            content = message.content,
-                            colors = markdownColor(
-                                text = messageTextStyle.color.takeOrElse { contentColor },
-                                linkText = theme.expandControlsStyle.color,
-                            ),
-                            typography = markdownTypography(
-                                paragraph = messageTextStyle,
-                                text = messageTextStyle,
-                            ),
-                            modifier = Modifier.fillMaxWidth(),
-                        )
+                    MessageType.QuickReply -> {
+                        val inlineButtons = message.buttons.filter { it.type != ButtonType.REPLY }
+                        if (!isUser && (inlineButtons.isNotEmpty() || !message.header.isNullOrEmpty())) {
+                            // Proto 2.0: agent text message with embedded buttons / header / footer.
+                            // Renders Markdown body between header and footer, then inline buttons.
+                            androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxWidth()) {
+                                if (!message.header.isNullOrEmpty()) {
+                                    Text(
+                                        text = message.header,
+                                        style = MaterialTheme.typography.bodyMedium.merge(theme.messageHeaderStyle),
+                                        modifier = Modifier.padding(bottom = 4.dp),
+                                    )
+                                }
+                                if (message.content.isNotEmpty()) {
+                                    Markdown(
+                                        content = message.content,
+                                        colors = markdownColor(
+                                            text = messageTextStyle.color.takeOrElse { contentColor },
+                                            linkText = theme.expandControlsStyle.color,
+                                        ),
+                                        typography = markdownTypography(
+                                            paragraph = messageTextStyle,
+                                            text = messageTextStyle,
+                                        ),
+                                        modifier = Modifier.fillMaxWidth().padding(bottom = 4.dp),
+                                    )
+                                }
+                                if (!message.footer.isNullOrEmpty()) {
+                                    Text(
+                                        text = message.footer,
+                                        style = MaterialTheme.typography.bodyMedium.merge(theme.messageFooterStyle),
+                                        modifier = Modifier.padding(bottom = 8.dp),
+                                    )
+                                }
+                                inlineButtons.forEach { button ->
+                                    MessageButton(button = button, onEvent = onEvent)
+                                }
+                            }
+                        } else if (isUser) {
+                            Text(
+                                text = message.content,
+                                style = messageTextStyle,
+                            )
+                        } else {
+                            // Agent messages render CommonMark — mirrors Flutter's flutter_markdown_plus.
+                            // Links open via LocalUriHandler (system browser), same as Flutter's
+                            // LaunchMode.externalApplication.
+                            Markdown(
+                                content = message.content,
+                                colors = markdownColor(
+                                    text = messageTextStyle.color.takeOrElse { contentColor },
+                                    linkText = theme.expandControlsStyle.color,
+                                ),
+                                typography = markdownTypography(
+                                    paragraph = messageTextStyle,
+                                    text = messageTextStyle,
+                                ),
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     }
                     MessageType.Image -> AsyncImage(
                         // fileName holds the local file path for user-sent images (set by
@@ -165,7 +205,7 @@ internal fun MessageItem(
                         message = message,
                         onEvent = onEvent,
                     )
-                    MessageType.CTA -> CtaMessage(message = message)
+                    MessageType.CTA -> CtaMessage(message = message, onEvent = onEvent)
                     MessageType.Unknown -> Text(
                         text = "Unsupported message",
                         style = messageTextStyle,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -40,7 +40,7 @@ import coil3.compose.AsyncImage
 import com.mikepenz.markdown.m3.Markdown
 import com.mikepenz.markdown.m3.markdownColor
 import com.mikepenz.markdown.m3.markdownTypography
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -120,8 +120,8 @@ internal fun MessageItem(
                 when (message.type) {
                     MessageType.Text,
                     MessageType.QuickReply -> {
-                        val inlineButtons = message.buttons.filter { it.type != ButtonType.REPLY }
-                        if (!isUser && (inlineButtons.isNotEmpty() || !message.header.isNullOrEmpty())) {
+                        val inlineButtons = message.buttons.filter { it.type != ChatButtonType.REPLY }
+                        if (!isUser && (inlineButtons.isNotEmpty() || !message.header.isNullOrEmpty() || !message.footer.isNullOrEmpty())) {
                             // Proto 2.0: agent text message with embedded buttons / header / footer.
                             // Also triggered by header-only (no buttons) — same column layout, buttons loop is a no-op.
                             // Renders Markdown body between header and footer, then inline buttons.
@@ -195,7 +195,7 @@ internal fun MessageItem(
                             placeholder = ColorPainter(theme.imagePlaceholderBackgroundColor),
                             error = ColorPainter(theme.imagePlaceholderBackgroundColor),
                         )
-                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                        message.buttons.filter { it.type != ChatButtonType.REPLY }.forEach { button ->
                             MessageButton(button = button, onEvent = onEvent)
                         }
                     }
@@ -208,7 +208,7 @@ internal fun MessageItem(
                             onPlay = onPlayAudio,
                             onStop = onStopAudio,
                         )
-                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                        message.buttons.filter { it.type != ChatButtonType.REPLY }.forEach { button ->
                             MessageButton(button = button, onEvent = onEvent)
                         }
                     }
@@ -219,7 +219,7 @@ internal fun MessageItem(
                             message = message,
                             messageTextStyle = messageTextStyle,
                         )
-                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                        message.buttons.filter { it.type != ChatButtonType.REPLY }.forEach { button ->
                             MessageButton(button = button, onEvent = onEvent)
                         }
                     }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -123,6 +123,7 @@ internal fun MessageItem(
                         val inlineButtons = message.buttons.filter { it.type != ButtonType.REPLY }
                         if (!isUser && (inlineButtons.isNotEmpty() || !message.header.isNullOrEmpty())) {
                             // Proto 2.0: agent text message with embedded buttons / header / footer.
+                            // Also triggered by header-only (no buttons) — same column layout, buttons loop is a no-op.
                             // Renders Markdown body between header and footer, then inline buttons.
                             androidx.compose.foundation.layout.Column(modifier = Modifier.fillMaxWidth()) {
                                 if (!message.header.isNullOrEmpty()) {
@@ -180,27 +181,48 @@ internal fun MessageItem(
                             )
                         }
                     }
-                    MessageType.Image -> AsyncImage(
-                        // fileName holds the local file path for user-sent images (set by
-                        // sendImageMessage). content holds the URL for agent/server images.
-                        // Fall back to content so both cases render correctly.
-                        model = message.fileName ?: message.content,
-                        contentDescription = "Image message",
-                        contentScale = ContentScale.Crop,
-                        modifier = Modifier.size(200.dp),
-                        placeholder = ColorPainter(theme.imagePlaceholderBackgroundColor),
-                        error = ColorPainter(theme.imagePlaceholderBackgroundColor),
-                    )
-                    MessageType.Voice -> AudioMessageItem(
-                        message = message,
-                        playingMessage = playingMessage,
-                        onPlay = onPlayAudio,
-                        onStop = onStopAudio,
-                    )
-                    MessageType.Video -> VideoMessageItem(
-                        message = message,
-                        messageTextStyle = messageTextStyle,
-                    )
+                    MessageType.Image -> androidx.compose.foundation.layout.Column(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        AsyncImage(
+                            // fileName holds the local file path for user-sent images (set by
+                            // sendImageMessage). content holds the URL for agent/server images.
+                            // Fall back to content so both cases render correctly.
+                            model = message.fileName ?: message.content,
+                            contentDescription = "Image message",
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier.size(200.dp),
+                            placeholder = ColorPainter(theme.imagePlaceholderBackgroundColor),
+                            error = ColorPainter(theme.imagePlaceholderBackgroundColor),
+                        )
+                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                            MessageButton(button = button, onEvent = onEvent)
+                        }
+                    }
+                    MessageType.Voice -> androidx.compose.foundation.layout.Column(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        AudioMessageItem(
+                            message = message,
+                            playingMessage = playingMessage,
+                            onPlay = onPlayAudio,
+                            onStop = onStopAudio,
+                        )
+                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                            MessageButton(button = button, onEvent = onEvent)
+                        }
+                    }
+                    MessageType.Video -> androidx.compose.foundation.layout.Column(
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        VideoMessageItem(
+                            message = message,
+                            messageTextStyle = messageTextStyle,
+                        )
+                        message.buttons.filter { it.type != ButtonType.REPLY }.forEach { button ->
+                            MessageButton(button = button, onEvent = onEvent)
+                        }
+                    }
                     MessageType.Buttons -> ButtonsMessage(
                         message = message,
                         onEvent = onEvent,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.MessageSyncService
 import com.yalo.chat.sdk.domain.model.AudioData
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.ImageData
@@ -249,7 +249,7 @@ internal class MessagesViewModel(
                         .lastOrNull {
                             it.role == MessageRole.AGENT &&
                             (it.type == MessageType.Text || it.type == MessageType.QuickReply) &&
-                            it.buttons.any { b -> b.type == ButtonType.REPLY }
+                            it.buttons.any { b -> b.type == ChatButtonType.REPLY }
                         }?.wiId
                     val quickReplies = if (latestQrWiId != null && latestQrWiId != currentState.lastQuickReplyMessageWiId) {
                         mergedMessages.extractQuickReplies()
@@ -354,5 +354,5 @@ private fun List<ChatMessage>.extractQuickReplies(): List<String> =
     lastOrNull {
         it.role == MessageRole.AGENT &&
         (it.type == MessageType.Text || it.type == MessageType.QuickReply) &&
-        it.buttons.any { b -> b.type == ButtonType.REPLY }
-    }?.buttons?.filter { it.type == ButtonType.REPLY }?.map { it.text }.orEmpty()
+        it.buttons.any { b -> b.type == ChatButtonType.REPLY }
+    }?.buttons?.filter { it.type == ChatButtonType.REPLY }?.map { it.text }.orEmpty()

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.MessageSyncService
 import com.yalo.chat.sdk.domain.model.AudioData
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.ImageData
@@ -245,7 +246,7 @@ internal class MessagesViewModel(
                     // triggers observeMessages, which would find the old QuickReply message
                     // and restore its replies).
                     val latestQrWiId = mergedMessages
-                        .lastOrNull { it.type == MessageType.QuickReply && it.role == MessageRole.AGENT }
+                        .lastOrNull { it.role == MessageRole.AGENT && it.buttons.any { b -> b.type == ButtonType.REPLY } }
                         ?.wiId
                     val quickReplies = if (latestQrWiId != null && latestQrWiId != currentState.lastQuickReplyMessageWiId) {
                         mergedMessages.extractQuickReplies()
@@ -343,8 +344,9 @@ internal class MessagesViewModel(
     }
 }
 
-// Derives quick replies from the most recent QuickReply message in the list,
-// mirroring the Flutter SDK behaviour where the last agent quick-reply message
-// drives the overlay buttons above ChatInput.
+// Derives quick replies from the most recent agent message that carries REPLY-typed buttons,
+// mirroring the Flutter SDK behaviour where the last such message drives the overlay chips
+// above ChatInput.
 private fun List<ChatMessage>.extractQuickReplies(): List<String> =
-    lastOrNull { it.type == MessageType.QuickReply && it.role == MessageRole.AGENT }?.quickReplies.orEmpty()
+    lastOrNull { it.role == MessageRole.AGENT && it.buttons.any { b -> b.type == ButtonType.REPLY } }
+        ?.buttons?.filter { it.type == ButtonType.REPLY }?.map { it.text }.orEmpty()

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModel.kt
@@ -246,8 +246,11 @@ internal class MessagesViewModel(
                     // triggers observeMessages, which would find the old QuickReply message
                     // and restore its replies).
                     val latestQrWiId = mergedMessages
-                        .lastOrNull { it.role == MessageRole.AGENT && it.buttons.any { b -> b.type == ButtonType.REPLY } }
-                        ?.wiId
+                        .lastOrNull {
+                            it.role == MessageRole.AGENT &&
+                            (it.type == MessageType.Text || it.type == MessageType.QuickReply) &&
+                            it.buttons.any { b -> b.type == ButtonType.REPLY }
+                        }?.wiId
                     val quickReplies = if (latestQrWiId != null && latestQrWiId != currentState.lastQuickReplyMessageWiId) {
                         mergedMessages.extractQuickReplies()
                     } else {
@@ -344,9 +347,12 @@ internal class MessagesViewModel(
     }
 }
 
-// Derives quick replies from the most recent agent message that carries REPLY-typed buttons,
-// mirroring the Flutter SDK behaviour where the last such message drives the overlay chips
-// above ChatInput.
+// Derives quick replies from the most recent agent Text message carrying REPLY-typed buttons.
+// Restricted to Text/QuickReply types so buttons on media messages (Image/Video/Voice) never
+// surface as chips — those message types render their own inline buttons instead.
 private fun List<ChatMessage>.extractQuickReplies(): List<String> =
-    lastOrNull { it.role == MessageRole.AGENT && it.buttons.any { b -> b.type == ButtonType.REPLY } }
-        ?.buttons?.filter { it.type == ButtonType.REPLY }?.map { it.text }.orEmpty()
+    lastOrNull {
+        it.role == MessageRole.AGENT &&
+        (it.type == MessageType.Text || it.type == MessageType.QuickReply) &&
+        it.buttons.any { b -> b.type == ButtonType.REPLY }
+    }?.buttons?.filter { it.type == ButtonType.REPLY }?.map { it.text }.orEmpty()

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -5,11 +5,12 @@ package com.yalo.chat.sdk.data.local
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.database.ChatDatabase
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
-import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.Product
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -119,19 +120,26 @@ class LocalChatMessageRepositoryTest {
     // ── JSON columns round-trip ───────────────────────────────────────────────
 
     @Test
-    fun `quickReplies round-trip through JSON column`() = runTest {
+    fun `REPLY buttons round-trip through JSON column`() = runTest {
         val message = ChatMessage(
             id = 1L,
             role = MessageRole.AGENT,
-            type = MessageType.QuickReply,
+            type = MessageType.Text,
             status = MessageStatus.DELIVERED,
             content = "Pick one:",
-            quickReplies = listOf("Yes", "No", "Maybe"),
+            buttons = listOf(
+                Button(text = "Yes", type = ButtonType.REPLY),
+                Button(text = "No", type = ButtonType.REPLY),
+                Button(text = "Maybe", type = ButtonType.REPLY),
+            ),
         )
         repo.insertMessage(message)
         val result = repo.getMessages(cursor = null, limit = 1)
         assertIs<Result.Ok<List<ChatMessage>>>(result)
-        assertEquals(listOf("Yes", "No", "Maybe"), result.result.first().quickReplies)
+        assertEquals(
+            listOf("Yes", "No", "Maybe"),
+            result.result.first().buttons.filter { it.type == ButtonType.REPLY }.map { it.text },
+        )
     }
 
     @Test
@@ -198,7 +206,11 @@ class LocalChatMessageRepositoryTest {
             content = "Pick an option:",
             header = "Order help",
             footer = "Tap any option",
-            buttons = listOf("Track order", "Cancel order", "Contact support"),
+            buttons = listOf(
+                Button(text = "Track order", type = ButtonType.POSTBACK),
+                Button(text = "Cancel order", type = ButtonType.POSTBACK),
+                Button(text = "Contact support", type = ButtonType.POSTBACK),
+            ),
             timestamp = 1000L,
         )
         repo.insertMessage(message)
@@ -208,7 +220,7 @@ class LocalChatMessageRepositoryTest {
         assertEquals(MessageType.Buttons, loaded.type)
         assertEquals("Order help", loaded.header)
         assertEquals("Tap any option", loaded.footer)
-        assertEquals(listOf("Track order", "Cancel order", "Contact support"), loaded.buttons)
+        assertEquals(listOf("Track order", "Cancel order", "Contact support"), loaded.buttons.map { it.text })
         assertEquals("Pick an option:", loaded.content)
     }
 
@@ -220,7 +232,10 @@ class LocalChatMessageRepositoryTest {
             type = MessageType.Buttons,
             status = MessageStatus.DELIVERED,
             content = "Choose:",
-            buttons = listOf("Yes", "No"),
+            buttons = listOf(
+                Button(text = "Yes", type = ButtonType.POSTBACK),
+                Button(text = "No", type = ButtonType.POSTBACK),
+            ),
             timestamp = 2000L,
         )
         repo.insertMessage(message)
@@ -229,13 +244,13 @@ class LocalChatMessageRepositoryTest {
         val loaded = result.result.first()
         assertEquals(null, loaded.header)
         assertEquals(null, loaded.footer)
-        assertEquals(listOf("Yes", "No"), loaded.buttons)
+        assertEquals(listOf("Yes", "No"), loaded.buttons.map { it.text })
     }
 
     // ── CTA message round-trip ────────────────────────────────────────────────
 
     @Test
-    fun `CTA message round-trips header, footer and ctaButtons through DB`() = runTest {
+    fun `CTA message round-trips header, footer and LINK buttons through DB`() = runTest {
         val message = ChatMessage(
             id = 3L,
             wiId = "cta-wi-1",
@@ -245,9 +260,9 @@ class LocalChatMessageRepositoryTest {
             content = "Check out our catalog",
             header = "Shop now",
             footer = "Limited time offer",
-            ctaButtons = listOf(
-                CtaButton(text = "View Catalog", url = "https://example.com/catalog"),
-                CtaButton(text = "View Promotions", url = "https://example.com/promos"),
+            buttons = listOf(
+                Button(text = "View Catalog", type = ButtonType.LINK, url = "https://example.com/catalog"),
+                Button(text = "View Promotions", type = ButtonType.LINK, url = "https://example.com/promos"),
             ),
             timestamp = 3000L,
         )
@@ -258,9 +273,9 @@ class LocalChatMessageRepositoryTest {
         assertEquals(MessageType.CTA, loaded.type)
         assertEquals("Shop now", loaded.header)
         assertEquals("Limited time offer", loaded.footer)
-        assertEquals(2, loaded.ctaButtons.size)
-        assertEquals("View Catalog", loaded.ctaButtons[0].text)
-        assertEquals("https://example.com/catalog", loaded.ctaButtons[0].url)
-        assertEquals("View Promotions", loaded.ctaButtons[1].text)
+        assertEquals(2, loaded.buttons.size)
+        assertEquals("View Catalog", loaded.buttons[0].text)
+        assertEquals("https://example.com/catalog", loaded.buttons[0].url)
+        assertEquals("View Promotions", loaded.buttons[1].text)
     }
 }

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -5,8 +5,8 @@ package com.yalo.chat.sdk.data.local
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.database.ChatDatabase
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -130,9 +130,9 @@ class LocalChatMessageRepositoryTest {
             status = MessageStatus.DELIVERED,
             content = "Pick one:",
             buttons = listOf(
-                Button(text = "Yes", type = ButtonType.REPLY),
-                Button(text = "No", type = ButtonType.REPLY),
-                Button(text = "Maybe", type = ButtonType.REPLY),
+                ChatButton(text = "Yes", type = ChatButtonType.REPLY),
+                ChatButton(text = "No", type = ChatButtonType.REPLY),
+                ChatButton(text = "Maybe", type = ChatButtonType.REPLY),
             ),
         )
         repo.insertMessage(message)
@@ -140,7 +140,7 @@ class LocalChatMessageRepositoryTest {
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         assertEquals(
             listOf("Yes", "No", "Maybe"),
-            result.result.first().buttons.filter { it.type == ButtonType.REPLY }.map { it.text },
+            result.result.first().buttons.filter { it.type == ChatButtonType.REPLY }.map { it.text },
         )
     }
 
@@ -209,9 +209,9 @@ class LocalChatMessageRepositoryTest {
             header = "Order help",
             footer = "Tap any option",
             buttons = listOf(
-                Button(text = "Track order", type = ButtonType.POSTBACK),
-                Button(text = "Cancel order", type = ButtonType.POSTBACK),
-                Button(text = "Contact support", type = ButtonType.POSTBACK),
+                ChatButton(text = "Track order", type = ChatButtonType.POSTBACK),
+                ChatButton(text = "Cancel order", type = ChatButtonType.POSTBACK),
+                ChatButton(text = "Contact support", type = ChatButtonType.POSTBACK),
             ),
             timestamp = 1000L,
         )
@@ -235,8 +235,8 @@ class LocalChatMessageRepositoryTest {
             status = MessageStatus.DELIVERED,
             content = "Choose:",
             buttons = listOf(
-                Button(text = "Yes", type = ButtonType.POSTBACK),
-                Button(text = "No", type = ButtonType.POSTBACK),
+                ChatButton(text = "Yes", type = ChatButtonType.POSTBACK),
+                ChatButton(text = "No", type = ChatButtonType.POSTBACK),
             ),
             timestamp = 2000L,
         )
@@ -271,7 +271,7 @@ class LocalChatMessageRepositoryTest {
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         val loaded = result.result.first()
         assertEquals(2, loaded.buttons.size)
-        assertTrue(loaded.buttons.all { it.type == ButtonType.POSTBACK })
+        assertTrue(loaded.buttons.all { it.type == ChatButtonType.POSTBACK })
         assertEquals(listOf("Track order", "Cancel order"), loaded.buttons.map { it.text })
     }
 
@@ -290,7 +290,7 @@ class LocalChatMessageRepositoryTest {
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         val loaded = result.result.first()
         assertEquals(2, loaded.buttons.size)
-        assertTrue(loaded.buttons.all { it.type == ButtonType.LINK })
+        assertTrue(loaded.buttons.all { it.type == ChatButtonType.LINK })
         assertEquals("View Catalog", loaded.buttons[0].text)
         assertEquals("https://example.com/catalog", loaded.buttons[0].url)
         assertEquals("View Promos", loaded.buttons[1].text)
@@ -310,7 +310,7 @@ class LocalChatMessageRepositoryTest {
         assertIs<Result.Ok<List<ChatMessage>>>(result)
         val loaded = result.result.first()
         assertEquals(3, loaded.buttons.size)
-        assertTrue(loaded.buttons.all { it.type == ButtonType.REPLY })
+        assertTrue(loaded.buttons.all { it.type == ChatButtonType.REPLY })
         assertEquals(listOf("Yes", "No", "Maybe"), loaded.buttons.map { it.text })
     }
 
@@ -326,8 +326,8 @@ class LocalChatMessageRepositoryTest {
             header = "Shop now",
             footer = "Limited time offer",
             buttons = listOf(
-                Button(text = "View Catalog", type = ButtonType.LINK, url = "https://example.com/catalog"),
-                Button(text = "View Promotions", type = ButtonType.LINK, url = "https://example.com/promos"),
+                ChatButton(text = "View Catalog", type = ChatButtonType.LINK, url = "https://example.com/catalog"),
+                ChatButton(text = "View Promotions", type = ChatButtonType.LINK, url = "https://example.com/promos"),
             ),
             timestamp = 3000L,
         )

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepositoryTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 // Uses JdbcSqliteDriver (in-memory) — no Android emulator required.
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -31,6 +32,7 @@ class LocalChatMessageRepositoryTest {
 
     private val dispatcher = UnconfinedTestDispatcher()
     private lateinit var driver: JdbcSqliteDriver
+    private lateinit var db: ChatDatabase
     private lateinit var repo: LocalChatMessageRepository
 
     @BeforeTest
@@ -38,7 +40,7 @@ class LocalChatMessageRepositoryTest {
         Dispatchers.setMain(dispatcher)
         driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         ChatDatabase.Schema.create(driver)
-        val db = createDatabase(driver)
+        db = createDatabase(driver)
         repo = LocalChatMessageRepository(db.chatMessageQueries, ioDispatcher = dispatcher)
     }
 
@@ -248,6 +250,69 @@ class LocalChatMessageRepositoryTest {
     }
 
     // ── CTA message round-trip ────────────────────────────────────────────────
+
+    // ── Backward-compat DB decode (legacy JSON column formats) ───────────────────
+
+    // These tests simulate rows written by a pre-proto-2.0 app version and verify that
+    // decodeButtons() reads them correctly without a DB migration.
+
+    @Test
+    fun `legacy List-String buttons column decoded as POSTBACK buttons`() = runTest {
+        // Old app wrote buttons as ["Yes","No"] (List<String>, POSTBACK-implied).
+        db.chatMessageQueries.insertOrReplace(
+            id = 100L, wi_id = "legacy-btn-1", role = "agent", content = "Choose:",
+            type = "buttons", status = "delivered", file_name = null, amplitudes = null,
+            duration = null, byte_count = null, media_type = null, products = null,
+            quick_replies = null, header_ = "Order help", footer = null,
+            buttons = """["Track order","Cancel order"]""", cta_buttons = null,
+            timestamp = 100_000L,
+        )
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(2, loaded.buttons.size)
+        assertTrue(loaded.buttons.all { it.type == ButtonType.POSTBACK })
+        assertEquals(listOf("Track order", "Cancel order"), loaded.buttons.map { it.text })
+    }
+
+    @Test
+    fun `legacy cta_buttons column decoded as LINK buttons`() = runTest {
+        // Old app wrote CTA buttons as List<CtaButton> JSON in cta_buttons; buttons was null.
+        db.chatMessageQueries.insertOrReplace(
+            id = 101L, wi_id = "legacy-cta-1", role = "agent", content = "Shop now",
+            type = "cta", status = "delivered", file_name = null, amplitudes = null,
+            duration = null, byte_count = null, media_type = null, products = null,
+            quick_replies = null, header_ = null, footer = null, buttons = null,
+            cta_buttons = """[{"text":"View Catalog","url":"https://example.com/catalog"},{"text":"View Promos","url":"https://example.com/promos"}]""",
+            timestamp = 101_000L,
+        )
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(2, loaded.buttons.size)
+        assertTrue(loaded.buttons.all { it.type == ButtonType.LINK })
+        assertEquals("View Catalog", loaded.buttons[0].text)
+        assertEquals("https://example.com/catalog", loaded.buttons[0].url)
+        assertEquals("View Promos", loaded.buttons[1].text)
+    }
+
+    @Test
+    fun `legacy quick_replies column decoded as REPLY buttons`() = runTest {
+        // Old app wrote quick replies as List<String> JSON in quick_replies; buttons was null.
+        db.chatMessageQueries.insertOrReplace(
+            id = 102L, wi_id = "legacy-qr-1", role = "agent", content = "Pick one:",
+            type = "quickReply", status = "delivered", file_name = null, amplitudes = null,
+            duration = null, byte_count = null, media_type = null, products = null,
+            quick_replies = """["Yes","No","Maybe"]""", header_ = null, footer = null,
+            buttons = null, cta_buttons = null, timestamp = 102_000L,
+        )
+        val result = repo.getMessages(cursor = null, limit = 1)
+        assertIs<Result.Ok<List<ChatMessage>>>(result)
+        val loaded = result.result.first()
+        assertEquals(3, loaded.buttons.size)
+        assertTrue(loaded.buttons.all { it.type == ButtonType.REPLY })
+        assertEquals(listOf("Yes", "No", "Maybe"), loaded.buttons.map { it.text })
+    }
 
     @Test
     fun `CTA message round-trips header, footer and LINK buttons through DB`() = runTest {

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -4,7 +4,7 @@ package com.yalo.chat.sdk.data.repository.remote
 
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatCommand
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.ui.chat.UnitType
@@ -656,7 +656,7 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals("Choose action:", msg.content)
         assertEquals(1, msg.buttons.size)
         assertEquals("Track order", msg.buttons.first().text)
-        assertEquals(ButtonType.POSTBACK, msg.buttons.first().type)
+        assertEquals(ChatButtonType.POSTBACK, msg.buttons.first().type)
         assertNull(msg.buttons.first().url)
     }
 
@@ -672,7 +672,7 @@ class YaloMessageRepositoryRemoteTest {
         val msg = batch.first()
         assertEquals(MessageType.Text, msg.type)
         assertEquals(1, msg.buttons.size)
-        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertEquals(ChatButtonType.LINK, msg.buttons.first().type)
         assertEquals("Open", msg.buttons.first().text)
         assertEquals("https://shop.example.com", msg.buttons.first().url)
     }
@@ -688,7 +688,7 @@ class YaloMessageRepositoryRemoteTest {
         val batch = repo.pollIncomingMessages().first()
         val msg = batch.first()
         assertEquals(2, msg.buttons.size)
-        assertTrue(msg.buttons.all { it.type == ButtonType.REPLY })
+        assertTrue(msg.buttons.all { it.type == ChatButtonType.REPLY })
     }
 
     @Test
@@ -706,9 +706,9 @@ class YaloMessageRepositoryRemoteTest {
         val batch = repo.pollIncomingMessages().first()
         val msg = batch.first()
         assertEquals(3, msg.buttons.size)
-        assertEquals(ButtonType.POSTBACK, msg.buttons[0].type)
-        assertEquals(ButtonType.LINK, msg.buttons[1].type)
-        assertEquals(ButtonType.REPLY, msg.buttons[2].type)
+        assertEquals(ChatButtonType.POSTBACK, msg.buttons[0].type)
+        assertEquals(ChatButtonType.LINK, msg.buttons[1].type)
+        assertEquals(ChatButtonType.REPLY, msg.buttons[2].type)
         assertEquals("https://details.example.com", msg.buttons[1].url)
     }
 
@@ -733,27 +733,27 @@ class YaloMessageRepositoryRemoteTest {
     fun `pollIncomingMessages maps button with absent buttonType field to REPLY (proto3 default)`() = runTest {
         // Proto3 omits fields at their default value on the wire. BUTTON_TYPE_REPLY = 0 is the
         // default, so a real server payload may omit the buttonType key entirely. The DTO default
-        // must catch this and produce ButtonType.REPLY.
+        // must catch this and produce ChatButtonType.REPLY.
         val json = """[{"id":"btn-proto3-default","message":{"textMessageRequest":{"content":{"text":"Pick:","role":"MESSAGE_ROLE_AGENT"},"buttons":[{"text":"Yes"},{"text":"No"}]}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         assertEquals(1, batch.size)
         val msg = batch.first()
         assertEquals(2, msg.buttons.size)
-        assertTrue(msg.buttons.all { it.type == ButtonType.REPLY }, "Absent buttonType must default to REPLY")
+        assertTrue(msg.buttons.all { it.type == ChatButtonType.REPLY }, "Absent buttonType must default to REPLY")
         assertEquals(listOf("Yes", "No"), msg.buttons.map { it.text })
     }
 
     @Test
     fun `pollIncomingMessages maps LINK button with absent url field to null url`() = runTest {
-        // url is optional in the proto — LINK buttons without a url field must map to Button(url=null),
+        // url is optional in the proto — LINK buttons without a url field must map to ChatButton(url=null),
         // not crash. MessageButton handles null url as a no-op tap.
         val json = """[{"id":"btn-link-no-url","message":{"textMessageRequest":{"content":{"text":"Visit:","role":"MESSAGE_ROLE_AGENT"},"buttons":[{"text":"Open","buttonType":"BUTTON_TYPE_LINK"}]}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         val msg = batch.first()
         assertEquals(1, msg.buttons.size)
-        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertEquals(ChatButtonType.LINK, msg.buttons.first().type)
         assertNull(msg.buttons.first().url, "LINK button with no url field must have url=null")
     }
 
@@ -783,7 +783,7 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals(MessageRole.AGENT, msg.role)
         assertEquals("Choose:", msg.content)
         assertEquals(2, msg.buttons.size)
-        assertTrue(msg.buttons.all { it.type == ButtonType.POSTBACK })
+        assertTrue(msg.buttons.all { it.type == ChatButtonType.POSTBACK })
         assertEquals(listOf("A", "B"), msg.buttons.map { it.text })
     }
 
@@ -823,7 +823,7 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals(MessageRole.AGENT, msg.role)
         assertEquals("Shop now", msg.content)
         assertEquals(1, msg.buttons.size)
-        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertEquals(ChatButtonType.LINK, msg.buttons.first().type)
         assertEquals("View", msg.buttons.first().text)
         assertEquals("https://shop.example.com", msg.buttons.first().url)
     }
@@ -836,7 +836,7 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals("Promo", batch.first().header)
         assertEquals("Limited", batch.first().footer)
         assertEquals(2, batch.first().buttons.size)
-        assertTrue(batch.first().buttons.all { it.type == ButtonType.LINK })
+        assertTrue(batch.first().buttons.all { it.type == ChatButtonType.LINK })
     }
 
     // ── pollIncomingMessages — video messages ──────────────────────────────────────

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -729,6 +729,34 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals("Pick an option", msg.content)
     }
 
+    @Test
+    fun `pollIncomingMessages maps button with absent buttonType field to REPLY (proto3 default)`() = runTest {
+        // Proto3 omits fields at their default value on the wire. BUTTON_TYPE_REPLY = 0 is the
+        // default, so a real server payload may omit the buttonType key entirely. The DTO default
+        // must catch this and produce ButtonType.REPLY.
+        val json = """[{"id":"btn-proto3-default","message":{"textMessageRequest":{"content":{"text":"Pick:","role":"MESSAGE_ROLE_AGENT"},"buttons":[{"text":"Yes"},{"text":"No"}]}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        val msg = batch.first()
+        assertEquals(2, msg.buttons.size)
+        assertTrue(msg.buttons.all { it.type == ButtonType.REPLY }, "Absent buttonType must default to REPLY")
+        assertEquals(listOf("Yes", "No"), msg.buttons.map { it.text })
+    }
+
+    @Test
+    fun `pollIncomingMessages maps LINK button with absent url field to null url`() = runTest {
+        // url is optional in the proto — LINK buttons without a url field must map to Button(url=null),
+        // not crash. MessageButton handles null url as a no-op tap.
+        val json = """[{"id":"btn-link-no-url","message":{"textMessageRequest":{"content":{"text":"Visit:","role":"MESSAGE_ROLE_AGENT"},"buttons":[{"text":"Open","buttonType":"BUTTON_TYPE_LINK"}]}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        val msg = batch.first()
+        assertEquals(1, msg.buttons.size)
+        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertNull(msg.buttons.first().url, "LINK button with no url field must have url=null")
+    }
+
     // ── pollIncomingMessages — legacy buttons messages (backward compat) ───────────
 
     private fun buttonsMessageJson(

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryRemoteTest.kt
@@ -4,6 +4,7 @@ package com.yalo.chat.sdk.data.repository.remote
 
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatCommand
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.ui.chat.UnitType
@@ -614,7 +615,121 @@ class YaloMessageRepositoryRemoteTest {
         assertEquals(MessageRole.AGENT, batch.first().role)
     }
 
-    // ── pollIncomingMessages — buttons messages ────────────────────────────────────
+    // ── pollIncomingMessages — proto 2.0 text messages with buttons ───────────────
+
+    private fun textMessageWithButtonsJson(
+        id: String,
+        text: String = "Pick one",
+        buttons: List<Triple<String, String, String?>> = emptyList(),
+        header: String? = null,
+        footer: String? = null,
+        role: String = "MESSAGE_ROLE_AGENT",
+    ): String {
+        val extras = buildList {
+            if (header != null) add(""""header":"$header"""")
+            if (footer != null) add(""""footer":"$footer"""")
+            if (buttons.isNotEmpty()) {
+                val items = buttons.joinToString(",") { (btnText, btnType, url) ->
+                    if (url != null) """{"text":"$btnText","buttonType":"$btnType","url":"$url"}"""
+                    else """{"text":"$btnText","buttonType":"$btnType"}"""
+                }
+                add(""""buttons":[$items]""")
+            }
+        }
+        val extrasJson = if (extras.isEmpty()) "" else ",${extras.joinToString(",")}"
+        return """[{"id":"$id","message":{"textMessageRequest":{"content":{"text":"$text","role":"$role"}$extrasJson}},"date":"2024-01-01T12:00:00Z","user_id":"u1","status":"IN_DELIVERY"}]"""
+    }
+
+    @Test
+    fun `pollIncomingMessages maps textMessageRequest POSTBACK button`() = runTest {
+        val json = textMessageWithButtonsJson(
+            id = "btn-p1",
+            text = "Choose action:",
+            buttons = listOf(Triple("Track order", "BUTTON_TYPE_POSTBACK", null)),
+        )
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        assertEquals(1, batch.size)
+        val msg = batch.first()
+        assertEquals(MessageType.Text, msg.type)
+        assertEquals(MessageRole.AGENT, msg.role)
+        assertEquals("Choose action:", msg.content)
+        assertEquals(1, msg.buttons.size)
+        assertEquals("Track order", msg.buttons.first().text)
+        assertEquals(ButtonType.POSTBACK, msg.buttons.first().type)
+        assertNull(msg.buttons.first().url)
+    }
+
+    @Test
+    fun `pollIncomingMessages maps textMessageRequest LINK button with url`() = runTest {
+        val json = textMessageWithButtonsJson(
+            id = "btn-l1",
+            text = "Visit our store:",
+            buttons = listOf(Triple("Open", "BUTTON_TYPE_LINK", "https://shop.example.com")),
+        )
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        val msg = batch.first()
+        assertEquals(MessageType.Text, msg.type)
+        assertEquals(1, msg.buttons.size)
+        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertEquals("Open", msg.buttons.first().text)
+        assertEquals("https://shop.example.com", msg.buttons.first().url)
+    }
+
+    @Test
+    fun `pollIncomingMessages maps textMessageRequest REPLY button`() = runTest {
+        val json = textMessageWithButtonsJson(
+            id = "btn-r1",
+            text = "Are you sure?",
+            buttons = listOf(Triple("Yes", "BUTTON_TYPE_REPLY", null), Triple("No", "BUTTON_TYPE_REPLY", null)),
+        )
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        val msg = batch.first()
+        assertEquals(2, msg.buttons.size)
+        assertTrue(msg.buttons.all { it.type == ButtonType.REPLY })
+    }
+
+    @Test
+    fun `pollIncomingMessages maps textMessageRequest with mixed button types`() = runTest {
+        val json = textMessageWithButtonsJson(
+            id = "btn-mix1",
+            text = "What would you like?",
+            buttons = listOf(
+                Triple("Confirm", "BUTTON_TYPE_POSTBACK", null),
+                Triple("Details", "BUTTON_TYPE_LINK", "https://details.example.com"),
+                Triple("Skip", "BUTTON_TYPE_REPLY", null),
+            ),
+        )
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        val msg = batch.first()
+        assertEquals(3, msg.buttons.size)
+        assertEquals(ButtonType.POSTBACK, msg.buttons[0].type)
+        assertEquals(ButtonType.LINK, msg.buttons[1].type)
+        assertEquals(ButtonType.REPLY, msg.buttons[2].type)
+        assertEquals("https://details.example.com", msg.buttons[1].url)
+    }
+
+    @Test
+    fun `pollIncomingMessages maps textMessageRequest header and footer`() = runTest {
+        val json = textMessageWithButtonsJson(
+            id = "btn-hf1",
+            text = "Pick an option",
+            buttons = listOf(Triple("Option A", "BUTTON_TYPE_POSTBACK", null)),
+            header = "Special Offer",
+            footer = "Valid today only",
+        )
+        val repo = buildRepo(listOf(json))
+        val batch = repo.pollIncomingMessages().first()
+        val msg = batch.first()
+        assertEquals("Special Offer", msg.header)
+        assertEquals("Valid today only", msg.footer)
+        assertEquals("Pick an option", msg.content)
+    }
+
+    // ── pollIncomingMessages — legacy buttons messages (backward compat) ───────────
 
     private fun buttonsMessageJson(
         id: String,
@@ -630,28 +745,31 @@ class YaloMessageRepositoryRemoteTest {
     }
 
     @Test
-    fun `pollIncomingMessages emits buttons message`() = runTest {
+    fun `pollIncomingMessages maps legacy buttonsMessageRequest to POSTBACK buttons`() = runTest {
         val json = buttonsMessageJson("btn-1", body = "Choose:", buttons = listOf("A", "B"))
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         assertEquals(1, batch.size)
-        assertEquals(MessageType.Buttons, batch.first().type)
-        assertEquals(MessageRole.AGENT, batch.first().role)
-        assertEquals("Choose:", batch.first().content)
-        assertEquals(listOf("A", "B"), batch.first().buttons)
+        val msg = batch.first()
+        assertEquals(MessageType.Buttons, msg.type)
+        assertEquals(MessageRole.AGENT, msg.role)
+        assertEquals("Choose:", msg.content)
+        assertEquals(2, msg.buttons.size)
+        assertTrue(msg.buttons.all { it.type == ButtonType.POSTBACK })
+        assertEquals(listOf("A", "B"), msg.buttons.map { it.text })
     }
 
     @Test
-    fun `pollIncomingMessages emits buttons message with header and footer`() = runTest {
+    fun `pollIncomingMessages maps legacy buttonsMessageRequest with header and footer`() = runTest {
         val json = buttonsMessageJson("btn-2", body = "Help?", header = "Order", footer = "Tap one", buttons = listOf("Track", "Cancel"))
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         assertEquals("Order", batch.first().header)
         assertEquals("Tap one", batch.first().footer)
-        assertEquals(listOf("Track", "Cancel"), batch.first().buttons)
+        assertEquals(listOf("Track", "Cancel"), batch.first().buttons.map { it.text })
     }
 
-    // ── pollIncomingMessages — CTA messages ────────────────────────────────────────
+    // ── pollIncomingMessages — legacy CTA messages (backward compat) ──────────────
 
     private fun ctaMessageJson(
         id: String,
@@ -667,27 +785,30 @@ class YaloMessageRepositoryRemoteTest {
     }
 
     @Test
-    fun `pollIncomingMessages emits CTA message`() = runTest {
+    fun `pollIncomingMessages maps legacy ctaMessageRequest to LINK buttons`() = runTest {
         val json = ctaMessageJson("cta-1", body = "Shop now", buttons = listOf("View" to "https://shop.example.com"))
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         assertEquals(1, batch.size)
-        assertEquals(MessageType.CTA, batch.first().type)
-        assertEquals(MessageRole.AGENT, batch.first().role)
-        assertEquals("Shop now", batch.first().content)
-        assertEquals(1, batch.first().ctaButtons.size)
-        assertEquals("View", batch.first().ctaButtons.first().text)
-        assertEquals("https://shop.example.com", batch.first().ctaButtons.first().url)
+        val msg = batch.first()
+        assertEquals(MessageType.CTA, msg.type)
+        assertEquals(MessageRole.AGENT, msg.role)
+        assertEquals("Shop now", msg.content)
+        assertEquals(1, msg.buttons.size)
+        assertEquals(ButtonType.LINK, msg.buttons.first().type)
+        assertEquals("View", msg.buttons.first().text)
+        assertEquals("https://shop.example.com", msg.buttons.first().url)
     }
 
     @Test
-    fun `pollIncomingMessages emits CTA message with header and footer`() = runTest {
+    fun `pollIncomingMessages maps legacy ctaMessageRequest with header and footer`() = runTest {
         val json = ctaMessageJson("cta-2", header = "Promo", footer = "Limited", buttons = listOf("Buy" to "https://a.com", "Learn" to "https://b.com"))
         val repo = buildRepo(listOf(json))
         val batch = repo.pollIncomingMessages().first()
         assertEquals("Promo", batch.first().header)
         assertEquals("Limited", batch.first().footer)
-        assertEquals(2, batch.first().ctaButtons.size)
+        assertEquals(2, batch.first().buttons.size)
+        assertTrue(batch.first().buttons.all { it.type == ButtonType.LINK })
     }
 
     // ── pollIncomingMessages — video messages ──────────────────────────────────────

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -5,6 +5,8 @@ package com.yalo.chat.sdk.ui.chat
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -232,9 +234,9 @@ class MessagesViewModelTest {
     fun `ClearQuickReplies empties quickReplies list`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         chatRepo.insertMessage(
-            ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick:",
-                quickReplies = listOf("A", "B"))
+                buttons = listOf(Button("A", ButtonType.REPLY), Button("B", ButtonType.REPLY)))
         )
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.LoadMessages)
@@ -286,12 +288,12 @@ class MessagesViewModelTest {
     // ── QuickReplies extraction ───────────────────────────────────────────────
 
     @Test
-    fun `LoadMessages extracts quickReplies from QuickReply message`() = runTest {
+    fun `LoadMessages extracts quickReplies from message with REPLY buttons`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         chatRepo.insertMessage(
-            ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Choose:",
-                quickReplies = listOf("Yes", "No"))
+                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
         )
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.LoadMessages)
@@ -299,36 +301,35 @@ class MessagesViewModelTest {
     }
 
     @Test
-    fun `SubscribeToMessages extracts quickReplies when QuickReply message arrives`() = runTest {
+    fun `SubscribeToMessages extracts quickReplies when message with REPLY buttons arrives`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SubscribeToMessages)
         chatRepo.insertMessage(
-            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                quickReplies = listOf("Option A", "Option B"))
+                buttons = listOf(Button("Option A", ButtonType.REPLY), Button("Option B", ButtonType.REPLY)))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
         vm.viewModelScope.cancel()
     }
 
     @Test
-    fun `ClearQuickReplies not restored when subsequent non-QuickReply message arrives`() = runTest {
+    fun `ClearQuickReplies not restored when subsequent non-REPLY message arrives`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SubscribeToMessages)
-        // Seed a QuickReply message so quickReplies are populated
+        // Seed a message with REPLY buttons so quickReplies are populated
         chatRepo.insertMessage(
-            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                quickReplies = listOf("Option A", "Option B"))
+                buttons = listOf(Button("Option A", ButtonType.REPLY), Button("Option B", ButtonType.REPLY)))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
         // User taps a chip → clear
         vm.handleEvent(MessagesEvent.ClearQuickReplies)
         assertTrue(vm.state.value.quickReplies.isEmpty())
-        // A new non-QuickReply message arrives (e.g. user sends text) —
-        // quick replies must NOT be restored.
+        // A new text message arrives (e.g. user sends text) — quick replies must NOT be restored.
         chatRepo.insertMessage(
             ChatMessage(id = 2L, role = MessageRole.USER, type = MessageType.Text,
                 status = MessageStatus.SENT, content = "Option A")
@@ -338,27 +339,27 @@ class MessagesViewModelTest {
     }
 
     @Test
-    fun `ClearQuickReplies IS restored when a new QuickReply message with the same content arrives`() = runTest {
+    fun `ClearQuickReplies IS restored when a new message with REPLY buttons arrives`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.SubscribeToMessages)
-        // First QuickReply message
+        // First message with REPLY buttons
         chatRepo.insertMessage(
-            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                quickReplies = listOf("Yes", "No"))
+                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
         )
         assertEquals(listOf("Yes", "No"), vm.state.value.quickReplies)
         vm.handleEvent(MessagesEvent.ClearQuickReplies)
         assertTrue(vm.state.value.quickReplies.isEmpty())
-        // Backend re-sends a QuickReply with identical options — different message (different wiId).
+        // Backend re-sends REPLY buttons with identical options — different message (different wiId).
         // The chip row MUST reappear even though the content is the same as the cleared one.
         chatRepo.insertMessage(
-            ChatMessage(id = 2L, wiId = "qr-wi-2", role = MessageRole.AGENT, type = MessageType.QuickReply,
+            ChatMessage(id = 2L, wiId = "qr-wi-2", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                quickReplies = listOf("Yes", "No"))
+                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
         )
-        assertEquals(listOf("Yes", "No"), vm.state.value.quickReplies, "chip row must reappear for a new QuickReply message even if content is identical")
+        assertEquals(listOf("Yes", "No"), vm.state.value.quickReplies, "chip row must reappear for a new REPLY message even if content is identical")
         vm.viewModelScope.cancel()
     }
 

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/MessagesViewModelTest.kt
@@ -5,8 +5,8 @@ package com.yalo.chat.sdk.ui.chat
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -236,7 +236,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick:",
-                buttons = listOf(Button("A", ButtonType.REPLY), Button("B", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("A", ChatButtonType.REPLY), ChatButton("B", ChatButtonType.REPLY)))
         )
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.LoadMessages)
@@ -293,7 +293,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 1L, role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Choose:",
-                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("Yes", ChatButtonType.REPLY), ChatButton("No", ChatButtonType.REPLY)))
         )
         val vm = viewModel(chatRepo = chatRepo)
         vm.handleEvent(MessagesEvent.LoadMessages)
@@ -308,7 +308,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                buttons = listOf(Button("Option A", ButtonType.REPLY), Button("Option B", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("Option A", ChatButtonType.REPLY), ChatButton("Option B", ChatButtonType.REPLY)))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
         vm.viewModelScope.cancel()
@@ -323,7 +323,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                buttons = listOf(Button("Option A", ButtonType.REPLY), Button("Option B", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("Option A", ChatButtonType.REPLY), ChatButton("Option B", ChatButtonType.REPLY)))
         )
         assertEquals(listOf("Option A", "Option B"), vm.state.value.quickReplies)
         // User taps a chip → clear
@@ -347,7 +347,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("Yes", ChatButtonType.REPLY), ChatButton("No", ChatButtonType.REPLY)))
         )
         assertEquals(listOf("Yes", "No"), vm.state.value.quickReplies)
         vm.handleEvent(MessagesEvent.ClearQuickReplies)
@@ -357,7 +357,7 @@ class MessagesViewModelTest {
         chatRepo.insertMessage(
             ChatMessage(id = 2L, wiId = "qr-wi-2", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick one:",
-                buttons = listOf(Button("Yes", ButtonType.REPLY), Button("No", ButtonType.REPLY)))
+                buttons = listOf(ChatButton("Yes", ChatButtonType.REPLY), ChatButton("No", ChatButtonType.REPLY)))
         )
         assertEquals(listOf("Yes", "No"), vm.state.value.quickReplies, "chip row must reappear for a new REPLY message even if content is identical")
         vm.viewModelScope.cancel()

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
@@ -5,6 +5,8 @@ package com.yalo.chat.sdk.ui.chat
 import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -57,13 +59,17 @@ class QuickRepliesTest {
     }
 
     @Test
-    fun `quickReplies is non-empty after loading a QuickReply message — chip row is visible`() = runTest {
+    fun `quickReplies is non-empty after loading a message with REPLY buttons — chip row is visible`() = runTest {
         val chatRepo = FakeChatMessageRepository()
         chatRepo.insertMessage(
             ChatMessage(
-                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick an option:",
-                quickReplies = listOf("Yes", "No", "Maybe"),
+                buttons = listOf(
+                    Button(text = "Yes", type = ButtonType.REPLY),
+                    Button(text = "No", type = ButtonType.REPLY),
+                    Button(text = "Maybe", type = ButtonType.REPLY),
+                ),
             )
         )
         val vm = viewModel(chatRepo = chatRepo)
@@ -81,9 +87,12 @@ class QuickRepliesTest {
         val chatRepo = FakeChatMessageRepository()
         chatRepo.insertMessage(
             ChatMessage(
-                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick:",
-                quickReplies = listOf("Track order", "Cancel order"),
+                buttons = listOf(
+                    Button(text = "Track order", type = ButtonType.REPLY),
+                    Button(text = "Cancel order", type = ButtonType.REPLY),
+                ),
             )
         )
         val vm = viewModel(chatRepo = chatRepo)
@@ -108,9 +117,13 @@ class QuickRepliesTest {
         val chatRepo = FakeChatMessageRepository()
         chatRepo.insertMessage(
             ChatMessage(
-                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.QuickReply,
+                id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "How can I help?",
-                quickReplies = listOf("Option A", "Option B", "Option C"),
+                buttons = listOf(
+                    Button(text = "Option A", type = ButtonType.REPLY),
+                    Button(text = "Option B", type = ButtonType.REPLY),
+                    Button(text = "Option C", type = ButtonType.REPLY),
+                ),
             )
         )
         val vm = viewModel(chatRepo = chatRepo)

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/ui/chat/QuickRepliesTest.kt
@@ -5,8 +5,8 @@ package com.yalo.chat.sdk.ui.chat
 import androidx.lifecycle.viewModelScope
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
@@ -66,9 +66,9 @@ class QuickRepliesTest {
                 id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick an option:",
                 buttons = listOf(
-                    Button(text = "Yes", type = ButtonType.REPLY),
-                    Button(text = "No", type = ButtonType.REPLY),
-                    Button(text = "Maybe", type = ButtonType.REPLY),
+                    ChatButton(text = "Yes", type = ChatButtonType.REPLY),
+                    ChatButton(text = "No", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Maybe", type = ChatButtonType.REPLY),
                 ),
             )
         )
@@ -90,8 +90,8 @@ class QuickRepliesTest {
                 id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "Pick:",
                 buttons = listOf(
-                    Button(text = "Track order", type = ButtonType.REPLY),
-                    Button(text = "Cancel order", type = ButtonType.REPLY),
+                    ChatButton(text = "Track order", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Cancel order", type = ChatButtonType.REPLY),
                 ),
             )
         )
@@ -120,9 +120,9 @@ class QuickRepliesTest {
                 id = 1L, wiId = "qr-wi-1", role = MessageRole.AGENT, type = MessageType.Text,
                 status = MessageStatus.DELIVERED, content = "How can I help?",
                 buttons = listOf(
-                    Button(text = "Option A", type = ButtonType.REPLY),
-                    Button(text = "Option B", type = ButtonType.REPLY),
-                    Button(text = "Option C", type = ButtonType.REPLY),
+                    ChatButton(text = "Option A", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Option B", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Option C", type = ChatButtonType.REPLY),
                 ),
             )
         )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -7,6 +7,8 @@ import app.cash.sqldelight.coroutines.mapToList
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.database.ChatMessageQueries
 import com.yalo.chat.sdk.database.Chat_message
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -116,11 +118,9 @@ internal class LocalChatMessageRepository(
         byteCount = byte_count,
         mediaType = media_type,
         products = products?.let { decodeProductList(it) } ?: emptyList(),
-        quickReplies = quick_replies?.let { decodeStringList(it) } ?: emptyList(),
         header = header_, // SQLDelight escapes 'header' (SQL keyword) → header_
         footer = footer,
-        buttons = buttons?.let { decodeStringList(it) } ?: emptyList(),
-        ctaButtons = cta_buttons?.let { decodeCtaButtonList(it) } ?: emptyList(),
+        buttons = decodeButtons(buttons, cta_buttons, quick_replies),
         timestamp = timestamp,
     )
 
@@ -137,11 +137,11 @@ internal class LocalChatMessageRepository(
         byte_count = byteCount,
         media_type = mediaType,
         products = products.takeIf { it.isNotEmpty() }?.let { encodeProductList(it) },
-        quick_replies = quickReplies.takeIf { it.isNotEmpty() }?.let { encodeStringList(it) },
+        quick_replies = null,
         header_ = header,
         footer = footer,
-        buttons = buttons.takeIf { it.isNotEmpty() }?.let { encodeStringList(it) },
-        cta_buttons = ctaButtons.takeIf { it.isNotEmpty() }?.let { encodeCtaButtonList(it) },
+        buttons = buttons.takeIf { it.isNotEmpty() }?.let { encodeButtonList(it) },
+        cta_buttons = null,
         timestamp = timestamp,
     )
 
@@ -151,6 +151,40 @@ internal class LocalChatMessageRepository(
     private val productListSerializer = ListSerializer(Product.serializer())
     private val stringListSerializer = ListSerializer(String.serializer())
     private val ctaButtonListSerializer = ListSerializer(CtaButton.serializer())
+    private val buttonListSerializer = ListSerializer(Button.serializer())
+
+    // Reads unified List<Button> from the three DB columns, handling both old and new formats.
+    // New records: `buttons` stores List<Button> JSON; `cta_buttons` and `quick_replies` are null.
+    // Old records: `buttons` stores List<String> JSON (POSTBACK-implied), `cta_buttons` stores
+    // List<CtaButton> JSON (LINK-implied), `quick_replies` stores List<String> JSON (REPLY-implied).
+    private fun decodeButtons(
+        buttonsJson: String?,
+        ctaJson: String?,
+        qrJson: String?,
+    ): List<Button> {
+        buttonsJson?.let { json ->
+            // Try new unified format (List<Button> with type field).
+            val asButtons = try { Json.decodeFromString(buttonListSerializer, json) } catch (_: Exception) { null }
+            if (asButtons != null) return asButtons
+            // Fall back to old List<String> format (POSTBACK-implied, no URL).
+            val asStrings = try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { null }
+            if (asStrings != null) return asStrings.map { Button(text = it, type = ButtonType.POSTBACK) }
+        }
+        val result = mutableListOf<Button>()
+        ctaJson?.let { json ->
+            try {
+                result += Json.decodeFromString(ctaButtonListSerializer, json)
+                    .map { Button(text = it.text, type = ButtonType.LINK, url = it.url) }
+            } catch (_: Exception) { }
+        }
+        qrJson?.let { json ->
+            try {
+                result += Json.decodeFromString(stringListSerializer, json)
+                    .map { Button(text = it, type = ButtonType.REPLY) }
+            } catch (_: Exception) { }
+        }
+        return result
+    }
 
     private fun decodeDoubleList(json: String): List<Double> =
         try { Json.decodeFromString(doubleListSerializer, json) } catch (_: Exception) { emptyList() }
@@ -158,23 +192,14 @@ internal class LocalChatMessageRepository(
     private fun decodeProductList(json: String): List<Product> =
         try { Json.decodeFromString(productListSerializer, json) } catch (_: Exception) { emptyList() }
 
-    private fun decodeStringList(json: String): List<String> =
-        try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { emptyList() }
-
-    private fun decodeCtaButtonList(json: String): List<CtaButton> =
-        try { Json.decodeFromString(ctaButtonListSerializer, json) } catch (_: Exception) { emptyList() }
-
     private fun encodeDoubleList(list: List<Double>): String =
         Json.encodeToString(doubleListSerializer, list)
 
     private fun encodeProductList(list: List<Product>): String =
         Json.encodeToString(productListSerializer, list)
 
-    private fun encodeStringList(list: List<String>): String =
-        Json.encodeToString(stringListSerializer, list)
-
-    private fun encodeCtaButtonList(list: List<CtaButton>): String =
-        Json.encodeToString(ctaButtonListSerializer, list)
+    private fun encodeButtonList(list: List<Button>): String =
+        Json.encodeToString(buttonListSerializer, list)
 }
 
 // Struct to carry insertOrReplace parameters (avoids a long positional call site).

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -7,8 +7,8 @@ import app.cash.sqldelight.coroutines.mapToList
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.database.ChatMessageQueries
 import com.yalo.chat.sdk.database.Chat_message
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -151,36 +151,36 @@ internal class LocalChatMessageRepository(
     private val productListSerializer = ListSerializer(Product.serializer())
     private val stringListSerializer = ListSerializer(String.serializer())
     private val ctaButtonListSerializer = ListSerializer(CtaButton.serializer())
-    private val buttonListSerializer = ListSerializer(Button.serializer())
+    private val buttonListSerializer = ListSerializer(ChatButton.serializer())
 
-    // Reads unified List<Button> from the three DB columns, handling both old and new formats.
-    // New records: `buttons` stores List<Button> JSON; `cta_buttons` and `quick_replies` are null.
+    // Reads unified List<ChatButton> from the three DB columns, handling both old and new formats.
+    // New records: `buttons` stores List<ChatButton> JSON; `cta_buttons` and `quick_replies` are null.
     // Old records: `buttons` stores List<String> JSON (POSTBACK-implied), `cta_buttons` stores
     // List<CtaButton> JSON (LINK-implied), `quick_replies` stores List<String> JSON (REPLY-implied).
     private fun decodeButtons(
         buttonsJson: String?,
         ctaJson: String?,
         qrJson: String?,
-    ): List<Button> {
+    ): List<ChatButton> {
         buttonsJson?.let { json ->
-            // Try new unified format (List<Button> with type field).
+            // Try new unified format (List<ChatButton> with type field).
             val asButtons = try { Json.decodeFromString(buttonListSerializer, json) } catch (_: Exception) { null }
             if (!asButtons.isNullOrEmpty()) return asButtons
             // Fall back to old List<String> format (POSTBACK-implied, no URL).
             val asStrings = try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { null }
-            if (asStrings != null) return asStrings.map { Button(text = it, type = ButtonType.POSTBACK) }
+            if (asStrings != null) return asStrings.map { ChatButton(text = it, type = ChatButtonType.POSTBACK) }
         }
-        val result = mutableListOf<Button>()
+        val result = mutableListOf<ChatButton>()
         ctaJson?.let { json ->
             try {
                 result += Json.decodeFromString(ctaButtonListSerializer, json)
-                    .map { Button(text = it.text, type = ButtonType.LINK, url = it.url) }
+                    .map { ChatButton(text = it.text, type = ChatButtonType.LINK, url = it.url) }
             } catch (_: Exception) { }
         }
         qrJson?.let { json ->
             try {
                 result += Json.decodeFromString(stringListSerializer, json)
-                    .map { Button(text = it, type = ButtonType.REPLY) }
+                    .map { ChatButton(text = it, type = ChatButtonType.REPLY) }
             } catch (_: Exception) { }
         }
         return result
@@ -198,7 +198,7 @@ internal class LocalChatMessageRepository(
     private fun encodeProductList(list: List<Product>): String =
         Json.encodeToString(productListSerializer, list)
 
-    private fun encodeButtonList(list: List<Button>): String =
+    private fun encodeButtonList(list: List<ChatButton>): String =
         Json.encodeToString(buttonListSerializer, list)
 }
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/local/LocalChatMessageRepository.kt
@@ -165,7 +165,7 @@ internal class LocalChatMessageRepository(
         buttonsJson?.let { json ->
             // Try new unified format (List<Button> with type field).
             val asButtons = try { Json.decodeFromString(buttonListSerializer, json) } catch (_: Exception) { null }
-            if (asButtons != null) return asButtons
+            if (!asButtons.isNullOrEmpty()) return asButtons
             // Fall back to old List<String> format (POSTBACK-implied, no URL).
             val asStrings = try { Json.decodeFromString(stringListSerializer, json) } catch (_: Exception) { null }
             if (asStrings != null) return asStrings.map { Button(text = it, type = ButtonType.POSTBACK) }

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -33,12 +33,16 @@ internal data class SdkMessageResponseDto(
 
 // ── Unified button (proto 2.0) ────────────────────────────────────────────────
 
-// Proto3 JSON for sdk_message.proto Button — button_type is serialized as its enum name string
+// Proto3 JSON for sdk_message.proto ChatButton — button_type is serialized as its enum name string
 // (e.g. "BUTTON_TYPE_POSTBACK"). url is omitted from JSON when absent (proto3 optional).
+internal const val BUTTON_TYPE_POSTBACK = "BUTTON_TYPE_POSTBACK"
+internal const val BUTTON_TYPE_LINK = "BUTTON_TYPE_LINK"
+internal const val BUTTON_TYPE_REPLY = "BUTTON_TYPE_REPLY"
+
 @Serializable
 internal data class SdkButtonDto(
     val text: String = "",
-    val buttonType: String = "BUTTON_TYPE_REPLY",
+    val buttonType: String = BUTTON_TYPE_REPLY,
     val url: String? = null,
 )
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/model/YaloFetchMessagesResponse.kt
@@ -31,11 +31,25 @@ internal data class SdkMessageResponseDto(
     val ctaMessageRequest: SdkCtaMessageResponseDto? = null,
 )
 
+// ── Unified button (proto 2.0) ────────────────────────────────────────────────
+
+// Proto3 JSON for sdk_message.proto Button — button_type is serialized as its enum name string
+// (e.g. "BUTTON_TYPE_POSTBACK"). url is omitted from JSON when absent (proto3 optional).
+@Serializable
+internal data class SdkButtonDto(
+    val text: String = "",
+    val buttonType: String = "BUTTON_TYPE_REPLY",
+    val url: String? = null,
+)
+
 // ── Text ──────────────────────────────────────────────────────────────────────
 
 @Serializable
 internal data class SdkTextMessageResponseDto(
     val content: SdkTextMessageContentDto? = null,
+    val buttons: List<SdkButtonDto> = emptyList(),
+    val header: String? = null,
+    val footer: String? = null,
 )
 
 @Serializable
@@ -73,6 +87,9 @@ internal data class SdkProductDto(
 @Serializable
 internal data class SdkImageMessageResponseDto(
     val content: SdkImageMessageContentDto? = null,
+    val buttons: List<SdkButtonDto> = emptyList(),
+    val header: String? = null,
+    val footer: String? = null,
 )
 
 @Serializable
@@ -88,6 +105,9 @@ internal data class SdkImageMessageContentDto(
 @Serializable
 internal data class SdkVideoMessageResponseDto(
     val content: SdkVideoMessageContentDto? = null,
+    val buttons: List<SdkButtonDto> = emptyList(),
+    val header: String? = null,
+    val footer: String? = null,
 )
 
 @Serializable
@@ -106,6 +126,9 @@ internal data class SdkVideoMessageContentDto(
 @Serializable
 internal data class SdkVoiceNoteMessageResponseDto(
     val content: SdkVoiceMessageContentDto? = null,
+    val buttons: List<SdkButtonDto> = emptyList(),
+    val header: String? = null,
+    val footer: String? = null,
 )
 
 @Serializable

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
@@ -3,6 +3,8 @@
 package com.yalo.chat.sdk.data.repository.fake
 
 import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -86,7 +88,11 @@ class FakeYaloMessageRepository : YaloMessageRepository {
                 type = MessageType.QuickReply,
                 status = MessageStatus.DELIVERED,
                 content = "Please choose an option:",
-                quickReplies = listOf("Track order", "Cancel order", "Talk to agent"),
+                buttons = listOf(
+                    Button(text = "Track order", type = ButtonType.REPLY),
+                    Button(text = "Cancel order", type = ButtonType.REPLY),
+                    Button(text = "Talk to agent", type = ButtonType.REPLY),
+                ),
                 timestamp = Clock.System.now().toEpochMilliseconds() - 10_000,
             ),
             ChatMessage(

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
@@ -3,8 +3,8 @@
 package com.yalo.chat.sdk.data.repository.fake
 
 import com.yalo.chat.sdk.common.Result
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatEvent
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -89,9 +89,9 @@ class FakeYaloMessageRepository : YaloMessageRepository {
                 status = MessageStatus.DELIVERED,
                 content = "Please choose an option:",
                 buttons = listOf(
-                    Button(text = "Track order", type = ButtonType.REPLY),
-                    Button(text = "Cancel order", type = ButtonType.REPLY),
-                    Button(text = "Talk to agent", type = ButtonType.REPLY),
+                    ChatButton(text = "Track order", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Cancel order", type = ChatButtonType.REPLY),
+                    ChatButton(text = "Talk to agent", type = ChatButtonType.REPLY),
                 ),
                 timestamp = Clock.System.now().toEpochMilliseconds() - 10_000,
             ),

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepository.kt
@@ -85,7 +85,7 @@ class FakeYaloMessageRepository : YaloMessageRepository {
             ChatMessage(
                 id = 6L,
                 role = MessageRole.AGENT,
-                type = MessageType.QuickReply,
+                type = MessageType.Text,
                 status = MessageStatus.DELIVERED,
                 content = "Please choose an option:",
                 buttons = listOf(

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/MessageMapper.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/MessageMapper.kt
@@ -4,13 +4,16 @@ package com.yalo.chat.sdk.data.repository.remote
 
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.data.remote.model.SdkButtonDto
+import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
+import com.yalo.chat.sdk.domain.model.Button
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.model.Product
-import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import com.yalo.chat.sdk.ui.chat.UnitType
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
@@ -68,17 +71,22 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
     val stableId = if (ts != 0L) (ts / 1000L) * 1000L + indexOffset else indexOffset.toLong()
 
     // Text message
-    message.textMessageRequest?.content?.let { textContent ->
-        if (deduplicate) cache.set(id, true)
-        return ChatMessage(
-            id = stableId,
-            wiId = id,
-            role = MessageRole.fromString(textContent.role ?: ""),
-            type = MessageType.Text,
-            status = MessageStatus.DELIVERED,
-            content = textContent.text,
-            timestamp = ts,
-        )
+    message.textMessageRequest?.let { request ->
+        request.content?.let { textContent ->
+            if (deduplicate) cache.set(id, true)
+            return ChatMessage(
+                id = stableId,
+                wiId = id,
+                role = MessageRole.fromString(textContent.role ?: ""),
+                type = MessageType.Text,
+                status = MessageStatus.DELIVERED,
+                content = textContent.text,
+                buttons = request.buttons.map { it.toDomain() },
+                header = request.header?.takeIf { it.isNotEmpty() },
+                footer = request.footer?.takeIf { it.isNotEmpty() },
+                timestamp = ts,
+            )
+        }
     }
 
     // Image message — download from CDN and save locally.
@@ -97,6 +105,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     bytes = bytes,
                 ) ?: return null
                 if (deduplicate) cache.set(id, true)
+                val imgRequest = message.imageMessageRequest!!
                 ChatMessage(
                     id = stableId,
                     wiId = id,
@@ -107,6 +116,9 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     fileName = localPath,
                     mediaType = mimeType,
                     byteCount = bytes.size.toLong(),
+                    buttons = imgRequest.buttons.map { it.toDomain() },
+                    header = imgRequest.header?.takeIf { it.isNotEmpty() },
+                    footer = imgRequest.footer?.takeIf { it.isNotEmpty() },
                     timestamp = ts,
                 )
             }
@@ -129,6 +141,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     bytes = bytes,
                 ) ?: return null
                 if (deduplicate) cache.set(id, true)
+                val videoRequest = message.videoMessageRequest!!
                 ChatMessage(
                     id = stableId,
                     wiId = id,
@@ -140,6 +153,9 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     mediaType = mimeType,
                     byteCount = bytes.size.toLong(),
                     duration = (videoContent.duration * 1000).toLong(),
+                    buttons = videoRequest.buttons.map { it.toDomain() },
+                    header = videoRequest.header?.takeIf { it.isNotEmpty() },
+                    footer = videoRequest.footer?.takeIf { it.isNotEmpty() },
                     timestamp = ts,
                 )
             }
@@ -166,6 +182,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     bytes = bytes,
                 ) ?: return null
                 if (deduplicate) cache.set(id, true)
+                val voiceRequest = message.voiceNoteMessageRequest!!
                 ChatMessage(
                     id = stableId,
                     wiId = id,
@@ -177,13 +194,16 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
                     duration = (voiceContent.duration * 1000).toLong(),
                     mediaType = mimeType,
                     byteCount = bytes.size.toLong(),
+                    buttons = voiceRequest.buttons.map { it.toDomain() },
+                    header = voiceRequest.header?.takeIf { it.isNotEmpty() },
+                    footer = voiceRequest.footer?.takeIf { it.isNotEmpty() },
                     timestamp = ts,
                 )
             }
         }
     }
 
-    // Buttons message
+    // Buttons message (legacy pre-proto-2.0 format — POSTBACK-implied buttons)
     message.buttonsMessageRequest?.content?.let { buttonsContent ->
         if (deduplicate) cache.set(id, true)
         return ChatMessage(
@@ -195,12 +215,12 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
             content = buttonsContent.body,
             header = buttonsContent.header.takeIf { !it.isNullOrEmpty() },
             footer = buttonsContent.footer.takeIf { !it.isNullOrEmpty() },
-            buttons = buttonsContent.buttons,
+            buttons = buttonsContent.buttons.map { Button(text = it, type = ButtonType.POSTBACK) },
             timestamp = ts,
         )
     }
 
-    // CTA message
+    // CTA message (legacy pre-proto-2.0 format — LINK-implied buttons)
     message.ctaMessageRequest?.content?.let { ctaContent ->
         if (deduplicate) cache.set(id, true)
         return ChatMessage(
@@ -212,7 +232,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
             content = ctaContent.body,
             header = ctaContent.header.takeIf { !it.isNullOrEmpty() },
             footer = ctaContent.footer.takeIf { !it.isNullOrEmpty() },
-            ctaButtons = ctaContent.buttons.map { CtaButton(text = it.text, url = it.url) },
+            buttons = ctaContent.buttons.map { Button(text = it.text, type = ButtonType.LINK, url = it.url) },
             timestamp = ts,
         )
     }
@@ -251,4 +271,16 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
     // Unknown payload — cache to avoid re-evaluating on every cycle.
     if (deduplicate) cache.set(id, true)
     return null
+}
+
+// Maps proto3 buttonType string to the domain enum. Proto3 JSON serializes enum values as their
+// name strings (e.g. "BUTTON_TYPE_POSTBACK"). BUTTON_TYPE_REPLY = 0 is the proto3 default and
+// may be omitted from JSON, in which case the DTO default "BUTTON_TYPE_REPLY" is used.
+private fun SdkButtonDto.toDomain(): Button {
+    val type = when (buttonType) {
+        "BUTTON_TYPE_POSTBACK" -> ButtonType.POSTBACK
+        "BUTTON_TYPE_LINK" -> ButtonType.LINK
+        else -> ButtonType.REPLY
+    }
+    return Button(text = text, type = type, url = url)
 }

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/MessageMapper.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/MessageMapper.kt
@@ -4,10 +4,12 @@ package com.yalo.chat.sdk.data.repository.remote
 
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
+import com.yalo.chat.sdk.data.remote.model.BUTTON_TYPE_LINK
+import com.yalo.chat.sdk.data.remote.model.BUTTON_TYPE_POSTBACK
 import com.yalo.chat.sdk.data.remote.model.SdkButtonDto
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
-import com.yalo.chat.sdk.domain.model.Button
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButton
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.CtaButton
 import com.yalo.chat.sdk.domain.model.MessageRole
@@ -215,7 +217,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
             content = buttonsContent.body,
             header = buttonsContent.header.takeIf { !it.isNullOrEmpty() },
             footer = buttonsContent.footer.takeIf { !it.isNullOrEmpty() },
-            buttons = buttonsContent.buttons.map { Button(text = it, type = ButtonType.POSTBACK) },
+            buttons = buttonsContent.buttons.map { ChatButton(text = it, type = ChatButtonType.POSTBACK) },
             timestamp = ts,
         )
     }
@@ -232,7 +234,7 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
             content = ctaContent.body,
             header = ctaContent.header.takeIf { !it.isNullOrEmpty() },
             footer = ctaContent.footer.takeIf { !it.isNullOrEmpty() },
-            buttons = ctaContent.buttons.map { Button(text = it.text, type = ButtonType.LINK, url = it.url) },
+            buttons = ctaContent.buttons.map { ChatButton(text = it.text, type = ChatButtonType.LINK, url = it.url) },
             timestamp = ts,
         )
     }
@@ -276,11 +278,11 @@ internal suspend fun YaloFetchMessagesResponse.toChatMessage(
 // Maps proto3 buttonType string to the domain enum. Proto3 JSON serializes enum values as their
 // name strings (e.g. "BUTTON_TYPE_POSTBACK"). BUTTON_TYPE_REPLY = 0 is the proto3 default and
 // may be omitted from JSON, in which case the DTO default "BUTTON_TYPE_REPLY" is used.
-private fun SdkButtonDto.toDomain(): Button {
+private fun SdkButtonDto.toDomain(): ChatButton {
     val type = when (buttonType) {
-        "BUTTON_TYPE_POSTBACK" -> ButtonType.POSTBACK
-        "BUTTON_TYPE_LINK" -> ButtonType.LINK
-        else -> ButtonType.REPLY
+        BUTTON_TYPE_POSTBACK -> ChatButtonType.POSTBACK
+        BUTTON_TYPE_LINK -> ChatButtonType.LINK
+        else -> ChatButtonType.REPLY
     }
-    return Button(text = text, type = type, url = url)
+    return ChatButton(text = text, type = type, url = url)
 }

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
@@ -5,15 +5,15 @@ package com.yalo.chat.sdk.domain.model
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-enum class ButtonType {
+enum class ChatButtonType {
     @SerialName("REPLY") REPLY,
     @SerialName("POSTBACK") POSTBACK,
     @SerialName("LINK") LINK,
 }
 
 @Serializable
-data class Button(
+data class ChatButton(
     val text: String,
-    val type: ButtonType,
+    val type: ChatButtonType,
     val url: String? = null,
 )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
@@ -1,0 +1,14 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+package com.yalo.chat.sdk.domain.model
+
+import kotlinx.serialization.Serializable
+
+enum class ButtonType { REPLY, POSTBACK, LINK }
+
+@Serializable
+data class Button(
+    val text: String,
+    val type: ButtonType,
+    val url: String? = null,
+)

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/Button.kt
@@ -2,9 +2,14 @@
 
 package com.yalo.chat.sdk.domain.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-enum class ButtonType { REPLY, POSTBACK, LINK }
+enum class ButtonType {
+    @SerialName("REPLY") REPLY,
+    @SerialName("POSTBACK") POSTBACK,
+    @SerialName("LINK") LINK,
+}
 
 @Serializable
 data class Button(

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
@@ -29,6 +29,6 @@ data class ChatMessage(
     val footer: String? = null,
     // Unified button list (proto 2.0). POSTBACK buttons send text; LINK buttons open URLs;
     // REPLY buttons surface as quick-reply chips above ChatInput.
-    val buttons: List<Button> = emptyList(),
+    val buttons: List<ChatButton> = emptyList(),
     val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 )

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/domain/model/ChatMessage.kt
@@ -24,13 +24,11 @@ data class ChatMessage(
     val products: List<Product> = emptyList(),
     // Transient UI state — not stored in DB. Defaults to false on every load from storage.
     val expand: Boolean = false,
-    val quickReplies: List<QuickReply> = emptyList(),
-    // Optional header/footer text for buttons and CTA messages.
+    // Optional header/footer text for messages with buttons.
     val header: String? = null,
     val footer: String? = null,
-    // Reply button labels for ButtonsMessage — tapping sends the label as a text message.
-    val buttons: List<String> = emptyList(),
-    // CTA buttons (text + URL) for CtaMessage — tapping opens the URL in the browser.
-    val ctaButtons: List<CtaButton> = emptyList(),
+    // Unified button list (proto 2.0). POSTBACK buttons send text; LINK buttons open URLs;
+    // REPLY buttons surface as quick-reply chips above ChatInput.
+    val buttons: List<Button> = emptyList(),
     val timestamp: Long = Clock.System.now().toEpochMilliseconds(),
 )

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepositoryTest.kt
@@ -3,6 +3,7 @@
 package com.yalo.chat.sdk.data.repository.fake
 
 import com.yalo.chat.sdk.common.Result
+import com.yalo.chat.sdk.domain.model.ButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageType
@@ -33,8 +34,12 @@ class FakeYaloMessageRepositoryTest {
         assertTrue(MessageType.Product in types)
         assertTrue(MessageType.ProductCarousel in types)
         assertTrue(MessageType.Promotion in types)
-        assertTrue(MessageType.QuickReply in types)
         assertTrue(MessageType.Unknown in types)
+        // Proto 2.0: quick replies are Text messages with REPLY-typed buttons, not a separate type.
+        val hasReplyButtons = result.result.any { msg ->
+            msg.type == MessageType.Text && msg.buttons.any { it.type == ButtonType.REPLY }
+        }
+        assertTrue(hasReplyButtons, "Seed data must include a Text message with REPLY buttons")
     }
 
     @Test

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepositoryTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/data/repository/fake/FakeYaloMessageRepositoryTest.kt
@@ -3,7 +3,7 @@
 package com.yalo.chat.sdk.data.repository.fake
 
 import com.yalo.chat.sdk.common.Result
-import com.yalo.chat.sdk.domain.model.ButtonType
+import com.yalo.chat.sdk.domain.model.ChatButtonType
 import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageType
@@ -37,7 +37,7 @@ class FakeYaloMessageRepositoryTest {
         assertTrue(MessageType.Unknown in types)
         // Proto 2.0: quick replies are Text messages with REPLY-typed buttons, not a separate type.
         val hasReplyButtons = result.result.any { msg ->
-            msg.type == MessageType.Text && msg.buttons.any { it.type == ButtonType.REPLY }
+            msg.type == MessageType.Text && msg.buttons.any { it.type == ChatButtonType.REPLY }
         }
         assertTrue(hasReplyButtons, "Seed data must include a Text message with REPLY buttons")
     }

--- a/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/domain/model/ChatMessageTest.kt
+++ b/android-sdk/sdk/src/commonTest/kotlin/com/yalo/chat/sdk/domain/model/ChatMessageTest.kt
@@ -36,7 +36,7 @@ class ChatMessageTest {
         assertEquals("", msg.content)
         assertEquals(MessageStatus.IN_PROGRESS, msg.status)
         assertEquals(emptyList(), msg.products)
-        assertEquals(emptyList(), msg.quickReplies)
+        assertEquals(emptyList(), msg.buttons)
         assertEquals(emptyList(), msg.amplitudes)
     }
 }

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -153,12 +153,12 @@ struct MessageItem: View {
                     .font(theme.messageFooterFont)
                     .foregroundColor(theme.messageFooterColor)
             }
-            let labels = message.buttons
-            if !labels.isEmpty {
+            let inlineButtons = message.buttons.filter { $0.type != ChatButtonType.reply }
+            if !inlineButtons.isEmpty {
                 VStack(spacing: 6) {
-                    ForEach(labels, id: \.self) { label in
-                        Button(action: { onButtonTap(label) }) {
-                            Text(label)
+                    ForEach(inlineButtons, id: \.text) { button in
+                        SwiftUI.Button(action: { onButtonTap(button.text) }) {
+                            Text(button.text)
                                 .font(.subheadline)
                                 .frame(maxWidth: .infinity)
                                 .padding(.vertical, 8)
@@ -196,12 +196,12 @@ struct MessageItem: View {
                     .font(theme.messageFooterFont)
                     .foregroundColor(theme.messageFooterColor)
             }
-            let buttons = message.ctaButtons
+            let buttons = message.buttons.filter { $0.type == ChatButtonType.link }
             if !buttons.isEmpty {
                 VStack(spacing: 6) {
-                    ForEach(buttons, id: \.url) { button in
-                        Button(action: {
-                            if let url = URL(string: button.url) {
+                    ForEach(buttons, id: \.text) { button in
+                        SwiftUI.Button(action: {
+                            if let urlStr = button.url, let url = URL(string: urlStr) {
                                 UIApplication.shared.open(url)
                             }
                         }) {

--- a/ios-sdk/YaloChatDemo/MessagesObservable.swift
+++ b/ios-sdk/YaloChatDemo/MessagesObservable.swift
@@ -141,13 +141,15 @@ class MessagesObservable: ObservableObject {
     // ClearQuickReplies triggered by user send isn't undone by the next observeMessages emission.
     private func updateQuickRepliesFromMessages(_ messages: [ChatMessage]) {
         let lastQr = messages.last { msg in
-            msg.type is MessageType.QuickReply && msg.role === MessageRole.agent
+            (msg.type is MessageType.Text || msg.type is MessageType.QuickReply)
+                && msg.role === MessageRole.agent
+                && msg.buttons.contains { $0.type == ChatButtonType.reply }
         }
         guard let qrMsg = lastQr else { return }
         let wiId = qrMsg.wiId
         guard wiId != lastQuickReplyWiId else { return }
         lastQuickReplyWiId = wiId
-        quickReplies = qrMsg.quickReplies
+        quickReplies = qrMsg.buttons.filter { $0.type == ChatButtonType.reply }.map { $0.text }
     }
 
     // MARK: - Product expand


### PR DESCRIPTION
## Summary

- **Unified button model**: replaces the three separate `buttons: List<String>`, `ctaButtons: List<CtaButton>`, and `quickReplies: List<QuickReply>` fields on `ChatMessage` with a single `buttons: List<Button>` where each `Button` carries `text`, `type` (`REPLY`/`POSTBACK`/`LINK`), and optional `url`
- **Proto 2.0 mapper**: `textMessageRequest` (and image/video/voice) now reads `buttons`, `header`, `footer` from the request wrapper — fixes buttons and CTA messages that were silently dropped on Android since the server migrated to proto 2.0
- **Quick replies fixed**: `extractQuickReplies()` previously filtered on `MessageType.QuickReply` which the mapper never set — now correctly detects REPLY-typed buttons on Text messages
- **`openContext: String?`** added to `ChatScreen` for API parity with Flutter
- **Backward compat**: `decodeButtons()` in `LocalChatMessageRepository` reads old DB records in all three legacy formats (old `List<String>`, `List<CtaButton>`, `quick_replies` strings) — no DB migration needed
- **New `MessageButton` composable** dispatches on `ButtonType` mirroring Flutter's `message_button.dart`

## Test plan

- [x] All 341 unit tests pass (`./gradlew :sdk:testDebugUnitTest`)
- [x] Lint clean (`./gradlew :sdk:lint`)
- [x] Proto3 default enum test (absent `buttonType` field → `ButtonType.REPLY`)
- [x] LINK button with null `url` → `url = null`, no crash
- [x] 3 backward-compat DB decode tests (legacy `List<String>`, `List<CtaButton>`, `quick_replies`)
- [x] Manual: REPLY chips appear above input, tap sends text and clears row
- [x] Manual: POSTBACK buttons appear inline in bubble, tap sends button text
- [x] Manual: LINK buttons open URL in system browser
- [x] Manual: legacy `buttonsMessageRequest` / `ctaMessageRequest` still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)