### PR TITLE
feat: Header commands flutter and test fixes

### DIFF
--- a/flutter-sdk/example/pubspec.lock
+++ b/flutter-sdk/example/pubspec.lock
@@ -568,10 +568,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -861,10 +861,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/flutter-sdk/lib/src/data/repositories/yalo_message/sdk_message_mapper.dart
+++ b/flutter-sdk/lib/src/data/repositories/yalo_message/sdk_message_mapper.dart
@@ -11,6 +11,7 @@ import 'package:uuid/uuid.dart';
 import 'package:yalo_chat_flutter_sdk/domain/models/product/product.dart';
 import 'package:yalo_chat_flutter_sdk/src/common/result.dart';
 import 'package:yalo_chat_flutter_sdk/src/data/services/yalo_media/yalo_media_service.dart';
+import 'package:yalo_chat_flutter_sdk/src/domain/models/chat_event/chat_event.dart';
 import 'package:yalo_chat_flutter_sdk/src/domain/models/chat_message/button.dart';
 import 'package:yalo_chat_flutter_sdk/src/domain/models/chat_message/chat_message.dart';
 import 'package:yalo_chat_flutter_sdk/src/domain/models/events/external_channel/in_app/sdk/sdk_message.pb.dart'
@@ -122,6 +123,18 @@ Future<ChatMessage?> pollMessageItemToChatMessage(
     case _:
       return null;
   }
+}
+
+ChatEvent? pollMessageItemToChatEvent(proto.PollMessageItem item) {
+  if (item.message.whichPayload() !=
+      proto.SdkMessage_Payload.chatStatusRequest) {
+    return null;
+  }
+  final String status = item.message.chatStatusRequest.status;
+  if (status.isEmpty) {
+    return TypingStop();
+  }
+  return TypingStart(statusText: status);
 }
 
 proto.SdkMessage? chatMessageToSdkMessage(

--- a/flutter-sdk/lib/src/data/repositories/yalo_message/yalo_message_repository_websocket.dart
+++ b/flutter-sdk/lib/src/data/repositories/yalo_message/yalo_message_repository_websocket.dart
@@ -67,6 +67,14 @@ final class YaloMessageRepositoryWebSocket implements YaloMessageRepository {
   }
 
   Future<void> _onItem(proto.PollMessageItem item) async {
+    final ChatEvent? chatEvent = pollMessageItemToChatEvent(item);
+    if (chatEvent != null) {
+      if (!_typingEventsStreamController.isClosed) {
+        _typingEventsStreamController.sink.add(chatEvent);
+      }
+      return;
+    }
+
     final ChatMessage? message = await pollMessageItemToChatMessage(
       item,
       mediaService: mediaService,
@@ -85,9 +93,6 @@ final class YaloMessageRepositoryWebSocket implements YaloMessageRepository {
 
   @override
   Future<Result<Unit>> sendMessage(ChatMessage chatMessage) async {
-    _typingEventsStreamController.sink.add(
-      TypingStart(statusText: 'Writing message...'),
-    );
     String? mediaId;
     if (chatMessage.type == MessageType.image ||
         chatMessage.type == MessageType.voice ||

--- a/flutter-sdk/lib/src/ui/chat/widgets/message_list/message_list.dart
+++ b/flutter-sdk/lib/src/ui/chat/widgets/message_list/message_list.dart
@@ -1,5 +1,6 @@
 // Copyright (c) Yalochat, Inc. All rights reserved.
 
+import 'package:flutter/rendering.dart';
 import 'package:yalo_chat_flutter_sdk/src/ui/chat/view_models/messages/messages_bloc.dart';
 import 'package:yalo_chat_flutter_sdk/src/domain/models/chat_message/chat_message.dart';
 import 'package:yalo_chat_flutter_sdk/src/ui/chat/view_models/messages/messages_event.dart';
@@ -49,7 +50,9 @@ class _MessageListState extends State<MessageList> {
           child: ListView.builder(
             key: Key('chat_messages'),
             reverse: true,
-            cacheExtent: SdkConstants.chatCacheExtent,
+            scrollCacheExtent: ScrollCacheExtent.pixels(
+              SdkConstants.chatCacheExtent,
+            ),
             itemCount: length + (isLoading ? 1 : 0),
             controller: _scrollController,
             itemBuilder: (context, index) {

--- a/flutter-sdk/test/data/repositories/yalo_message/yalo_message_repository_websocket_test.dart
+++ b/flutter-sdk/test/data/repositories/yalo_message/yalo_message_repository_websocket_test.dart
@@ -96,6 +96,28 @@ void main() {
       status: 'IN_DELIVERY',
     );
 
+    final chatStatusStub = proto.PollMessageItem(
+      id: 'status-1',
+      message: proto.SdkMessage(
+        chatStatusRequest: proto.ChatStatusRequest(
+          status: 'Agent is typing',
+        ),
+      ),
+      date: Timestamp.fromDateTime(DateTime.parse(fixedDate)),
+      userId: 'user-123',
+      status: 'IN_DELIVERY',
+    );
+
+    final emptyChatStatusStub = proto.PollMessageItem(
+      id: 'status-2',
+      message: proto.SdkMessage(
+        chatStatusRequest: proto.ChatStatusRequest(status: ''),
+      ),
+      date: Timestamp.fromDateTime(DateTime.parse(fixedDate)),
+      userId: 'user-123',
+      status: 'IN_DELIVERY',
+    );
+
     final assistantCarouselStub = proto.PollMessageItem(
       id: 'carousel-1',
       message: proto.SdkMessage(
@@ -274,6 +296,41 @@ void main() {
         expect(received.single.products.first.sku, equals('sku-2'));
       });
 
+      test('emits TypingStart with status text on ChatStatusRequest', () async {
+        final eventFuture = repo.events().first;
+        repo.messages().listen((_) {});
+
+        incoming.add(chatStatusStub);
+        final event = await eventFuture;
+
+        expect(event, isA<TypingStart>());
+        expect(
+          (event as TypingStart).statusText,
+          equals('Agent is typing'),
+        );
+      });
+
+      test('emits TypingStop on ChatStatusRequest with empty status', () async {
+        final eventFuture = repo.events().first;
+        repo.messages().listen((_) {});
+
+        incoming.add(emptyChatStatusStub);
+        final event = await eventFuture;
+
+        expect(event, isA<TypingStop>());
+      });
+
+      test('does not emit a ChatMessage for ChatStatusRequest frames',
+          () async {
+        final received = <ChatMessage>[];
+        repo.messages().listen(received.add);
+
+        incoming.add(chatStatusStub);
+        await Future.delayed(Duration.zero);
+
+        expect(received, isEmpty);
+      });
+
       test('emits TypingStop when the websocket stream errors', () async {
         final eventFuture = repo.events().first;
         repo.messages().listen((_) {}, onError: (_) {});
@@ -297,18 +354,6 @@ void main() {
         timestamp: DateTime.utc(2024),
         content: 'Hello',
       );
-
-      test('emits TypingStart on the events stream before sending', () async {
-        when(() => mockWebSocketService.sendSdkMessage(any()))
-            .thenAnswer((_) async => Result.ok(Unit()));
-
-        final eventFuture = repo.events().first;
-        await repo.sendMessage(textMessage);
-
-        final event = await eventFuture;
-        expect(event, isA<TypingStart>());
-        expect((event as TypingStart).statusText, equals('Writing message...'));
-      });
 
       test('delegates text messages to websocketService.sendSdkMessage',
           () async {


### PR DESCRIPTION
- Header commands are now used to display header text.
- Changed LitView.builder to use scrollCacheExtent