### PR TITLE
feat(ios/android): FDE-145 — Localization (ES), font parity, not-delivered label

### DIFF
--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/ChatScreen.kt
@@ -50,7 +50,10 @@ import com.yalo.chat.sdk.ui.chat.MessagesEvent
 import com.yalo.chat.sdk.ui.chat.MessagesViewModel
 import com.yalo.chat.sdk.ui.chat.WaveformRecorder
 import com.yalo.chat.sdk.ui.chat.isRecording
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.ChatThemeProvider
+import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // android.net.Uri is used only at the Activity Result boundary; URIs are Strings inside ViewModels.
 @OptIn(ExperimentalMaterial3Api::class)
@@ -228,8 +231,10 @@ fun ChatScreen(
     // ── Scaffold ──────────────────────────────────────────────────────────────
 
     ChatThemeProvider(YaloChat.theme) {
+        val theme = LocalChatTheme.current
         Box {
             Scaffold(
+                containerColor = theme.backgroundColor,
                 topBar = {
                     appBar?.invoke() ?: ChatAppBar(
                         title = YaloChat.config.channelName,
@@ -323,7 +328,7 @@ fun ChatScreen(
                         imageViewModel.handleEvent(ImageEvent.PickFromGallery)
                     },
                 ) {
-                    Text("Choose from Gallery")
+                    Text(stringResource(R.string.chat_choose_from_gallery))
                 }
                 TextButton(
                     onClick = {
@@ -331,7 +336,7 @@ fun ChatScreen(
                         imageViewModel.handleEvent(ImageEvent.PickFromCamera)
                     },
                 ) {
-                    Text("Take Photo")
+                    Text(stringResource(R.string.chat_take_photo))
                 }
             }
         }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/AudioMessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/AudioMessageItem.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.ChatMessage
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Renders a voice message bubble: play/pause button + waveform preview of the recorded amplitudes.
@@ -36,7 +38,7 @@ internal fun AudioMessageItem(
         ) {
             Icon(
                 imageVector = if (isPlaying) theme.pauseAudioIcon else theme.playAudioIcon,
-                contentDescription = if (isPlaying) "Pause voice message" else "Play voice message",
+                contentDescription = if (isPlaying) stringResource(R.string.chat_pause_voice_content_description) else stringResource(R.string.chat_play_voice_content_description),
                 tint = if (isPlaying) theme.pauseAudioIconColor else theme.playAudioIconColor,
             )
         }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatAppBar.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Chat app bar with:
@@ -82,19 +84,19 @@ internal fun ChatAppBar(
         navigationIcon = {
             if (onBack != null) {
                 IconButton(onClick = onBack) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.chat_back_content_description))
                 }
             }
         },
         actions = {
             if (onShopPressed != null) {
                 IconButton(onClick = onShopPressed) {
-                    Icon(theme.shopIcon, contentDescription = "Shop", tint = theme.actionIconColor)
+                    Icon(theme.shopIcon, contentDescription = stringResource(R.string.chat_shop_content_description), tint = theme.actionIconColor)
                 }
             }
             if (onCartPressed != null) {
                 IconButton(onClick = onCartPressed) {
-                    Icon(theme.cartIcon, contentDescription = "Cart", tint = theme.actionIconColor)
+                    Icon(theme.cartIcon, contentDescription = stringResource(R.string.chat_cart_content_description), tint = theme.actionIconColor)
                 }
             }
         },

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
@@ -21,6 +21,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
 import com.yalo.chat.sdk.R
@@ -73,10 +76,11 @@ internal fun ChatInput(
         if (userMessage.isBlank()) {
             Box(
                 modifier = Modifier
-                    .size(44.dp)
+                    .size(48.dp)
                     .clip(CircleShape)
                     .background(theme.sendButtonColor)
-                    .clickable(onClick = onMicClick),
+                    .clickable(onClick = onMicClick)
+                    .semantics { role = Role.Button },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
@@ -89,10 +93,11 @@ internal fun ChatInput(
         } else {
             Box(
                 modifier = Modifier
-                    .size(44.dp)
+                    .size(48.dp)
                     .clip(CircleShape)
                     .background(theme.sendButtonColor)
-                    .clickable(onClick = onSendMessage),
+                    .clickable(onClick = onSendMessage)
+                    .semantics { role = Role.Button },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
@@ -80,7 +80,7 @@ internal fun ChatInput(
                     .clip(CircleShape)
                     .background(theme.sendButtonColor)
                     .clickable(onClick = onMicClick)
-                    .semantics { role = Role.Button },
+                    .semantics(mergeDescendants = true) { role = Role.Button },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(
@@ -97,7 +97,7 @@ internal fun ChatInput(
                     .clip(CircleShape)
                     .background(theme.sendButtonColor)
                     .clickable(onClick = onSendMessage)
-                    .semantics { role = Role.Button },
+                    .semantics(mergeDescendants = true) { role = Role.Button },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ChatInput.kt
@@ -3,9 +3,14 @@
 package com.yalo.chat.sdk.ui.chat
 
 import com.yalo.chat.sdk.ui.theme.SdkConstants
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,7 +20,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // When the text field is blank a mic icon replaces the Send button — tapping it starts
@@ -40,7 +48,7 @@ internal fun ChatInput(
             IconButton(onClick = onAttachmentClick) {
                 Icon(
                     imageVector = theme.attachIcon,
-                    contentDescription = "Attach image",
+                    contentDescription = stringResource(R.string.chat_attach_content_description),
                     tint = theme.attachIconColor,
                 )
             }
@@ -49,7 +57,7 @@ internal fun ChatInput(
             value = userMessage,
             onValueChange = onUserMessageChange,
             modifier = Modifier.weight(1f),
-            placeholder = { Text("Type a message…", style = theme.hintTextStyle) },
+            placeholder = { Text(stringResource(R.string.chat_input_placeholder), style = theme.hintTextStyle) },
             singleLine = true,
             shape = RoundedCornerShape(SdkConstants.inputBorderRadius.dp),
             colors = OutlinedTextFieldDefaults.colors(
@@ -63,19 +71,35 @@ internal fun ChatInput(
             ),
         )
         if (userMessage.isBlank()) {
-            IconButton(onClick = onMicClick) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(theme.sendButtonColor)
+                    .clickable(onClick = onMicClick),
+                contentAlignment = Alignment.Center,
+            ) {
                 Icon(
                     imageVector = theme.recordAudioIcon,
-                    contentDescription = "Record voice message",
-                    tint = theme.actionIconColor,
+                    contentDescription = stringResource(R.string.chat_record_content_description),
+                    tint = theme.sendButtonForegroundColor,
+                    modifier = Modifier.size(20.dp),
                 )
             }
         } else {
-            IconButton(onClick = onSendMessage) {
+            Box(
+                modifier = Modifier
+                    .size(44.dp)
+                    .clip(CircleShape)
+                    .background(theme.sendButtonColor)
+                    .clickable(onClick = onSendMessage),
+                contentAlignment = Alignment.Center,
+            ) {
                 Icon(
                     imageVector = theme.sendButtonIcon,
-                    contentDescription = "Send",
-                    tint = theme.sendButtonColor,
+                    contentDescription = stringResource(R.string.chat_send_content_description),
+                    tint = theme.sendButtonForegroundColor,
+                    modifier = Modifier.size(20.dp),
                 )
             }
         }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ImagePreview.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ImagePreview.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Full-screen overlay that shows the picked image with Cancel (X) and Send buttons.
@@ -38,7 +40,7 @@ internal fun ImagePreview(
     ) {
         AsyncImage(
             model = imagePath,
-            contentDescription = "Image preview",
+            contentDescription = stringResource(R.string.chat_image_preview_content_description),
             contentScale = ContentScale.Fit,
             modifier = Modifier
                 .fillMaxSize()
@@ -54,7 +56,7 @@ internal fun ImagePreview(
         ) {
             Icon(
                 imageVector = theme.closeModalIcon,
-                contentDescription = "Cancel",
+                contentDescription = stringResource(R.string.chat_cancel_content_description),
                 tint = theme.closeModalIconColor,
             )
         }
@@ -70,13 +72,13 @@ internal fun ImagePreview(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = "Send image?",
+                text = stringResource(R.string.chat_send_image_label),
                 style = MaterialTheme.typography.bodyMedium.merge(theme.modalHeaderStyle),
             )
             IconButton(onClick = onSend) {
                 Icon(
                     imageVector = theme.sendButtonIcon,
-                    contentDescription = "Send image",
+                    contentDescription = stringResource(R.string.chat_send_image_content_description),
                     tint = theme.sendButtonColor,
                 )
             }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ImagePreview.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ImagePreview.kt
@@ -79,7 +79,7 @@ internal fun ImagePreview(
                 Icon(
                     imageVector = theme.sendButtonIcon,
                     contentDescription = stringResource(R.string.chat_send_image_content_description),
-                    tint = theme.sendButtonColor,
+                    tint = theme.sendButtonForegroundColor,
                 )
             }
         }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -110,13 +110,14 @@ internal fun MessageItem(
         verticalAlignment = Alignment.Bottom,
     ) {
         if (isUser && message.status == MessageStatus.ERROR) {
+            val notDeliveredLabel = stringResource(R.string.chat_not_delivered)
             val retryLabel = stringResource(R.string.chat_retry)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 modifier = Modifier
                     .clickable { message.id?.let { onEvent(MessagesEvent.RetryMessage(it)) } }
                     .padding(end = 4.dp)
-                    .semantics { role = Role.Button; contentDescription = retryLabel },
+                    .semantics { role = Role.Button; contentDescription = "$notDeliveredLabel $retryLabel" },
             ) {
                 androidx.compose.material3.Icon(
                     imageVector = theme.errorIcon,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -48,6 +48,10 @@ import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 import kotlinx.coroutines.Dispatchers
@@ -106,21 +110,20 @@ internal fun MessageItem(
         verticalAlignment = Alignment.Bottom,
     ) {
         if (isUser && message.status == MessageStatus.ERROR) {
+            val retryLabel = stringResource(R.string.chat_retry)
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
-                modifier = Modifier.padding(end = 4.dp),
+                modifier = Modifier
+                    .clickable { message.id?.let { onEvent(MessagesEvent.RetryMessage(it)) } }
+                    .padding(end = 4.dp)
+                    .semantics { role = Role.Button; contentDescription = retryLabel },
             ) {
-                androidx.compose.material3.IconButton(
-                    onClick = { message.id?.let { onEvent(MessagesEvent.RetryMessage(it)) } },
-                    modifier = Modifier.size(36.dp),
-                ) {
-                    androidx.compose.material3.Icon(
-                        imageVector = theme.errorIcon,
-                        contentDescription = stringResource(R.string.chat_send_failed_content_description),
-                        tint = theme.errorColor,
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
+                androidx.compose.material3.Icon(
+                    imageVector = theme.errorIcon,
+                    contentDescription = null,
+                    tint = theme.errorColor,
+                    modifier = Modifier.size(20.dp),
+                )
                 Text(
                     text = stringResource(R.string.chat_not_delivered),
                     style = MaterialTheme.typography.labelSmall,

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageItem.kt
@@ -47,6 +47,8 @@ import com.yalo.chat.sdk.domain.model.ChatMessage
 import com.yalo.chat.sdk.domain.model.MessageRole
 import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -104,15 +106,25 @@ internal fun MessageItem(
         verticalAlignment = Alignment.Bottom,
     ) {
         if (isUser && message.status == MessageStatus.ERROR) {
-            androidx.compose.material3.IconButton(
-                onClick = { message.id?.let { onEvent(MessagesEvent.RetryMessage(it)) } },
-                modifier = Modifier.size(48.dp),
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(end = 4.dp),
             ) {
-                androidx.compose.material3.Icon(
-                    imageVector = theme.errorIcon,
-                    contentDescription = "Send failed",
-                    tint = theme.errorColor,
-                    modifier = Modifier.size(16.dp),
+                androidx.compose.material3.IconButton(
+                    onClick = { message.id?.let { onEvent(MessagesEvent.RetryMessage(it)) } },
+                    modifier = Modifier.size(36.dp),
+                ) {
+                    androidx.compose.material3.Icon(
+                        imageVector = theme.errorIcon,
+                        contentDescription = stringResource(R.string.chat_send_failed_content_description),
+                        tint = theme.errorColor,
+                        modifier = Modifier.size(16.dp),
+                    )
+                }
+                Text(
+                    text = stringResource(R.string.chat_not_delivered),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = theme.errorColor,
                 )
             }
         }
@@ -194,12 +206,19 @@ internal fun MessageItem(
                             // sendImageMessage). content holds the URL for agent/server images.
                             // Fall back to content so both cases render correctly.
                             model = message.fileName ?: message.content,
-                            contentDescription = "Image message",
+                            contentDescription = stringResource(R.string.chat_image_message_content_description),
                             contentScale = ContentScale.Crop,
                             modifier = Modifier.size(200.dp),
                             placeholder = ColorPainter(theme.imagePlaceholderBackgroundColor),
                             error = ColorPainter(theme.imagePlaceholderBackgroundColor),
                         )
+                        if (message.content.isNotEmpty() && message.fileName != null) {
+                            Text(
+                                text = message.content,
+                                style = messageTextStyle,
+                                modifier = Modifier.padding(top = 4.dp),
+                            )
+                        }
                         message.buttons.filter { it.type != ChatButtonType.REPLY }.forEach { button ->
                             MessageButton(button = button, onEvent = onEvent)
                         }
@@ -234,7 +253,7 @@ internal fun MessageItem(
                     )
                     MessageType.CTA -> CtaMessage(message = message, onEvent = onEvent)
                     MessageType.Unknown -> Text(
-                        text = "Unsupported message",
+                        text = stringResource(R.string.chat_unsupported_message),
                         style = messageTextStyle,
                     )
                     else -> Text(
@@ -300,7 +319,7 @@ private fun VideoMessageItem(
                 if (thumbnail != null) {
                     Image(
                         bitmap = thumbnail!!,
-                        contentDescription = "Video thumbnail",
+                        contentDescription = stringResource(R.string.chat_video_thumbnail_content_description),
                         contentScale = ContentScale.Crop,
                         modifier = Modifier.matchParentSize(),
                     )
@@ -313,7 +332,7 @@ private fun VideoMessageItem(
                 }
                 androidx.compose.material3.Icon(
                     imageVector = Icons.Filled.PlayCircle,
-                    contentDescription = "Play video",
+                    contentDescription = stringResource(R.string.chat_play_video_content_description),
                     modifier = Modifier.size(48.dp),
                     tint = Color.White.copy(alpha = 0.85f),
                 )

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/MessageList.kt
@@ -14,7 +14,9 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.domain.model.ChatMessage
 
 // reverseLayout puts the newest message at the bottom, matching chat convention.
@@ -34,7 +36,7 @@ internal fun MessageList(
             modifier = modifier.fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            Text(text = "No messages yet")
+            Text(text = stringResource(R.string.chat_no_messages_yet))
         }
         return
     }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCard.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCard.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.yalo.chat.sdk.domain.model.Product
 import com.yalo.chat.sdk.domain.util.formatIcuUnit
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // ── Shared price row ──────────────────────────────────────────────────────────
@@ -94,7 +96,7 @@ private fun ProductImage(
         }
         AsyncImage(
             model = imagesUrl.firstOrNull(),
-            contentDescription = "Product image",
+            contentDescription = stringResource(R.string.chat_product_image_content_description),
             contentScale = ContentScale.Crop,
             modifier = Modifier.matchParentSize(),
         )

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCarouselMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductCarouselMessage.kt
@@ -28,6 +28,8 @@ import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.model.Product
 import com.yalo.chat.sdk.ui.theme.ChatTheme
 import com.yalo.chat.sdk.ui.theme.ChatThemeProvider
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 private const val COLLAPSED_MAX_ITEMS = 3
@@ -114,7 +116,7 @@ internal fun ProductCarouselMessage(
                         onClick = { onEvent(MessagesEvent.ChatToggleMessageExpand(messageId)) },
                     ) {
                         Text(
-                            text = if (expand) "Show less" else "Show more",
+                            text = if (expand) stringResource(R.string.chat_show_less) else stringResource(R.string.chat_show_more),
                             style = theme.expandControlsStyle,
                         )
                     }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductListMessage.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductListMessage.kt
@@ -27,6 +27,8 @@ import com.yalo.chat.sdk.domain.model.MessageType
 import com.yalo.chat.sdk.domain.model.Product
 import com.yalo.chat.sdk.ui.theme.ChatTheme
 import com.yalo.chat.sdk.ui.theme.ChatThemeProvider
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 private const val COLLAPSED_MAX_ITEMS = 3
@@ -108,7 +110,7 @@ internal fun ProductListMessage(
                 modifier = Modifier.fillMaxWidth(),
             ) {
                 Text(
-                    text = if (expand) "Show less" else "Show more",
+                    text = if (expand) stringResource(R.string.chat_show_less) else stringResource(R.string.chat_show_more),
                     style = theme.expandControlsStyle,
                 )
             }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductQuantityStepper.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/ProductQuantityStepper.kt
@@ -13,6 +13,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 @Composable
@@ -31,7 +33,7 @@ internal fun ProductQuantityStepper(
         IconButton(onClick = onRemove, enabled = value > 0.0) {
             Icon(
                 imageVector = theme.removeIcon,
-                contentDescription = "Remove",
+                contentDescription = stringResource(R.string.chat_remove_content_description),
                 tint = if (value > 0.0) theme.numericControlIconColor else theme.numericControlIconColor.copy(alpha = 0.38f),
             )
         }
@@ -42,7 +44,7 @@ internal fun ProductQuantityStepper(
         IconButton(onClick = onAdd) {
             Icon(
                 imageVector = theme.addIcon,
-                contentDescription = "Add",
+                contentDescription = stringResource(R.string.chat_add_content_description),
                 tint = theme.numericControlIconColor,
             )
         }

--- a/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/WaveformRecorder.kt
+++ b/android-sdk/sdk/src/androidMain/kotlin/com/yalo/chat/sdk/ui/chat/WaveformRecorder.kt
@@ -17,6 +17,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.yalo.chat.sdk.domain.model.AudioData
+import androidx.compose.ui.res.stringResource
+import com.yalo.chat.sdk.R
 import com.yalo.chat.sdk.ui.theme.LocalChatTheme
 
 // Replaces ChatInput while the user is recording a voice message.
@@ -40,7 +42,7 @@ internal fun WaveformRecorder(
         IconButton(onClick = onCancel) {
             Icon(
                 imageVector = theme.cancelRecordingIcon,
-                contentDescription = "Cancel recording",
+                contentDescription = stringResource(R.string.chat_cancel_recording_content_description),
                 tint = theme.cancelRecordingIconColor,
             )
         }
@@ -63,7 +65,7 @@ internal fun WaveformRecorder(
         IconButton(onClick = onSend) {
             Icon(
                 imageVector = theme.sendButtonIcon,
-                contentDescription = "Send voice message",
+                contentDescription = stringResource(R.string.chat_send_voice_content_description),
                 tint = theme.sendButtonColor,
             )
         }

--- a/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
+++ b/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="chat_input_placeholder">Escribe un mensaje…</string>
+    <string name="chat_input_placeholder">Escribe un mensaje</string>
     <string name="chat_attach_content_description">Adjuntar imagen</string>
     <string name="chat_record_content_description">Grabar mensaje de voz</string>
     <string name="chat_send_content_description">Enviar</string>
     <string name="chat_back_content_description">Atrás</string>
     <string name="chat_shop_content_description">Tienda</string>
     <string name="chat_cart_content_description">Carrito</string>
-    <string name="chat_send_failed_content_description">No se pudo enviar</string>
+    <string name="chat_retry">Reintentar</string>
     <string name="chat_image_message_content_description">Mensaje de imagen</string>
     <string name="chat_video_thumbnail_content_description">Miniatura de video</string>
     <string name="chat_play_video_content_description">Reproducir video</string>
-    <string name="chat_unsupported_message">Mensaje no soportado</string>
+    <string name="chat_unsupported_message">Tipo de mensaje no soportado</string>
     <string name="chat_no_messages_yet">Sin mensajes aún</string>
     <string name="chat_image_preview_content_description">Vista previa de imagen</string>
     <string name="chat_cancel_content_description">Cancelar</string>
@@ -23,10 +23,10 @@
     <string name="chat_play_voice_content_description">Reproducir mensaje de voz</string>
     <string name="chat_choose_from_gallery">Subir desde galería</string>
     <string name="chat_take_photo">Tomar foto</string>
-    <string name="chat_remove_content_description">Eliminar</string>
-    <string name="chat_add_content_description">Agregar</string>
-    <string name="chat_product_image_content_description">Imagen del producto</string>
     <string name="chat_show_more">Ver más</string>
     <string name="chat_show_less">Ver menos</string>
     <string name="chat_not_delivered">No entregado.</string>
+    <string name="chat_remove_content_description">Eliminar</string>
+    <string name="chat_add_content_description">Agregar</string>
+    <string name="chat_product_image_content_description">Imagen del producto</string>
 </resources>

--- a/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
+++ b/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="chat_input_placeholder">Escribe un mensaje…</string>
+    <string name="chat_send_content_description">Enviar</string>
+    <string name="chat_send_image_content_description">Enviar imagen</string>
+    <string name="chat_send_image_label">¿Enviar imagen?</string>
+    <string name="chat_send_voice_content_description">Enviar mensaje de voz</string>
+    <string name="chat_choose_from_gallery">Subir desde galería</string>
+    <string name="chat_take_photo">Tomar foto</string>
+    <string name="chat_show_more">Ver más</string>
+    <string name="chat_show_less">Ver menos</string>
+    <string name="chat_not_delivered">No entregado.</string>
+    <string name="chat_unsupported_message">Mensaje no soportado</string>
+    <string name="chat_no_messages_yet">Sin mensajes aún</string>
+    <string name="chat_cancel_content_description">Cancelar</string>
+</resources>

--- a/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
+++ b/android-sdk/sdk/src/androidMain/res/values-es/strings.xml
@@ -1,16 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="chat_input_placeholder">Escribe un mensaje…</string>
+    <string name="chat_attach_content_description">Adjuntar imagen</string>
+    <string name="chat_record_content_description">Grabar mensaje de voz</string>
     <string name="chat_send_content_description">Enviar</string>
+    <string name="chat_back_content_description">Atrás</string>
+    <string name="chat_shop_content_description">Tienda</string>
+    <string name="chat_cart_content_description">Carrito</string>
+    <string name="chat_send_failed_content_description">No se pudo enviar</string>
+    <string name="chat_image_message_content_description">Mensaje de imagen</string>
+    <string name="chat_video_thumbnail_content_description">Miniatura de video</string>
+    <string name="chat_play_video_content_description">Reproducir video</string>
+    <string name="chat_unsupported_message">Mensaje no soportado</string>
+    <string name="chat_no_messages_yet">Sin mensajes aún</string>
+    <string name="chat_image_preview_content_description">Vista previa de imagen</string>
+    <string name="chat_cancel_content_description">Cancelar</string>
     <string name="chat_send_image_content_description">Enviar imagen</string>
     <string name="chat_send_image_label">¿Enviar imagen?</string>
+    <string name="chat_cancel_recording_content_description">Cancelar grabación</string>
     <string name="chat_send_voice_content_description">Enviar mensaje de voz</string>
+    <string name="chat_pause_voice_content_description">Pausar mensaje de voz</string>
+    <string name="chat_play_voice_content_description">Reproducir mensaje de voz</string>
     <string name="chat_choose_from_gallery">Subir desde galería</string>
     <string name="chat_take_photo">Tomar foto</string>
+    <string name="chat_remove_content_description">Eliminar</string>
+    <string name="chat_add_content_description">Agregar</string>
+    <string name="chat_product_image_content_description">Imagen del producto</string>
     <string name="chat_show_more">Ver más</string>
     <string name="chat_show_less">Ver menos</string>
     <string name="chat_not_delivered">No entregado.</string>
-    <string name="chat_unsupported_message">Mensaje no soportado</string>
-    <string name="chat_no_messages_yet">Sin mensajes aún</string>
-    <string name="chat_cancel_content_description">Cancelar</string>
 </resources>

--- a/android-sdk/sdk/src/androidMain/res/values/strings.xml
+++ b/android-sdk/sdk/src/androidMain/res/values/strings.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="chat_input_placeholder">Type a message…</string>
+    <string name="chat_input_placeholder">Type a message</string>
     <string name="chat_attach_content_description">Attach image</string>
     <string name="chat_record_content_description">Record voice message</string>
     <string name="chat_send_content_description">Send</string>
     <string name="chat_back_content_description">Back</string>
     <string name="chat_shop_content_description">Shop</string>
     <string name="chat_cart_content_description">Cart</string>
-    <string name="chat_send_failed_content_description">Send failed</string>
+    <string name="chat_retry">Retry</string>
     <string name="chat_image_message_content_description">Image message</string>
     <string name="chat_video_thumbnail_content_description">Video thumbnail</string>
     <string name="chat_play_video_content_description">Play video</string>
-    <string name="chat_unsupported_message">Unsupported message</string>
+    <string name="chat_unsupported_message">Unsupported message type</string>
     <string name="chat_no_messages_yet">No messages yet</string>
     <string name="chat_image_preview_content_description">Image preview</string>
     <string name="chat_cancel_content_description">Cancel</string>
@@ -21,8 +21,8 @@
     <string name="chat_send_voice_content_description">Send voice message</string>
     <string name="chat_pause_voice_content_description">Pause voice message</string>
     <string name="chat_play_voice_content_description">Play voice message</string>
-    <string name="chat_choose_from_gallery">Choose from Gallery</string>
-    <string name="chat_take_photo">Take Photo</string>
+    <string name="chat_choose_from_gallery">Choose from gallery</string>
+    <string name="chat_take_photo">Take a photo</string>
     <string name="chat_remove_content_description">Remove</string>
     <string name="chat_add_content_description">Add</string>
     <string name="chat_product_image_content_description">Product image</string>

--- a/android-sdk/sdk/src/androidMain/res/values/strings.xml
+++ b/android-sdk/sdk/src/androidMain/res/values/strings.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="chat_input_placeholder">Type a message…</string>
+    <string name="chat_attach_content_description">Attach image</string>
+    <string name="chat_record_content_description">Record voice message</string>
+    <string name="chat_send_content_description">Send</string>
+    <string name="chat_back_content_description">Back</string>
+    <string name="chat_shop_content_description">Shop</string>
+    <string name="chat_cart_content_description">Cart</string>
+    <string name="chat_send_failed_content_description">Send failed</string>
+    <string name="chat_image_message_content_description">Image message</string>
+    <string name="chat_video_thumbnail_content_description">Video thumbnail</string>
+    <string name="chat_play_video_content_description">Play video</string>
+    <string name="chat_unsupported_message">Unsupported message</string>
+    <string name="chat_no_messages_yet">No messages yet</string>
+    <string name="chat_image_preview_content_description">Image preview</string>
+    <string name="chat_cancel_content_description">Cancel</string>
+    <string name="chat_send_image_content_description">Send image</string>
+    <string name="chat_send_image_label">Send image?</string>
+    <string name="chat_cancel_recording_content_description">Cancel recording</string>
+    <string name="chat_send_voice_content_description">Send voice message</string>
+    <string name="chat_pause_voice_content_description">Pause voice message</string>
+    <string name="chat_play_voice_content_description">Play voice message</string>
+    <string name="chat_choose_from_gallery">Choose from Gallery</string>
+    <string name="chat_take_photo">Take Photo</string>
+    <string name="chat_remove_content_description">Remove</string>
+    <string name="chat_add_content_description">Add</string>
+    <string name="chat_product_image_content_description">Product image</string>
+    <string name="chat_show_more">Show more</string>
+    <string name="chat_show_less">Show less</string>
+    <string name="chat_not_delivered">Not delivered.</string>
+</resources>

--- a/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryWebSocketTest.kt
+++ b/android-sdk/sdk/src/androidUnitTest/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryWebSocketTest.kt
@@ -11,6 +11,9 @@ import com.yalo.chat.sdk.data.remote.model.SdkTextMessageResponseDto
 import com.yalo.chat.sdk.data.remote.model.YaloFetchMessagesResponse
 import com.yalo.chat.sdk.domain.model.ChatCommand
 import com.yalo.chat.sdk.domain.model.ChatEvent
+import com.yalo.chat.sdk.domain.model.ChatMessage
+import com.yalo.chat.sdk.domain.model.MessageRole
+import com.yalo.chat.sdk.domain.model.MessageStatus
 import com.yalo.chat.sdk.domain.model.MessageType
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -62,9 +65,14 @@ class YaloMessageRepositoryWebSocketTest {
         tempDir.deleteRecursively()
     }
 
+    private val uploadSuccessJson =
+        """{"id":"media-123","signed_url":"https://s3.example.com/media-123","original_name":"file","type":"image/jpeg","created_at":"2024-01-01T00:00:00Z","expires_at":"2024-12-31T00:00:00Z"}"""
+
     private fun buildComponents(
         fetchResponse: String = "[]",
         sendResponse: String = "{}",
+        uploadResponse: String = uploadSuccessJson,
+        uploadStatus: HttpStatusCode = HttpStatusCode.Created,
     ): Triple<YaloMessageServiceWebSocket, YaloChatApiService, YaloMessageRepositoryWebSocket> {
         val engine = MockEngine { request ->
             when {
@@ -72,6 +80,8 @@ class YaloMessageRepositoryWebSocketTest {
                     respond(authResponse, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
                 request.url.encodedPath.contains("/messages") && request.method.value == "GET" ->
                     respond(fetchResponse, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
+                request.url.encodedPath.contains("/all/media") ->
+                    respond(uploadResponse, uploadStatus, headersOf(HttpHeaders.ContentType, "application/json"))
                 else ->
                     respond(sendResponse, HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json"))
             }
@@ -256,16 +266,110 @@ class YaloMessageRepositoryWebSocketTest {
     }
 
     @Test
-    fun `sendMessage returns Error for non-text message types`() = runTest {
+    fun `sendMessage image missing fileName returns Error`() = runTest {
         val (_, _, repo) = buildComponents()
         val result = repo.sendMessage(
-            com.yalo.chat.sdk.domain.model.ChatMessage(
+            ChatMessage(
                 id = 1L,
-                role = com.yalo.chat.sdk.domain.model.MessageRole.USER,
+                role = MessageRole.USER,
                 type = MessageType.Image,
-                status = com.yalo.chat.sdk.domain.model.MessageStatus.SENT,
+                status = MessageStatus.SENT,
                 content = "",
                 timestamp = 0L,
+            )
+        )
+        assertIs<Result.Error<Unit>>(result)
+    }
+
+    @Test
+    fun `sendMessage image with valid file returns Ok`() = runTest {
+        val imageFile = File(tempDir, "photo.jpg").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val (_, _, repo) = buildComponents()
+        val result = repo.sendMessage(
+            ChatMessage(
+                id = 1L,
+                role = MessageRole.USER,
+                type = MessageType.Image,
+                status = MessageStatus.SENT,
+                content = "",
+                timestamp = 0L,
+                fileName = imageFile.absolutePath,
+            )
+        )
+        assertIs<Result.Ok<Unit>>(result)
+    }
+
+    @Test
+    fun `sendMessage image upload failure returns Error`() = runTest {
+        val imageFile = File(tempDir, "photo.jpg").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val (_, _, repo) = buildComponents(
+            uploadResponse = """{"error":"upload failed"}""",
+            uploadStatus = HttpStatusCode.InternalServerError,
+        )
+        val result = repo.sendMessage(
+            ChatMessage(
+                id = 1L,
+                role = MessageRole.USER,
+                type = MessageType.Image,
+                status = MessageStatus.SENT,
+                content = "",
+                timestamp = 0L,
+                fileName = imageFile.absolutePath,
+            )
+        )
+        assertIs<Result.Error<Unit>>(result)
+    }
+
+    @Test
+    fun `sendMessage voice missing fileName returns Error`() = runTest {
+        val (_, _, repo) = buildComponents()
+        val result = repo.sendMessage(
+            ChatMessage(
+                id = 1L,
+                role = MessageRole.USER,
+                type = MessageType.Voice,
+                status = MessageStatus.SENT,
+                content = "",
+                timestamp = 0L,
+            )
+        )
+        assertIs<Result.Error<Unit>>(result)
+    }
+
+    @Test
+    fun `sendMessage voice with valid file returns Ok`() = runTest {
+        val voiceFile = File(tempDir, "note.m4a").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val (_, _, repo) = buildComponents()
+        val result = repo.sendMessage(
+            ChatMessage(
+                id = 1L,
+                role = MessageRole.USER,
+                type = MessageType.Voice,
+                status = MessageStatus.SENT,
+                content = "",
+                timestamp = 0L,
+                fileName = voiceFile.absolutePath,
+            )
+        )
+        assertIs<Result.Ok<Unit>>(result)
+    }
+
+    @Test
+    fun `sendMessage voice upload failure returns Error`() = runTest {
+        val voiceFile = File(tempDir, "note.m4a").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+        val (_, _, repo) = buildComponents(
+            uploadResponse = """{"error":"upload failed"}""",
+            uploadStatus = HttpStatusCode.InternalServerError,
+        )
+        val result = repo.sendMessage(
+            ChatMessage(
+                id = 1L,
+                role = MessageRole.USER,
+                type = MessageType.Voice,
+                status = MessageStatus.SENT,
+                content = "",
+                timestamp = 0L,
+                fileName = voiceFile.absolutePath,
             )
         )
         assertIs<Result.Error<Unit>>(result)

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloMessageServiceWebSocket.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloMessageServiceWebSocket.kt
@@ -23,7 +23,9 @@ import kotlinx.serialization.json.Json
 
 // Manages a single WebSocket connection with exponential back-off reconnection.
 // Decoded frames are emitted on [frames]; consumers call connect(scope) to start
-// the loop and disconnect() to stop it.
+// the loop and disconnect() to stop it. Thread-safety: connect/disconnect are
+// expected to be called from the same coroutine scope; the connection loop itself
+// runs on the provided scope's dispatcher.
 internal class YaloMessageServiceWebSocket(
     // Full WebSocket URL without the auth token, e.g. "wss://api.yalochat.com/websocket/v1/connect/inapp"
     private val wsUrl: String,
@@ -34,6 +36,8 @@ internal class YaloMessageServiceWebSocket(
     companion object {
         private const val INITIAL_BACKOFF_MS  = 1_000L
         private const val MAX_BACKOFF_MS      = 30_000L
+        // Caps the left-shift exponent in scheduleReconnect to prevent integer overflow.
+        // Produces delays: 1s, 2s, 4s, 8s, 16s, then 30s (clamped) for all subsequent attempts.
         private const val MAX_BACKOFF_EXPONENT = 5
     }
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloMessageServiceWebSocket.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/remote/YaloMessageServiceWebSocket.kt
@@ -23,9 +23,7 @@ import kotlinx.serialization.json.Json
 
 // Manages a single WebSocket connection with exponential back-off reconnection.
 // Decoded frames are emitted on [frames]; consumers call connect(scope) to start
-// the loop and disconnect() to stop it. Thread-safety: connect/disconnect are
-// expected to be called from the same coroutine scope; the connection loop itself
-// runs on the provided scope's dispatcher.
+// the loop and disconnect() to stop it.
 internal class YaloMessageServiceWebSocket(
     // Full WebSocket URL without the auth token, e.g. "wss://api.yalochat.com/websocket/v1/connect/inapp"
     private val wsUrl: String,
@@ -36,8 +34,6 @@ internal class YaloMessageServiceWebSocket(
     companion object {
         private const val INITIAL_BACKOFF_MS  = 1_000L
         private const val MAX_BACKOFF_MS      = 30_000L
-        // Caps the left-shift exponent in scheduleReconnect to prevent integer overflow.
-        // Produces delays: 1s, 2s, 4s, 8s, 16s, then 30s (clamped) for all subsequent attempts.
         private const val MAX_BACKOFF_EXPONENT = 5
     }
 

--- a/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryWebSocket.kt
+++ b/android-sdk/sdk/src/commonMain/kotlin/com/yalo/chat/sdk/data/repository/remote/YaloMessageRepositoryWebSocket.kt
@@ -5,9 +5,13 @@ package com.yalo.chat.sdk.data.repository.remote
 import com.yalo.chat.sdk.common.Result
 import com.yalo.chat.sdk.data.remote.YaloChatApiService
 import com.yalo.chat.sdk.data.remote.YaloMessageServiceWebSocket
+import com.yalo.chat.sdk.data.remote.model.SdkImageMessageBody
+import com.yalo.chat.sdk.data.remote.model.SdkImageMessageRequestBody
 import com.yalo.chat.sdk.data.remote.model.SdkMessageBody
 import com.yalo.chat.sdk.data.remote.model.SdkTextMessageBody
 import com.yalo.chat.sdk.data.remote.model.SdkTextMessageRequestBody
+import com.yalo.chat.sdk.data.remote.model.SdkVoiceMessageBody
+import com.yalo.chat.sdk.data.remote.model.SdkVoiceNoteMessageRequestBody
 import com.yalo.chat.sdk.domain.model.ChatCommand
 import com.yalo.chat.sdk.domain.model.ChatCommandCallback
 import com.yalo.chat.sdk.domain.model.ChatEvent
@@ -77,22 +81,106 @@ internal class YaloMessageRepositoryWebSocket(
         }
 
     override suspend fun sendMessage(message: ChatMessage): Result<Unit> {
-        if (message.type != MessageType.Text) {
-            return Result.Error(UnsupportedOperationException("WebSocket transport only supports text sends; got ${message.type}"))
-        }
         val nowIso = Clock.System.now().toString()
-        _events.tryEmit(ChatEvent.TypingStart(TYPING_STATUS_TEXT))
-        val body = SdkMessageBody(
-            correlationId = Uuid.random().toString(),
-            timestamp = nowIso,
-            textMessageRequest = SdkTextMessageRequestBody(
-                content = SdkTextMessageBody(text = message.content, timestamp = nowIso),
-                timestamp = nowIso,
-            ),
-        )
-        val result = apiService.sendMessage(body)
-        if (result is Result.Error) _events.tryEmit(ChatEvent.TypingStop)
-        return result
+        return when (message.type) {
+            MessageType.Text -> {
+                _events.tryEmit(ChatEvent.TypingStart(TYPING_STATUS_TEXT))
+                val body = SdkMessageBody(
+                    correlationId = Uuid.random().toString(),
+                    timestamp = nowIso,
+                    textMessageRequest = SdkTextMessageRequestBody(
+                        content = SdkTextMessageBody(text = message.content, timestamp = nowIso),
+                        timestamp = nowIso,
+                    ),
+                )
+                val result = apiService.sendMessage(body)
+                if (result is Result.Error) _events.tryEmit(ChatEvent.TypingStop)
+                result
+            }
+
+            MessageType.Image -> {
+                val filePath = message.fileName
+                    ?: return Result.Error(IllegalArgumentException("image message missing fileName"))
+                val mimeType = message.mediaType ?: "image/jpeg"
+                _events.tryEmit(ChatEvent.TypingStart(TYPING_STATUS_TEXT))
+                val bytes = try {
+                    PlatformFiles.readBytes(filePath)
+                } catch (e: Exception) {
+                    _events.tryEmit(ChatEvent.TypingStop)
+                    return Result.Error(e)
+                }
+                val filename = filePath.substringAfterLast('/')
+                when (val uploadResult = apiService.uploadMedia(bytes, filename, mimeType)) {
+                    is Result.Error -> {
+                        _events.tryEmit(ChatEvent.TypingStop)
+                        Result.Error(uploadResult.error)
+                    }
+                    is Result.Ok -> {
+                        val body = SdkMessageBody(
+                            correlationId = Uuid.random().toString(),
+                            timestamp = nowIso,
+                            imageMessageRequest = SdkImageMessageRequestBody(
+                                content = SdkImageMessageBody(
+                                    timestamp = nowIso,
+                                    text = message.content.takeIf { it.isNotEmpty() },
+                                    mediaUrl = uploadResult.result.id,
+                                    mediaType = mimeType,
+                                    byteCount = bytes.size.toLong(),
+                                    fileName = filename,
+                                ),
+                                timestamp = nowIso,
+                            ),
+                        )
+                        val result = apiService.sendMessage(body)
+                        if (result is Result.Error) _events.tryEmit(ChatEvent.TypingStop)
+                        result
+                    }
+                }
+            }
+
+            MessageType.Voice -> {
+                val filePath = message.fileName
+                    ?: return Result.Error(IllegalArgumentException("voice message missing fileName"))
+                val mimeType = message.mediaType ?: "audio/mp4"
+                _events.tryEmit(ChatEvent.TypingStart(TYPING_STATUS_TEXT))
+                val bytes = try {
+                    PlatformFiles.readBytes(filePath)
+                } catch (e: Exception) {
+                    _events.tryEmit(ChatEvent.TypingStop)
+                    return Result.Error(e)
+                }
+                val filename = filePath.substringAfterLast('/')
+                when (val uploadResult = apiService.uploadMedia(bytes, filename, mimeType)) {
+                    is Result.Error -> {
+                        _events.tryEmit(ChatEvent.TypingStop)
+                        Result.Error(uploadResult.error)
+                    }
+                    is Result.Ok -> {
+                        val body = SdkMessageBody(
+                            correlationId = Uuid.random().toString(),
+                            timestamp = nowIso,
+                            voiceNoteMessageRequest = SdkVoiceNoteMessageRequestBody(
+                                content = SdkVoiceMessageBody(
+                                    timestamp = nowIso,
+                                    mediaUrl = uploadResult.result.id,
+                                    mediaType = mimeType,
+                                    byteCount = bytes.size.toLong(),
+                                    fileName = filename,
+                                    amplitudesPreview = message.amplitudes.map { it.toFloat() },
+                                    duration = message.duration?.toDouble(),
+                                ),
+                                timestamp = nowIso,
+                            ),
+                        )
+                        val result = apiService.sendMessage(body)
+                        if (result is Result.Error) _events.tryEmit(ChatEvent.TypingStop)
+                        result
+                    }
+                }
+            }
+
+            else -> Result.Error(UnsupportedOperationException("Message type ${message.type} is not supported"))
+        }
     }
 
     // Each WebSocket frame that passes dedup becomes a single-item list, mirroring

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -33,13 +33,12 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
 
-// Mirrors BuildConfig.TRANSPORT on Android. Change to "LONG_POLL" to use the polling transport.
+// "WEBSOCKET" | "LONG_POLL"
 private const val TRANSPORT = "WEBSOCKET"
 
 // iOS entry point — wires the shared commonMain business logic with iOS platform drivers:
 //   - Darwin HTTP engine (URLSession) via ktor-client-darwin
 //   - NativeSqliteDriver via sqldelight-native-driver
-// Called from Swift by YaloChat.initialize() — see ios-sdk/YaloChatDemo/YaloChat.swift.
 object YaloChatSdk {
 
     private var _syncService: MessageSyncService? = null
@@ -102,7 +101,10 @@ object YaloChatSdk {
                 ?.path
                 ?.let { "$it/ChatSdk" }
 
-            if (runCatching { Transport.valueOf(TRANSPORT) }.getOrDefault(Transport.LONG_POLL) == Transport.WEBSOCKET) {
+            val transport = runCatching { Transport.valueOf(TRANSPORT) }
+                .onFailure { platform.Foundation.NSLog("[YaloChatSdk] invalid TRANSPORT value \"%@\" — defaulting to LONG_POLL", TRANSPORT) }
+                .getOrDefault(Transport.LONG_POLL)
+            if (transport == Transport.WEBSOCKET) {
                 val wsUrl = "${config.environment.wsBaseUrl}$WS_CONNECT_PATH"
                 val wsService = YaloMessageServiceWebSocket(
                     wsUrl = wsUrl,

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -33,8 +33,7 @@ import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
 
-// "WEBSOCKET" | "LONG_POLL"
-private const val TRANSPORT = "WEBSOCKET"
+private val TRANSPORT = Transport.WEBSOCKET
 
 // iOS entry point — wires the shared commonMain business logic with iOS platform drivers:
 //   - Darwin HTTP engine (URLSession) via ktor-client-darwin
@@ -101,10 +100,7 @@ object YaloChatSdk {
                 ?.path
                 ?.let { "$it/ChatSdk" }
 
-            val transport = runCatching { Transport.valueOf(TRANSPORT) }
-                .onFailure { platform.Foundation.NSLog("[YaloChatSdk] invalid TRANSPORT value \"%@\" — defaulting to LONG_POLL", TRANSPORT) }
-                .getOrDefault(Transport.LONG_POLL)
-            if (transport == Transport.WEBSOCKET) {
+            if (TRANSPORT == Transport.WEBSOCKET) {
                 val wsUrl = "${config.environment.wsBaseUrl}$WS_CONNECT_PATH"
                 val wsService = YaloMessageServiceWebSocket(
                     wsUrl = wsUrl,

--- a/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
+++ b/android-sdk/sdk/src/iosMain/kotlin/com/yalo/chat/sdk/YaloChatSdk.kt
@@ -14,6 +14,7 @@ import com.yalo.chat.sdk.data.remote.buildHttpClient
 import com.yalo.chat.sdk.data.KeychainTokenStorage
 import com.yalo.chat.sdk.data.repository.fake.FakeChatMessageRepository
 import com.yalo.chat.sdk.data.repository.fake.FakeYaloMessageRepository
+import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryRemote
 import com.yalo.chat.sdk.data.repository.remote.YaloMessageRepositoryWebSocket
 import com.yalo.chat.sdk.database.ChatDatabase
 import com.yalo.chat.sdk.domain.model.ChatCommand
@@ -31,6 +32,9 @@ import platform.Foundation.NSCachesDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSURL
 import platform.Foundation.NSUserDomainMask
+
+// Mirrors BuildConfig.TRANSPORT on Android. Change to "LONG_POLL" to use the polling transport.
+private const val TRANSPORT = "WEBSOCKET"
 
 // iOS entry point — wires the shared commonMain business logic with iOS platform drivers:
 //   - Darwin HTTP engine (URLSession) via ktor-client-darwin
@@ -98,21 +102,28 @@ object YaloChatSdk {
                 ?.path
                 ?.let { "$it/ChatSdk" }
 
-            val wsUrl = "${config.environment.wsBaseUrl}$WS_CONNECT_PATH"
-            val wsService = YaloMessageServiceWebSocket(
-                wsUrl = wsUrl,
-                apiService = apiService,
-                httpClient = httpClient,
-            )
-            val wsRepo = YaloMessageRepositoryWebSocket(
-                wsService = wsService,
-                apiService = apiService,
-                tempDir = cacheDir,
-            )
-            val wsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-            _wsScope = wsScope
-            wsRepo.start(wsScope)
-            yaloRepo = wsRepo
+            if (runCatching { Transport.valueOf(TRANSPORT) }.getOrDefault(Transport.LONG_POLL) == Transport.WEBSOCKET) {
+                val wsUrl = "${config.environment.wsBaseUrl}$WS_CONNECT_PATH"
+                val wsService = YaloMessageServiceWebSocket(
+                    wsUrl = wsUrl,
+                    apiService = apiService,
+                    httpClient = httpClient,
+                )
+                val wsRepo = YaloMessageRepositoryWebSocket(
+                    wsService = wsService,
+                    apiService = apiService,
+                    tempDir = cacheDir,
+                )
+                val wsScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+                _wsScope = wsScope
+                wsRepo.start(wsScope)
+                yaloRepo = wsRepo
+            } else {
+                yaloRepo = YaloMessageRepositoryRemote(
+                    apiService = apiService,
+                    tempDir = cacheDir,
+                )
+            }
 
             // DB name includes channelId+userId so switching users never sees stale messages.
             val dbName = "chat_${config.channelId}${config.userId?.let { "_${sanitizeStorageId(it)}" } ?: ""}.db"

--- a/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
+++ b/ios-sdk/YaloChatDemo.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		05D563B68F202040D37D6212 /* MessageItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageItem.swift; sourceTree = "<group>"; };
 		0EF71DFCB68275F5614937DD /* ProductCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCard.swift; sourceTree = "<group>"; };
 		192FC4739922F8D122901DB5 /* ImageObservable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageObservable.swift; sourceTree = "<group>"; };
+		204E00CE5F4010F34FAC52DD /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
 		23407D6589CAA8A5F7913634 /* ChatInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatInput.swift; sourceTree = "<group>"; };
 		2ED2567261F6D10227B02251 /* YaloChatAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YaloChatAction.swift; sourceTree = "<group>"; };
 		34E80F747F4EC2822662317B /* YaloChatDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = YaloChatDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -201,6 +202,7 @@
 			knownRegions = (
 				Base,
 				en,
+				es,
 			);
 			mainGroup = 244AB61E08D7C520123CEA59;
 			minimizedProjectReferenceProxies = 1;
@@ -266,6 +268,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				B6D12EA3158328A83F178A91 /* en */,
+				204E00CE5F4010F34FAC52DD /* es */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/ios-sdk/YaloChatDemo/ChatInput.swift
+++ b/ios-sdk/YaloChatDemo/ChatInput.swift
@@ -48,6 +48,7 @@ struct ChatInput: View {
                     }
 
                     TextField(Translate.inputPlaceholder, text: $messagesObservable.userMessage)
+                        .font(theme.hintFont)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 10)
                         .background(theme.inputBackgroundColor)
@@ -85,6 +86,7 @@ struct ChatInput: View {
         if hasImage || !isBlank {
             Button(action: sendAction) {
                 Image(systemName: theme.sendIconName)
+                    .font(.system(size: 17, weight: .medium))
                     .foregroundColor(theme.sendButtonIconColor)
                     .padding(10)
                     .background(theme.sendButtonColor)
@@ -93,6 +95,7 @@ struct ChatInput: View {
         } else {
             Button(action: audioObservable.startRecording) {
                 Image(systemName: theme.micIconName)
+                    .font(.system(size: 17, weight: .medium))
                     .foregroundColor(theme.sendButtonIconColor)
                     .padding(10)
                     .background(theme.sendButtonColor)

--- a/ios-sdk/YaloChatDemo/ChatTheme.swift
+++ b/ios-sdk/YaloChatDemo/ChatTheme.swift
@@ -90,8 +90,15 @@ public struct ChatTheme {
     public var productTitleFont: Font
     public var productSubunitsFont: Font
     public var productPriceFont: Font
+    public var productSalePriceFont: Font
     public var messageHeaderFont: Font
     public var messageFooterFont: Font
+    public var quickReplyFont: Font
+    public var ctaButtonFont: Font
+    public var buttonsButtonFont: Font
+    public var hintFont: Font
+    public var timerFont: Font
+    public var expandControlFont: Font
 
     // MARK: - Layout
     public var bubbleCornerRadius: CGFloat
@@ -172,8 +179,15 @@ public struct ChatTheme {
         productTitleFont: Font                = .subheadline,
         productSubunitsFont: Font             = .caption,
         productPriceFont: Font                = .subheadline,
+        productSalePriceFont: Font            = .caption,
         messageHeaderFont: Font               = .subheadline,
         messageFooterFont: Font               = .caption,
+        quickReplyFont: Font                  = .subheadline,
+        ctaButtonFont: Font                   = .subheadline,
+        buttonsButtonFont: Font               = .subheadline,
+        hintFont: Font                        = .body,
+        timerFont: Font                       = .caption,
+        expandControlFont: Font               = .subheadline,
         bubbleCornerRadius: CGFloat           = 16,
         sendIconName: String                  = "paperplane.fill",
         micIconName: String                   = "mic.fill",
@@ -247,8 +261,15 @@ public struct ChatTheme {
         self.productTitleFont = productTitleFont
         self.productSubunitsFont = productSubunitsFont
         self.productPriceFont = productPriceFont
+        self.productSalePriceFont = productSalePriceFont
         self.messageHeaderFont = messageHeaderFont
         self.messageFooterFont = messageFooterFont
+        self.quickReplyFont = quickReplyFont
+        self.ctaButtonFont = ctaButtonFont
+        self.buttonsButtonFont = buttonsButtonFont
+        self.hintFont = hintFont
+        self.timerFont = timerFont
+        self.expandControlFont = expandControlFont
         self.bubbleCornerRadius = bubbleCornerRadius
         self.sendIconName = sendIconName
         self.micIconName = micIconName

--- a/ios-sdk/YaloChatDemo/ChatView.swift
+++ b/ios-sdk/YaloChatDemo/ChatView.swift
@@ -24,6 +24,7 @@ struct ChatView: View {
             )
 
             MessageList(observable: observable, audioObservable: audioObservable)
+                .frame(maxHeight: .infinity)
 
             Divider()
 

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -16,12 +16,9 @@ struct MessageItem: View {
     var isExpanded: Bool = false
 
     @Environment(\.chatTheme) private var theme
+    @State private var containerWidth: CGFloat = 390
 
     private var isUser: Bool { message.role === MessageRole.user }
-
-    private var listWidth: CGFloat {
-        UIScreen.main.bounds.width - SdkConstants.messageListMargin * 2
-    }
 
     // Product messages render their own card borders — bypass the bubble HStack layout.
     private var isProductMessage: Bool {
@@ -34,14 +31,21 @@ struct MessageItem: View {
         } else {
             HStack(alignment: .bottom, spacing: 4) {
                 if isUser {
-                    Spacer(minLength: listWidth * 0.2)
+                    Spacer(minLength: 48)
                     errorIndicator
                     bubble
                 } else {
                     bubble
-                    Spacer(minLength: listWidth * 0.1)
+                    Spacer(minLength: 48)
                 }
             }
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .onAppear { containerWidth = geo.size.width }
+                        .onChange(of: geo.size.width) { containerWidth = $0 }
+                }
+            )
         }
     }
 
@@ -108,6 +112,7 @@ struct MessageItem: View {
                     .cornerRadius(theme.bubbleCornerRadius)
             }
         }
+        .frame(maxWidth: containerWidth * (isUser ? 0.8 : 0.9))
     }
 
     @ViewBuilder

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -16,7 +16,7 @@ struct MessageItem: View {
     var isExpanded: Bool = false
 
     @Environment(\.chatTheme) private var theme
-    @State private var containerWidth: CGFloat = 390
+    @State private var rowWidth: CGFloat = 393
 
     private var isUser: Bool { message.role === MessageRole.user }
 
@@ -31,19 +31,19 @@ struct MessageItem: View {
         } else {
             HStack(alignment: .bottom, spacing: 4) {
                 if isUser {
-                    Spacer(minLength: 48)
+                    Spacer(minLength: rowWidth * 0.2)
                     errorIndicator
                     bubble
                 } else {
                     bubble
-                    Spacer(minLength: 48)
+                    Spacer(minLength: rowWidth * 0.1)
                 }
             }
             .background(
                 GeometryReader { geo in
                     Color.clear
-                        .onAppear { containerWidth = geo.size.width }
-                        .onChange(of: geo.size.width) { containerWidth = $0 }
+                        .onAppear { rowWidth = geo.size.width }
+                        .onChange(of: geo.size.width) { rowWidth = $0 }
                 }
             )
         }
@@ -112,7 +112,6 @@ struct MessageItem: View {
                     .cornerRadius(theme.bubbleCornerRadius)
             }
         }
-        .frame(maxWidth: containerWidth * (isUser ? 0.8 : 0.9))
     }
 
     @ViewBuilder

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -65,7 +65,7 @@ struct MessageItem: View {
                 }
             }
             .buttonStyle(.plain)
-            .accessibilityLabel(Translate.retry)
+            .accessibilityLabel("\(Translate.notDelivered) \(Translate.retry)")
         }
     }
 

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -16,9 +16,16 @@ struct MessageItem: View {
     var isExpanded: Bool = false
 
     @Environment(\.chatTheme) private var theme
-    @State private var containerWidth: CGFloat = 390
 
     private var isUser: Bool { message.role === MessageRole.user }
+
+    private var listWidth: CGFloat {
+        UIScreen.main.bounds.width - SdkConstants.messageListMargin * 2
+    }
+
+    private var maxBubbleWidth: CGFloat {
+        listWidth * (isUser ? 0.8 : 0.9)
+    }
 
     // Product messages render their own card borders — bypass the bubble HStack layout.
     private var isProductMessage: Bool {
@@ -31,21 +38,14 @@ struct MessageItem: View {
         } else {
             HStack(alignment: .bottom, spacing: 4) {
                 if isUser {
-                    Spacer(minLength: 48)
+                    Spacer(minLength: listWidth * 0.2)
                     errorIndicator
                     bubble
                 } else {
                     bubble
-                    Spacer(minLength: 48)
+                    Spacer(minLength: listWidth * 0.1)
                 }
             }
-            .background(
-                GeometryReader { geo in
-                    Color.clear
-                        .onAppear { containerWidth = geo.size.width }
-                        .onChange(of: geo.size.width) { containerWidth = $0 }
-                }
-            )
         }
     }
 
@@ -55,9 +55,14 @@ struct MessageItem: View {
             Button {
                 if let id = message.id?.int64Value { onRetry(id) }
             } label: {
-                Image(systemName: theme.errorIconName)
-                    .foregroundColor(theme.errorColor)
-                    .font(.caption)
+                VStack(spacing: 2) {
+                    Image(systemName: theme.errorIconName)
+                        .foregroundColor(theme.errorColor)
+                        .font(.caption)
+                    Text(Translate.notDelivered)
+                        .font(.caption2)
+                        .foregroundColor(theme.errorColor)
+                }
             }
             .buttonStyle(.plain)
             .accessibilityLabel(Translate.retry)
@@ -107,7 +112,6 @@ struct MessageItem: View {
                     .cornerRadius(theme.bubbleCornerRadius)
             }
         }
-        .frame(maxWidth: containerWidth * (isUser ? 0.8 : 0.9))
     }
 
     @ViewBuilder
@@ -269,7 +273,7 @@ struct MessageItem: View {
                     }) {
                         HStack {
                             Text(button.text)
-                                .font(.subheadline)
+                                .font(theme.ctaButtonFont)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                             Image(systemName: theme.ctaArrowIconName)
                                 .font(.caption)
@@ -286,7 +290,7 @@ struct MessageItem: View {
                 } else {
                     SwiftUI.Button(action: { onButtonTap(button.text) }) {
                         Text(button.text)
-                            .font(.subheadline)
+                            .font(theme.buttonsButtonFont)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)
                             .background(theme.buttonsButtonColor)
@@ -408,10 +412,10 @@ private struct StableVideoPlayer: View {
         Group {
             if let player {
                 VideoPlayer(player: player)
-                    .frame(maxWidth: 240, minHeight: 160, maxHeight: 180)
+                    .frame(maxWidth: 240, minHeight: 160, maxHeight: 180, alignment: .leading)
             } else {
                 Color.black
-                    .frame(maxWidth: 240, minHeight: 160, maxHeight: 180)
+                    .frame(maxWidth: 240, minHeight: 160, maxHeight: 180, alignment: .leading)
                     .overlay(
                         Image(systemName: "play.circle.fill")
                             .font(.largeTitle)
@@ -440,7 +444,7 @@ private struct LocalFileImage: View {
                 Image(uiImage: img)
                     .resizable()
                     .scaledToFill()
-                    .frame(maxWidth: 200, maxHeight: 200)
+                    .frame(maxWidth: 200, maxHeight: 200, alignment: .leading)
                     .clipped()
             } else {
                 fallbackColor

--- a/ios-sdk/YaloChatDemo/MessageItem.swift
+++ b/ios-sdk/YaloChatDemo/MessageItem.swift
@@ -23,10 +23,6 @@ struct MessageItem: View {
         UIScreen.main.bounds.width - SdkConstants.messageListMargin * 2
     }
 
-    private var maxBubbleWidth: CGFloat {
-        listWidth * (isUser ? 0.8 : 0.9)
-    }
-
     // Product messages render their own card borders — bypass the bubble HStack layout.
     private var isProductMessage: Bool {
         message.type is MessageType.Product || message.type is MessageType.ProductCarousel

--- a/ios-sdk/YaloChatDemo/ProductCard.swift
+++ b/ios-sdk/YaloChatDemo/ProductCard.swift
@@ -148,7 +148,7 @@ private struct ProductPriceRow: View {
 
             if salePrice != nil {
                 Text(formatPrice(product.price))
-                    .font(.caption)
+                    .font(theme.productSalePriceFont)
                     .strikethrough()
                     .foregroundColor(theme.productSalePriceColor)
             }

--- a/ios-sdk/YaloChatDemo/ProductCarouselView.swift
+++ b/ios-sdk/YaloChatDemo/ProductCarouselView.swift
@@ -57,8 +57,8 @@ struct ProductCarouselView: View {
 
                 if showToggle {
                     Button(action: onToggleExpand) {
-                        Text(isExpanded ? "Show less" : "Show more")
-                            .font(.subheadline)
+                        Text(isExpanded ? Translate.showLess : Translate.showMore)
+                            .font(theme.expandControlFont)
                             .foregroundColor(theme.expandControlColor)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 8)

--- a/ios-sdk/YaloChatDemo/ProductListView.swift
+++ b/ios-sdk/YaloChatDemo/ProductListView.swift
@@ -55,8 +55,8 @@ struct ProductListView: View {
 
             if products.count > collapsedMaxItems {
                 Button(action: onToggleExpand) {
-                    Text(isExpanded ? "Show less" : "Show more")
-                        .font(.subheadline)
+                    Text(isExpanded ? Translate.showLess : Translate.showMore)
+                        .font(theme.expandControlFont)
                         .foregroundColor(theme.expandControlColor)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 4)

--- a/ios-sdk/YaloChatDemo/QuickRepliesView.swift
+++ b/ios-sdk/YaloChatDemo/QuickRepliesView.swift
@@ -34,7 +34,7 @@ private struct QuickReplyChip: View {
     var body: some View {
         Button(action: onTap) {
             Text(text)
-                .font(.subheadline)
+                .font(theme.quickReplyFont)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 8)
                 .background(theme.quickReplyBackgroundColor)

--- a/ios-sdk/YaloChatDemo/Translate.swift
+++ b/ios-sdk/YaloChatDemo/Translate.swift
@@ -21,4 +21,7 @@ enum Translate {
     static let cancel             = string("chat.cancel")
     static let inputPlaceholder   = string("chat.input_placeholder")
     static let retry              = string("chat.retry")
+    static let showMore           = string("chat.show_more")
+    static let showLess           = string("chat.show_less")
+    static let notDelivered       = string("chat.not_delivered")
 }

--- a/ios-sdk/YaloChatDemo/WaveformRecorder.swift
+++ b/ios-sdk/YaloChatDemo/WaveformRecorder.swift
@@ -20,6 +20,7 @@ struct WaveformRecorder: View {
             }
 
             Text(audioObservable.durationText)
+                .font(theme.timerFont)
                 .monospacedDigit()
                 .foregroundColor(theme.timerColor)
                 .frame(width: 48, alignment: .leading)

--- a/ios-sdk/YaloChatDemo/en.lproj/Localizable.strings
+++ b/ios-sdk/YaloChatDemo/en.lproj/Localizable.strings
@@ -29,7 +29,7 @@
 "chat.cancel" = "Cancel";
 
 /* Placeholder text in the message text field */
-"chat.input_placeholder" = "Type a message…";
+"chat.input_placeholder" = "Type a message";
 
 /* Accessibility label for the retry button on a failed message */
 "chat.retry" = "Retry";

--- a/ios-sdk/YaloChatDemo/es.lproj/Localizable.strings
+++ b/ios-sdk/YaloChatDemo/es.lproj/Localizable.strings
@@ -29,7 +29,7 @@
 "chat.cancel" = "Cancelar";
 
 /* Placeholder text in the message text field */
-"chat.input_placeholder" = "Escribe un mensaje…";
+"chat.input_placeholder" = "Escribe un mensaje";
 
 /* Accessibility label for the retry button on a failed message */
 "chat.retry" = "Reintentar";

--- a/ios-sdk/YaloChatDemo/es.lproj/Localizable.strings
+++ b/ios-sdk/YaloChatDemo/es.lproj/Localizable.strings
@@ -1,44 +1,44 @@
 /* Message list — shown when the conversation has no messages */
-"chat.no_messages_yet" = "No messages yet";
+"chat.no_messages_yet" = "Sin mensajes aún";
 
 /* Bubble fallback for message types the SDK does not render */
-"chat.unsupported_message_type" = "Unsupported message type";
+"chat.unsupported_message_type" = "Tipo de mensaje no soportado";
 
 /* Placeholder when an image message has no local file path */
-"chat.image_unavailable" = "Image unavailable";
+"chat.image_unavailable" = "Imagen no disponible";
 
 /* Placeholder when a video message has no local file path */
-"chat.video_unavailable" = "Video unavailable";
+"chat.video_unavailable" = "Video no disponible";
 
 /* Error shown when the picked image cannot be written to a temp file */
-"chat.image_save_error" = "Failed to save image. Please try again.";
+"chat.image_save_error" = "No se pudo guardar la imagen. Inténtalo de nuevo.";
 
 /* App bar title fallback when no channel name is configured */
 "chat.default_channel_name" = "Chat";
 
 /* Title of the attachment source picker */
-"chat.attach_image_title" = "Attach Image";
+"chat.attach_image_title" = "Adjuntar imagen";
 
 /* Photo library option in the attachment source picker */
-"chat.photo_library" = "Photo Library";
+"chat.photo_library" = "Subir desde galería";
 
 /* Camera option in the attachment source picker */
-"chat.camera" = "Camera";
+"chat.camera" = "Tomar foto";
 
 /* Cancel button in the attachment source picker */
-"chat.cancel" = "Cancel";
+"chat.cancel" = "Cancelar";
 
 /* Placeholder text in the message text field */
-"chat.input_placeholder" = "Type a message…";
+"chat.input_placeholder" = "Escribe un mensaje…";
 
 /* Accessibility label for the retry button on a failed message */
-"chat.retry" = "Retry";
+"chat.retry" = "Reintentar";
 
 /* Expand control on product lists and carousels */
-"chat.show_more" = "Show more";
+"chat.show_more" = "Ver más";
 
 /* Collapse control on product lists and carousels */
-"chat.show_less" = "Show less";
+"chat.show_less" = "Ver menos";
 
 /* Label shown below a user message that failed to deliver */
-"chat.not_delivered" = "Not delivered.";
+"chat.not_delivered" = "No entregado.";


### PR DESCRIPTION
## Summary

- **iOS M11**: Added `es.lproj/Localizable.strings` (15 Spanish strings from Flutter ARB), wired `Translate.showMore/showLess/notDelivered` into all product views, added 7 font fields to `ChatTheme` and wired them into all UI components, added "Not delivered." text label below the error icon
- **Android M14**: Created `res/values/strings.xml` (29 English) and `res/values-es/strings.xml` (Spanish), replaced all 27 hardcoded UI strings across 13 composable files with `stringResource()`, added "Not delivered." text label below the error icon (Column layout)
- **KMP / WebSocket**: WebSocket receive + REST send improvements bundled from `main`
- Both iOS build (`xcodebuild`) and Android unit tests (`./gradlew :sdk:testDebugUnitTest`) pass clean

## Test plan

- [ ] iOS Simulator → Settings → General → Language & Region → add Spanish → relaunch → all UI strings appear in Spanish
- [ ] Android Emulator → Settings → System → Language → add Spanish → relaunch → same
- [ ] Send a message while offline on both platforms → error icon AND "Not delivered." text appear
- [ ] Trigger a product list with 4+ products → "Show more" / "Show less" uses localized string
- [ ] RTL smoke: add Arabic locale → user bubbles move to left, agent bubbles to right

🤖 Generated with [Claude Code](https://claude.com/claude-code)