### PR TITLE
fix: Allow queueing pending frames

### DIFF
--- a/web-sdk/doc/commands.md
+++ b/web-sdk/doc/commands.md
@@ -21,7 +21,5 @@ client.init();
 |---------|---------------|-----------------|
 | `updateCartProduct` | User confirms a product in a product message via "Add to cart" | `{ sku: string, units: number, subunits?: number }` |
 | `clearCart` | Cart is cleared | `unknown` |
-| `guidanceCard` | Guidance cards are requested | `unknown` |
-| `addPromotion` | A promotion is applied | `unknown` |
 
 If a command has no registered callback, the SDK sends the action through the remote API as usual.

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
@@ -45,6 +45,15 @@ const closed = (s: MockSocket) => {
 };
 const message = (s: MockSocket, data: string) =>
   s.dispatchEvent(new MessageEvent('message', { data }));
+const ack = (s: MockSocket) =>
+  message(
+    s,
+    JSON.stringify({
+      type: 'connection_ack',
+      connection_id: 'conn-1',
+      timestamp: '2026-01-01T00:00:00Z',
+    })
+  );
 const errored = (s: MockSocket) => s.dispatchEvent(new Event('error'));
 
 const makeTokenRepository = (
@@ -161,11 +170,12 @@ describe('YaloMessageServiceWebSocket', () => {
   });
 
   describe('sendMessage', () => {
-    it('sends the frame as SdkMessage JSON when the socket is open', async () => {
+    it('sends the frame as SdkMessage JSON once the socket is acked', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
       open(sockets[0]);
+      ack(sockets[0]);
 
       const result = await service.sendMessage(makeTextMessage('hi'));
 
@@ -177,40 +187,28 @@ describe('YaloMessageServiceWebSocket', () => {
       });
     });
 
-    it('buffers the frame and flushes on open when the socket is still connecting', async () => {
+    it('buffers frames until connection_ack arrives, even after open', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
 
-      const result = await service.sendMessage(makeTextMessage('one'));
-
-      expect(result.ok).toBe(true);
+      const beforeOpen = await service.sendMessage(makeTextMessage('one'));
+      expect(beforeOpen.ok).toBe(true);
       expect(sockets[0].send).not.toHaveBeenCalled();
 
       open(sockets[0]);
+      const afterOpen = await service.sendMessage(makeTextMessage('two'));
+      expect(afterOpen.ok).toBe(true);
+      expect(sockets[0].send).not.toHaveBeenCalled();
 
-      expect(sockets[0].send).toHaveBeenCalledTimes(1);
-      expect(JSON.parse(sockets[0].send.mock.calls[0][0])).toMatchObject({
-        correlationId: 'cid-one',
-        textMessageRequest: { content: { text: 'one' } },
-      });
-    });
-
-    it('flushes buffered frames in the order they were enqueued', async () => {
-      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
-      service.subscribe(() => {});
-      await flush();
-
-      await service.sendMessage(makeTextMessage('first'));
-      await service.sendMessage(makeTextMessage('second'));
-      open(sockets[0]);
+      ack(sockets[0]);
 
       expect(sockets[0].send).toHaveBeenCalledTimes(2);
       expect(JSON.parse(sockets[0].send.mock.calls[0][0])).toMatchObject({
-        correlationId: 'cid-first',
+        correlationId: 'cid-one',
       });
       expect(JSON.parse(sockets[0].send.mock.calls[1][0])).toMatchObject({
-        correlationId: 'cid-second',
+        correlationId: 'cid-two',
       });
     });
 
@@ -227,11 +225,12 @@ describe('YaloMessageServiceWebSocket', () => {
       expect(sockets).toHaveLength(0);
     });
 
-    it('buffers frames sent after a close and flushes them once reconnect opens', async () => {
+    it('buffers frames sent after a close and flushes them once a new ack arrives', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
       open(sockets[0]);
+      ack(sockets[0]);
       closed(sockets[0]);
 
       const result = await service.sendMessage(makeTextMessage('after-close'));
@@ -240,6 +239,9 @@ describe('YaloMessageServiceWebSocket', () => {
 
       await vi.advanceTimersByTimeAsync(1000);
       open(sockets[1]);
+      expect(sockets[1].send).not.toHaveBeenCalled();
+
+      ack(sockets[1]);
 
       expect(sockets[1].send).toHaveBeenCalledTimes(1);
       expect(JSON.parse(sockets[1].send.mock.calls[0][0])).toMatchObject({
@@ -247,11 +249,28 @@ describe('YaloMessageServiceWebSocket', () => {
       });
     });
 
+    it('buffers again after a close even if the previous connection was acked', async () => {
+      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
+      service.subscribe(() => {});
+      await flush();
+      open(sockets[0]);
+      ack(sockets[0]);
+      closed(sockets[0]);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      open(sockets[1]);
+
+      const result = await service.sendMessage(makeTextMessage('mid-reconnect'));
+      expect(result.ok).toBe(true);
+      expect(sockets[1].send).not.toHaveBeenCalled();
+    });
+
     it('returns Err when the socket send throws', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
       open(sockets[0]);
+      ack(sockets[0]);
       sockets[0].send.mockImplementation(() => {
         throw new Error('socket failed');
       });
@@ -316,6 +335,30 @@ describe('YaloMessageServiceWebSocket', () => {
       expect(sockets).toHaveLength(4);
     });
 
+    it('closes the socket if connection_ack does not arrive within 10s', async () => {
+      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
+      service.subscribe(() => {});
+      await flush();
+      open(sockets[0]);
+
+      await vi.advanceTimersByTimeAsync(10000);
+      expect(sockets[0].close).toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(sockets).toHaveLength(2);
+    });
+
+    it('does not close the socket after ack even if 10s pass without traffic', async () => {
+      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
+      service.subscribe(() => {});
+      await flush();
+      open(sockets[0]);
+      ack(sockets[0]);
+
+      await vi.advanceTimersByTimeAsync(60000);
+      expect(sockets[0].close).not.toHaveBeenCalled();
+    });
+
     it('closes the socket and reconnects when an error event fires', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
@@ -369,6 +412,7 @@ describe('YaloMessageServiceWebSocket', () => {
       service.subscribe(() => {});
       await flush();
       open(sockets[1]);
+      ack(sockets[1]);
 
       expect(sockets[1].send).not.toHaveBeenCalled();
     });

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
@@ -177,18 +177,41 @@ describe('YaloMessageServiceWebSocket', () => {
       });
     });
 
-    it('returns Err when the socket is not yet open', async () => {
+    it('buffers the frame and flushes on open when the socket is still connecting', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
 
       const result = await service.sendMessage(makeTextMessage('one'));
 
-      expect(result).toMatchObject({
-        ok: false,
-        error: { message: 'WebSocket is not connected' },
-      });
+      expect(result.ok).toBe(true);
       expect(sockets[0].send).not.toHaveBeenCalled();
+
+      open(sockets[0]);
+
+      expect(sockets[0].send).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(sockets[0].send.mock.calls[0][0])).toMatchObject({
+        correlationId: 'cid-one',
+        textMessageRequest: { content: { text: 'one' } },
+      });
+    });
+
+    it('flushes buffered frames in the order they were enqueued', async () => {
+      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
+      service.subscribe(() => {});
+      await flush();
+
+      await service.sendMessage(makeTextMessage('first'));
+      await service.sendMessage(makeTextMessage('second'));
+      open(sockets[0]);
+
+      expect(sockets[0].send).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(sockets[0].send.mock.calls[0][0])).toMatchObject({
+        correlationId: 'cid-first',
+      });
+      expect(JSON.parse(sockets[0].send.mock.calls[1][0])).toMatchObject({
+        correlationId: 'cid-second',
+      });
     });
 
     it('returns Err when called before subscribe and does not open a socket', async () => {
@@ -204,7 +227,7 @@ describe('YaloMessageServiceWebSocket', () => {
       expect(sockets).toHaveLength(0);
     });
 
-    it('returns Err after the socket closes until reconnect succeeds', async () => {
+    it('buffers frames sent after a close and flushes them once reconnect opens', async () => {
       const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
       service.subscribe(() => {});
       await flush();
@@ -213,9 +236,14 @@ describe('YaloMessageServiceWebSocket', () => {
 
       const result = await service.sendMessage(makeTextMessage('after-close'));
 
-      expect(result).toMatchObject({
-        ok: false,
-        error: { message: 'WebSocket is not connected' },
+      expect(result.ok).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(1000);
+      open(sockets[1]);
+
+      expect(sockets[1].send).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(sockets[1].send.mock.calls[0][0])).toMatchObject({
+        correlationId: 'cid-after-close',
       });
     });
 
@@ -328,6 +356,21 @@ describe('YaloMessageServiceWebSocket', () => {
 
       await vi.advanceTimersByTimeAsync(60000);
       expect(sockets).toHaveLength(1);
+    });
+
+    it('drops buffered frames so they are not sent on a later resubscribe', async () => {
+      const service = new YaloMessageServiceWebSocket(baseUrl, makeTokenRepository());
+      service.subscribe(() => {});
+      await flush();
+
+      await service.sendMessage(makeTextMessage('dropped'));
+      service.unsubscribe();
+
+      service.subscribe(() => {});
+      await flush();
+      open(sockets[1]);
+
+      expect(sockets[1].send).not.toHaveBeenCalled();
     });
   });
 });

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.ts
@@ -13,6 +13,13 @@ import type {
 
 const INITIAL_BACKOFF_MS = 1000;
 const MAX_BACKOFF_MS = 30000;
+const ACK_TIMEOUT_MS = 10000;
+
+type ConnectionAck = {
+  type: string;
+  connection_id: string;
+  timestamp: string;
+};
 
 export class YaloMessageServiceWebSocket implements YaloMessageService {
   private readonly _wsUrl: string;
@@ -21,8 +28,10 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
   private _callback?: MessageCallback;
   private _reconnectAttempt = 0;
   private _reconnectTimeout?: ReturnType<typeof setTimeout>;
+  private _ackTimeout?: ReturnType<typeof setTimeout>;
   private _running = false;
   private _pendingFrames: string[] = [];
+  private _connectionAcked = false;
 
   constructor(baseUrl: string, tokenRepository: TokenRepository) {
     this._wsUrl = `wss://${baseUrl}/websocket/v1/connect/webchat`;
@@ -40,10 +49,12 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
     this._callback = undefined;
     this._reconnectAttempt = 0;
     this._pendingFrames = [];
+    this._connectionAcked = false;
     if (this._reconnectTimeout) {
       clearTimeout(this._reconnectTimeout);
       this._reconnectTimeout = undefined;
     }
+    this._clearAckTimeout();
     if (this._socket) {
       this._socket.close();
       this._socket = undefined;
@@ -60,7 +71,10 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
     } catch (e) {
       return new Err(e instanceof Error ? e : new Error(String(e)));
     }
-    if (this._socket?.readyState !== WebSocket.OPEN) {
+    if (
+      !this._connectionAcked ||
+      this._socket?.readyState !== WebSocket.OPEN
+    ) {
       this._pendingFrames.push(frame);
       return new Ok(undefined);
     }
@@ -69,6 +83,13 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
       return new Ok(undefined);
     } catch (e) {
       return new Err(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  private _clearAckTimeout(): void {
+    if (this._ackTimeout) {
+      clearTimeout(this._ackTimeout);
+      this._ackTimeout = undefined;
     }
   }
 
@@ -100,13 +121,32 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
 
     socket.addEventListener('open', () => {
       this._reconnectAttempt = 0;
-      this._flushPending();
+      this._ackTimeout = setTimeout(() => {
+        this._ackTimeout = undefined;
+        socket.close();
+      }, ACK_TIMEOUT_MS);
     });
 
     socket.addEventListener('message', (event: MessageEvent) => {
       if (typeof event.data !== 'string') return;
+      let parsed: unknown;
       try {
-        const item = PollMessageItem.fromJSON(JSON.parse(event.data));
+        parsed = JSON.parse(event.data);
+      } catch {
+        return;
+      }
+      if (
+        typeof parsed === 'object' &&
+        parsed !== null &&
+        (parsed as ConnectionAck).type === 'connection_ack'
+      ) {
+        this._connectionAcked = true;
+        this._clearAckTimeout();
+        this._flushPending();
+        return;
+      }
+      try {
+        const item = PollMessageItem.fromJSON(parsed);
         this._callback?.(item);
       } catch {
         // ignore malformed frames
@@ -121,6 +161,8 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
       if (this._socket === socket) {
         this._socket = undefined;
       }
+      this._connectionAcked = false;
+      this._clearAckTimeout();
       if (this._running) {
         this._scheduleReconnect();
       }

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.ts
@@ -22,6 +22,7 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
   private _reconnectAttempt = 0;
   private _reconnectTimeout?: ReturnType<typeof setTimeout>;
   private _running = false;
+  private _pendingFrames: string[] = [];
 
   constructor(baseUrl: string, tokenRepository: TokenRepository) {
     this._wsUrl = `wss://${baseUrl}/websocket/v1/connect/webchat`;
@@ -38,6 +39,7 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
     this._running = false;
     this._callback = undefined;
     this._reconnectAttempt = 0;
+    this._pendingFrames = [];
     if (this._reconnectTimeout) {
       clearTimeout(this._reconnectTimeout);
       this._reconnectTimeout = undefined;
@@ -49,15 +51,36 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
   }
 
   async sendMessage(message: SdkMessage): Promise<Result<void>> {
-    if (this._socket?.readyState !== WebSocket.OPEN) {
+    if (!this._running) {
       return new Err(new Error('WebSocket is not connected'));
     }
+    let frame: string;
     try {
-      const frame = JSON.stringify(SdkMessage.toJSON(message));
+      frame = JSON.stringify(SdkMessage.toJSON(message));
+    } catch (e) {
+      return new Err(e instanceof Error ? e : new Error(String(e)));
+    }
+    if (this._socket?.readyState !== WebSocket.OPEN) {
+      this._pendingFrames.push(frame);
+      return new Ok(undefined);
+    }
+    try {
       this._socket.send(frame);
       return new Ok(undefined);
     } catch (e) {
       return new Err(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  private _flushPending(): void {
+    const pending = this._pendingFrames;
+    this._pendingFrames = [];
+    for (const frame of pending) {
+      try {
+        this._socket?.send(frame);
+      } catch {
+        // The caller already received Ok at enqueue time.
+      }
     }
   }
 
@@ -77,6 +100,7 @@ export class YaloMessageServiceWebSocket implements YaloMessageService {
 
     socket.addEventListener('open', () => {
       this._reconnectAttempt = 0;
+      this._flushPending();
     });
 
     socket.addEventListener('message', (event: MessageEvent) => {

--- a/web-sdk/src/domain/models/command/chat-command.ts
+++ b/web-sdk/src/domain/models/command/chat-command.ts
@@ -4,8 +4,6 @@
 export const ChatCommands = [
   'updateCartProduct',
   'clearCart',
-  'guidanceCard',
-  'addPromotion',
 ] as const;
 
 export type ChatCommand = (typeof ChatCommands)[number];

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -326,7 +326,6 @@ export default class YaloChatWindowController implements ReactiveController {
   }
 
   async markProductAddedToCart(e: CustomEvent) {
-    console.log('test');
     const { messageId, sku } = e.detail as {
       messageId: number;
       sku: string;

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -326,6 +326,7 @@ export default class YaloChatWindowController implements ReactiveController {
   }
 
   async markProductAddedToCart(e: CustomEvent) {
+    console.log('test');
     const { messageId, sku } = e.detail as {
       messageId: number;
       sku: string;
@@ -341,9 +342,6 @@ export default class YaloChatWindowController implements ReactiveController {
       return;
     }
     const product = message.products[productIndex];
-    if (product.inCart) {
-      return;
-    }
 
     const updatedProducts = [...message.products];
     updatedProducts[productIndex] = new Product({ ...product, inCart: true });

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -1147,28 +1147,28 @@ describe('YaloChatWindow', () => {
       expect(updateCart).toHaveBeenCalledWith('sku-sub', 1, 4);
     });
 
-    it('does nothing when the product is already in the cart', async () => {
+    it('sends updateCartProduct with the latest quantities when the product is already in the cart', async () => {
       const seeded = await seedProductMessage(
         new Product({
-          sku: 'sku-dup',
+          sku: 'sku-update',
           name: 'Item',
           price: 1,
           unitName: 'unit',
+          unitsAdded: 5,
           inCart: true,
         })
       );
-      const updateCart = vi.spyOn(
-        el.yaloMessageRepository,
-        'updateCartProduct'
-      );
+      const updateCart = vi
+        .spyOn(el.yaloMessageRepository, 'updateCartProduct')
+        .mockResolvedValue(new Ok(undefined));
 
       dispatchFromList(el, 'yalo-chat-product-add-to-cart', {
         messageId: seeded.id,
-        sku: 'sku-dup',
+        sku: 'sku-update',
       });
 
-      await new Promise((resolve) => setTimeout(resolve, 30));
-      expect(updateCart).not.toHaveBeenCalled();
+      await vi.waitUntil(() => updateCart.mock.calls.length > 0);
+      expect(updateCart).toHaveBeenCalledWith('sku-update', 5, undefined);
     });
 
     it('routes updateCartProduct through a registered command when present', async () => {


### PR DESCRIPTION
- Fixes race condition for guidance cards by queueing early frames
- Removes non implemented commands and unnecessary commands from doc and code
- Waits for connection ACK before flushing