### PR TITLE
fix: Theme variables are now overridable via :root

### DIFF
--- a/web-sdk/doc/theming.md
+++ b/web-sdk/doc/theming.md
@@ -36,30 +36,6 @@ Every variable includes a built-in fallback, so the widget renders correctly eve
 }
 ```
 
-#### Width and height
-
-`--yalo-chat-width` and `--yalo-chat-height` must be set on the `yalo-chat-window` element itself (or as an inline `style` on it). Setting them on `:root` or on a wrapping element has no effect: the component declares its own defaults in `:host`, and `:host` wins over inherited custom properties.
-
-Fixed size:
-
-```css
-yalo-chat-window {
-  --yalo-chat-width: 500px;
-  --yalo-chat-height: 720px;
-}
-```
-
-Fill the parent container (the embedding pattern, for full-page or panel embeds):
-
-```css
-yalo-chat-window {
-  --yalo-chat-width: 100%;
-  --yalo-chat-height: 100%;
-}
-```
-
-Both accept any CSS length (`px`, `rem`, `%`, `vw`, `vh`, etc.). The defaults are `auto`, which collapses the window to its content.
-
 ### Spacing
 
 ```css

--- a/web-sdk/src/ui/chat/chat-footer/chat-footer.ts
+++ b/web-sdk/src/ui/chat/chat-footer/chat-footer.ts
@@ -21,18 +21,6 @@ import '@ui/chat/waveform-painter/waveform-painter';
 @localized()
 export class ChatFooter extends LitElement {
   static styles = css`
-    :host {
-      --yalo-chat-input-border: 1px solid #e8e8e8;
-      --yalo-chat-input-border-radius: 25.5px;
-      --yalo-chat-input-font-size: 1rem;
-      --yalo-chat-input-placeholder-color: #757575;
-      --yalo-chat-send-btn-background: #2207f1;
-      --yalo-chat-send-btn-color: white;
-      --yalo-chat-attachment-button-color: #7c8086;
-      --yalo-chat-action-button-size: 2.5rem;
-      --yalo-chat-footer-icon-font-size: 1.5rem;
-    }
-
     .chat-form {
       display: flex;
       padding: 8px;
@@ -41,16 +29,16 @@ export class ChatFooter extends LitElement {
 
     .chat-input-box {
       flex-grow: 1;
-      border: var(--yalo-chat-input-border);
-      border-radius: var(--yalo-chat-input-border-radius);
-      padding: var(--yalo-chat-column-item-space);
+      border: var(--yalo-chat-input-border, 1px solid #e8e8e8);
+      border-radius: var(--yalo-chat-input-border-radius, 25.5px);
+      padding: var(--yalo-chat-column-item-space, 8px);
     }
 
     .chat-input {
       display: flex;
       align-items: center;
       line-height: 1.6rem;
-      font-size: var(--yalo-chat-input-font-size);
+      font-size: var(--yalo-chat-input-font-size, 1rem);
       max-height: calc(1.5em * 3);
       box-sizing: border-box;
       outline: none;
@@ -72,7 +60,7 @@ export class ChatFooter extends LitElement {
       inset: 0;
       display: flex;
       align-items: center;
-      color: var(--yalo-chat-input-placeholder-color);
+      color: var(--yalo-chat-input-placeholder-color, #757575);
       pointer-events: none;
     }
 
@@ -80,11 +68,11 @@ export class ChatFooter extends LitElement {
       appearance: none;
       border: none;
       outline: none;
-      background: var(--yalo-chat-send-btn-background);
-      color: var(--yalo-chat-send-btn-color);
+      background: var(--yalo-chat-send-btn-background, #2207f1);
+      color: var(--yalo-chat-send-btn-color, white);
       border-radius: 50%;
-      width: var(--yalo-chat-action-button-size);
-      height: var(--yalo-chat-action-button-size);
+      width: var(--yalo-chat-action-button-size, 2.5rem);
+      height: var(--yalo-chat-action-button-size, 2.5rem);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -111,7 +99,7 @@ export class ChatFooter extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-footer-icon-font-size);
+      font-size: var(--yalo-chat-footer-icon-font-size, 1.5rem);
       font-family: 'Material Symbols Outlined';
     }
 
@@ -130,7 +118,7 @@ export class ChatFooter extends LitElement {
       justify-content: center;
       cursor: pointer;
       flex-shrink: 0;
-      color: var(--yalo-chat-attachment-button-color);
+      color: var(--yalo-chat-attachment-button-color, #7c8086);
       border-radius: 50%;
       width: 2rem;
       height: 2rem;

--- a/web-sdk/src/ui/chat/chat-header/chat-header.ts
+++ b/web-sdk/src/ui/chat/chat-header/chat-header.ts
@@ -13,21 +13,14 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 @customElement('yalo-chat-header')
 export class ChatHeader extends LitElement {
   static styles = css`
-    :host {
-      --yalo-chat-header-background: #f1f5fc;
-      --yalo-chat-header-color: #010101;
-      --yalo-chat-close-btn-color: #010101;
-      --yalo-chat-header-icon-font-size: 1.5rem;
-    }
-
     .chat-header {
       display: flex;
       gap: 1rem;
       align-items: center;
       justify-content: space-between;
       padding: 12px 16px;
-      background: var(--yalo-chat-header-background);
-      color: var(--yalo-chat-header-color);
+      background: var(--yalo-chat-header-background, #f1f5fc);
+      color: var(--yalo-chat-header-color, #010101);
     }
 
     .chat-header-title-group {
@@ -55,7 +48,7 @@ export class ChatHeader extends LitElement {
     .chat-close-btn {
       background: none;
       border: none;
-      color: var(--yalo-chat-close-btn-color);
+      color: var(--yalo-chat-close-btn-color, #010101);
       cursor: pointer;
       padding: 4px;
       display: flex;
@@ -71,7 +64,7 @@ export class ChatHeader extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-header-icon-font-size);
+      font-size: var(--yalo-chat-header-icon-font-size, 1.5rem);
       font-family: 'Material Symbols Outlined';
     }
   `;

--- a/web-sdk/src/ui/chat/chat-message-list/assistant-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/assistant-message.ts
@@ -20,18 +20,6 @@ import './voice-message';
 export class AssistantMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-link-button-color: #2207f1;
-      --yalo-chat-message-header-font-weight: bold;
-      --yalo-chat-message-footer-color: #7c8086;
-      --yalo-chat-message-footer-font-size: 0.75em;
-      --yalo-chat-buttons-border-color: #9db1c8;
-      --yalo-chat-buttons-gap: 0.5rem;
-      --yalo-chat-buttons-padding: 0.5rem;
-      --yalo-chat-buttons-border-radius: 0.5rem;
-      --yalo-chat-buttons-background: transparent;
-      --yalo-chat-buttons-color: #111111;
-      --yalo-chat-buttons-font-size: 0.875rem;
-      --yalo-chat-assistant-message-icon-font-size: 1rem;
       display: flow;
       justify-content: flex-start;
       margin: 0.25rem 0.5rem;
@@ -44,7 +32,7 @@ export class AssistantMessage extends LitElement {
     }
 
     a {
-      color: var(--yalo-chat-link-button-color);
+      color: var(--yalo-chat-link-button-color, #2207f1);
     }
 
     .voice-bubble {
@@ -69,14 +57,14 @@ export class AssistantMessage extends LitElement {
     }
 
     .header {
-      font-weight: var(--yalo-chat-message-header-font-weight);
+      font-weight: var(--yalo-chat-message-header-font-weight, bold);
       margin-bottom: 0.25rem;
       word-break: break-word;
     }
 
     .footer {
-      color: var(--yalo-chat-message-footer-color);
-      font-size: var(--yalo-chat-message-footer-font-size);
+      color: var(--yalo-chat-message-footer-color, #7c8086);
+      font-size: var(--yalo-chat-message-footer-font-size, 0.75em);
       margin-top: 0.25rem;
       word-break: break-word;
     }
@@ -84,18 +72,18 @@ export class AssistantMessage extends LitElement {
     .buttons {
       display: flex;
       flex-direction: column;
-      gap: var(--yalo-chat-buttons-gap);
+      gap: var(--yalo-chat-buttons-gap, 0.5rem);
       margin-top: 0.5rem;
     }
 
     .buttons button,
     .buttons a {
-      padding: var(--yalo-chat-buttons-padding);
-      border: 1px solid var(--yalo-chat-buttons-border-color);
-      border-radius: var(--yalo-chat-buttons-border-radius);
-      background: var(--yalo-chat-buttons-background);
-      color: var(--yalo-chat-buttons-color);
-      font-size: var(--yalo-chat-buttons-font-size);
+      padding: var(--yalo-chat-buttons-padding, 0.5rem);
+      border: 1px solid var(--yalo-chat-buttons-border-color, #9db1c8);
+      border-radius: var(--yalo-chat-buttons-border-radius, 0.5rem);
+      background: var(--yalo-chat-buttons-background, transparent);
+      color: var(--yalo-chat-buttons-color, #111111);
+      font-size: var(--yalo-chat-buttons-font-size, 0.875rem);
       cursor: pointer;
       word-break: break-word;
     }
@@ -117,7 +105,7 @@ export class AssistantMessage extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-assistant-message-icon-font-size);
+      font-size: var(--yalo-chat-assistant-message-icon-font-size, 1rem);
       font-family: 'Material Symbols Outlined';
     }
 

--- a/web-sdk/src/ui/chat/chat-message-list/attachment-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/attachment-message.ts
@@ -12,7 +12,6 @@ import { unsafeHTML } from 'lit/directives/unsafe-html.js';
 export class AttachmentMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-attachment-message-icon-font-size: 1.5rem;
       display: block;
     }
 
@@ -36,7 +35,7 @@ export class AttachmentMessage extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-attachment-message-icon-font-size);
+      font-size: var(--yalo-chat-attachment-message-icon-font-size, 1.5rem);
       font-family: 'Material Symbols Outlined';
     }
   `;

--- a/web-sdk/src/ui/chat/chat-message-list/chat-message-list.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/chat-message-list.ts
@@ -17,9 +17,6 @@ import './chat-quick-replies';
 export default class ChatMessageList extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-user-message-background: #f9fafc;
-      --yalo-chat-spinner-color: #2207f1;
-      --yalo-chat-dot-color: #2207f1;
       width: 100%;
       display: flex;
       flex-direction: column;
@@ -55,7 +52,7 @@ export default class ChatMessageList extends LitElement {
       padding: 0.5rem 0.75rem;
       border-radius: 1.125rem;
       border-bottom-right-radius: 0.25rem;
-      background: var(--yalo-chat-user-message-background);
+      background: var(--yalo-chat-user-message-background, #f9fafc);
       word-break: break-word;
     }
 
@@ -69,7 +66,7 @@ export default class ChatMessageList extends LitElement {
     .spinner {
       width: 48px;
       height: 48px;
-      border: 5px solid var(--yalo-chat-spinner-color);
+      border: 5px solid var(--yalo-chat-spinner-color, #2207f1);
       border-bottom-color: transparent;
       border-radius: 50%;
       display: inline-block;
@@ -97,7 +94,7 @@ export default class ChatMessageList extends LitElement {
       --_g: no-repeat
         radial-gradient(
           circle closest-side,
-          var(--yalo-chat-dot-color) 90%,
+          var(--yalo-chat-dot-color, #2207f1) 90%,
           #0000
         );
       background:

--- a/web-sdk/src/ui/chat/chat-message-list/chat-quick-replies.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/chat-quick-replies.ts
@@ -9,16 +9,6 @@ import ChatQuickRepliesController from './chat-quick-replies-controller';
 export default class ChatQuickReplies extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-quick-replies-gap: 0.5rem;
-      --yalo-chat-quick-replies-padding: 0.5rem;
-      --yalo-chat-quick-replies-border: 1px solid #e8e8e8;
-      --yalo-chat-quick-replies-chip-padding: 0.5rem 0.75rem;
-      --yalo-chat-quick-replies-chip-border-color: #9db1c8;
-      --yalo-chat-quick-replies-chip-border-radius: 1.125rem;
-      --yalo-chat-quick-replies-chip-background: transparent;
-      --yalo-chat-quick-replies-chip-color: #111111;
-      --yalo-chat-quick-replies-chip-font-size: 0.875rem;
-      --yalo-chat-quick-replies-animation-duration: 0.3s;
       display: block;
     }
 
@@ -26,7 +16,7 @@ export default class ChatQuickReplies extends LitElement {
       display: grid;
       grid-template-rows: 0fr;
       transition: grid-template-rows
-        var(--yalo-chat-quick-replies-animation-duration) ease;
+        var(--yalo-chat-quick-replies-animation-duration, 0.3s) ease;
     }
 
     .container.open {
@@ -42,18 +32,19 @@ export default class ChatQuickReplies extends LitElement {
       display: flex;
       flex-wrap: wrap;
       justify-content: flex-start;
-      gap: var(--yalo-chat-quick-replies-gap);
-      padding: var(--yalo-chat-quick-replies-padding);
-      border-top: var(--yalo-chat-quick-replies-border);
+      gap: var(--yalo-chat-quick-replies-gap, 0.5rem);
+      padding: var(--yalo-chat-quick-replies-padding, 0.5rem);
+      border-top: var(--yalo-chat-quick-replies-border, 1px solid #e8e8e8);
     }
 
     button {
-      padding: var(--yalo-chat-quick-replies-chip-padding);
-      border: 1px solid var(--yalo-chat-quick-replies-chip-border-color);
-      border-radius: var(--yalo-chat-quick-replies-chip-border-radius);
-      background: var(--yalo-chat-quick-replies-chip-background);
-      color: var(--yalo-chat-quick-replies-chip-color);
-      font-size: var(--yalo-chat-quick-replies-chip-font-size);
+      padding: var(--yalo-chat-quick-replies-chip-padding, 0.5rem 0.75rem);
+      border: 1px solid
+        var(--yalo-chat-quick-replies-chip-border-color, #9db1c8);
+      border-radius: var(--yalo-chat-quick-replies-chip-border-radius, 1.125rem);
+      background: var(--yalo-chat-quick-replies-chip-background, transparent);
+      color: var(--yalo-chat-quick-replies-chip-color, #111111);
+      font-size: var(--yalo-chat-quick-replies-chip-font-size, 0.875rem);
       cursor: pointer;
       word-break: break-word;
     }

--- a/web-sdk/src/ui/chat/chat-message-list/numeric-input.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/numeric-input.ts
@@ -8,30 +8,23 @@ import NumericInputController from './numeric-input-controller';
 export class NumericInput extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-numeric-icon-color: #334155;
-      --yalo-chat-numeric-text-color: #111111;
-      --yalo-chat-numeric-border-color: #dde4ec;
-      --yalo-chat-numeric-radius: 0.5rem;
-      --yalo-chat-numeric-padding: 0.25rem;
-      --yalo-chat-numeric-gap: 0.5rem;
-      --yalo-chat-numeric-font-size: 0.875rem;
       display: block;
     }
 
     .field {
       display: flex;
       align-items: center;
-      gap: var(--yalo-chat-numeric-gap);
-      border: 1px solid var(--yalo-chat-numeric-border-color);
-      border-radius: var(--yalo-chat-numeric-radius);
-      padding: var(--yalo-chat-numeric-padding);
+      gap: var(--yalo-chat-numeric-gap, 0.5rem);
+      border: 1px solid var(--yalo-chat-numeric-border-color, #dde4ec);
+      border-radius: var(--yalo-chat-numeric-radius, 0.5rem);
+      padding: var(--yalo-chat-numeric-padding, 0.25rem);
     }
 
     button {
       background: none;
       border: none;
       cursor: pointer;
-      color: var(--yalo-chat-numeric-icon-color);
+      color: var(--yalo-chat-numeric-icon-color, #334155);
       font-size: 1.25rem;
       line-height: 1;
       width: 1.75rem;
@@ -47,7 +40,7 @@ export class NumericInput extends LitElement {
     }
 
     button:disabled {
-      color: var(--yalo-chat-numeric-border-color);
+      color: var(--yalo-chat-numeric-border-color, #dde4ec);
       cursor: not-allowed;
       background: none;
     }
@@ -59,8 +52,8 @@ export class NumericInput extends LitElement {
       outline: none;
       background: transparent;
       text-align: center;
-      color: var(--yalo-chat-numeric-text-color);
-      font-size: var(--yalo-chat-numeric-font-size);
+      color: var(--yalo-chat-numeric-text-color, #111111);
+      font-size: var(--yalo-chat-numeric-font-size, 0.875rem);
       font-family: inherit;
     }
   `;

--- a/web-sdk/src/ui/chat/chat-message-list/product-card.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/product-card.ts
@@ -21,28 +21,13 @@ export type ProductCardCartState = 'not-added' | 'in-cart' | 'modified';
 export class ProductCard extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-product-title-color: #111111;
-      --yalo-chat-product-subunits-color: #7c8086;
-      --yalo-chat-product-image-radius: 0.125em;
-      --yalo-chat-product-gap: 0.5rem;
-      --yalo-chat-product-title-size: 1rem;
-      --yalo-chat-product-subunits-size: 0.875rem;
-      --yalo-chat-product-card-button-background: #111111;
-      --yalo-chat-product-card-button-color: #ffffff;
-      --yalo-chat-product-card-button-background-clicked: #0b996d;
-      --yalo-chat-product-card-button-color-clicked: #ffffff;
-      --yalo-chat-product-card-button-border: none;
-      --yalo-chat-product-card-button-border-radius: 0.5rem;
-      --yalo-chat-product-card-button-padding: 0.5rem;
-      --yalo-chat-product-card-button-font-size: 0.875rem;
-      --yalo-chat-product-card-button-icon-font-size: 1rem;
       display: block;
       width: 100%;
     }
 
     .card {
       display: flex;
-      gap: var(--yalo-chat-product-gap);
+      gap: var(--yalo-chat-product-gap, 0.5rem);
     }
 
     .card.horizontal {
@@ -55,7 +40,7 @@ export class ProductCard extends LitElement {
     }
 
     .image-wrap {
-      border-radius: var(--yalo-chat-product-image-radius);
+      border-radius: var(--yalo-chat-product-image-radius, 0.125em);
       overflow: hidden;
       background: #f1f3f6;
       flex-shrink: 0;
@@ -96,15 +81,15 @@ export class ProductCard extends LitElement {
     }
 
     .title {
-      font-size: var(--yalo-chat-product-title-size);
+      font-size: var(--yalo-chat-product-title-size, 1rem);
       font-weight: 600;
-      color: var(--yalo-chat-product-title-color);
+      color: var(--yalo-chat-product-title-color, #111111);
       word-break: break-word;
     }
 
     .subunits {
-      font-size: var(--yalo-chat-product-subunits-size);
-      color: var(--yalo-chat-product-subunits-color);
+      font-size: var(--yalo-chat-product-subunits-size, 0.875rem);
+      color: var(--yalo-chat-product-subunits-color, #7c8086);
     }
 
     .quantities {
@@ -120,23 +105,23 @@ export class ProductCard extends LitElement {
       justify-content: center;
       gap: 0.25rem;
       margin-top: 0.5rem;
-      padding: var(--yalo-chat-product-card-button-padding);
-      border: var(--yalo-chat-product-card-button-border);
-      border-radius: var(--yalo-chat-product-card-button-border-radius);
-      background: var(--yalo-chat-product-card-button-background);
-      color: var(--yalo-chat-product-card-button-color);
-      font-size: var(--yalo-chat-product-card-button-font-size);
+      padding: var(--yalo-chat-product-card-button-padding, 0.5rem);
+      border: var(--yalo-chat-product-card-button-border, none);
+      border-radius: var(--yalo-chat-product-card-button-border-radius, 0.5rem);
+      background: var(--yalo-chat-product-card-button-background, #111111);
+      color: var(--yalo-chat-product-card-button-color, #ffffff);
+      font-size: var(--yalo-chat-product-card-button-font-size, 0.875rem);
       cursor: pointer;
       word-break: break-word;
     }
 
     .cart-button.in-cart {
-      background: var(--yalo-chat-product-card-button-background-clicked);
-      color: var(--yalo-chat-product-card-button-color-clicked);
+      background: var(--yalo-chat-product-card-button-background-clicked, #0b996d);
+      color: var(--yalo-chat-product-card-button-color-clicked, #ffffff);
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-product-card-button-icon-font-size);
+      font-size: var(--yalo-chat-product-card-button-icon-font-size, 1rem);
       font-family: 'Material Symbols Outlined';
     }
   `;

--- a/web-sdk/src/ui/chat/chat-message-list/product-confirmation-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/product-confirmation-message.ts
@@ -13,27 +13,6 @@ import ProductConfirmationMessageController from './product-confirmation-message
 export class ProductConfirmationMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-product-confirmation-background: #ffffff;
-      --yalo-chat-product-confirmation-border-color: #dde4ec;
-      --yalo-chat-product-confirmation-border-radius: 1rem;
-      --yalo-chat-product-confirmation-box-shadow: 0 4.396px 8px 0
-        rgba(0, 0, 0, 0.06);
-      --yalo-chat-product-confirmation-padding: 1rem;
-      --yalo-chat-product-confirmation-gap: 0.75rem;
-      --yalo-chat-product-confirmation-title-color: #111111;
-      --yalo-chat-product-confirmation-title-font-weight: bold;
-      --yalo-chat-product-confirmation-body-color: #111111;
-      --yalo-chat-product-confirmation-button-background: #111111;
-      --yalo-chat-product-confirmation-button-color: #ffffff;
-      --yalo-chat-product-confirmation-button-background-clicked: #0b996d;
-      --yalo-chat-product-confirmation-button-color-clicked: #ffffff;
-      --yalo-chat-product-confirmation-button-border: none;
-      --yalo-chat-product-confirmation-button-border-radius: 0.5rem;
-      --yalo-chat-product-confirmation-button-padding: 0.5rem;
-      --yalo-chat-product-confirmation-button-font-size: 0.875rem;
-      --yalo-chat-product-confirmation-footer-color: #444444;
-      --yalo-chat-product-confirmation-footer-font-size: 0.875rem;
-      --yalo-chat-product-confirmation-icon-font-size: 1rem;
       display: block;
       width: 100%;
     }
@@ -41,23 +20,30 @@ export class ProductConfirmationMessage extends LitElement {
     .card {
       display: flex;
       flex-direction: column;
-      gap: var(--yalo-chat-product-confirmation-gap);
-      padding: var(--yalo-chat-product-confirmation-padding);
-      background: var(--yalo-chat-product-confirmation-background);
-      border: 1px solid var(--yalo-chat-product-confirmation-border-color);
-      border-radius: var(--yalo-chat-product-confirmation-border-radius);
-      box-shadow: var(--yalo-chat-product-confirmation-box-shadow);
+      gap: var(--yalo-chat-product-confirmation-gap, 0.75rem);
+      padding: var(--yalo-chat-product-confirmation-padding, 1rem);
+      background: var(--yalo-chat-product-confirmation-background, #ffffff);
+      border: 1px solid
+        var(--yalo-chat-product-confirmation-border-color, #dde4ec);
+      border-radius: var(--yalo-chat-product-confirmation-border-radius, 1rem);
+      box-shadow: var(
+        --yalo-chat-product-confirmation-box-shadow,
+        0 4.396px 8px 0 rgba(0, 0, 0, 0.06)
+      );
       box-sizing: border-box;
     }
 
     .title {
-      color: var(--yalo-chat-product-confirmation-title-color);
-      font-weight: var(--yalo-chat-product-confirmation-title-font-weight);
+      color: var(--yalo-chat-product-confirmation-title-color, #111111);
+      font-weight: var(
+        --yalo-chat-product-confirmation-title-font-weight,
+        bold
+      );
       word-break: break-word;
     }
 
     .body {
-      color: var(--yalo-chat-product-confirmation-body-color);
+      color: var(--yalo-chat-product-confirmation-body-color, #111111);
       word-break: break-word;
     }
 
@@ -66,26 +52,39 @@ export class ProductConfirmationMessage extends LitElement {
       align-items: center;
       justify-content: center;
       gap: 0.25rem;
-      padding: var(--yalo-chat-product-confirmation-button-padding);
-      border: var(--yalo-chat-product-confirmation-button-border);
-      border-radius: var(--yalo-chat-product-confirmation-button-border-radius);
-      background: var(--yalo-chat-product-confirmation-button-background);
-      color: var(--yalo-chat-product-confirmation-button-color);
-      font-size: var(--yalo-chat-product-confirmation-button-font-size);
+      padding: var(--yalo-chat-product-confirmation-button-padding, 0.5rem);
+      border: var(--yalo-chat-product-confirmation-button-border, none);
+      border-radius: var(
+        --yalo-chat-product-confirmation-button-border-radius,
+        0.5rem
+      );
+      background: var(
+        --yalo-chat-product-confirmation-button-background,
+        #111111
+      );
+      color: var(--yalo-chat-product-confirmation-button-color, #ffffff);
+      font-size: var(
+        --yalo-chat-product-confirmation-button-font-size,
+        0.875rem
+      );
       cursor: pointer;
       word-break: break-word;
     }
 
     .button.clicked {
       background: var(
-        --yalo-chat-product-confirmation-button-background-clicked
+        --yalo-chat-product-confirmation-button-background-clicked,
+        #0b996d
       );
-      color: var(--yalo-chat-product-confirmation-button-color-clicked);
+      color: var(
+        --yalo-chat-product-confirmation-button-color-clicked,
+        #ffffff
+      );
       cursor: default;
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-product-confirmation-icon-font-size);
+      font-size: var(--yalo-chat-product-confirmation-icon-font-size, 1rem);
       font-family: 'Material Symbols Outlined';
     }
 
@@ -94,8 +93,11 @@ export class ProductConfirmationMessage extends LitElement {
       background: none;
       border: none;
       padding: 0;
-      color: var(--yalo-chat-product-confirmation-footer-color);
-      font-size: var(--yalo-chat-product-confirmation-footer-font-size);
+      color: var(--yalo-chat-product-confirmation-footer-color, #444444);
+      font-size: var(
+        --yalo-chat-product-confirmation-footer-font-size,
+        0.875rem
+      );
       text-decoration: underline;
       cursor: pointer;
       word-break: break-word;

--- a/web-sdk/src/ui/chat/chat-message-list/product-message-price.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/product-message-price.ts
@@ -11,14 +11,6 @@ import { customElement, property } from 'lit/decorators.js';
 export class ProductMessagePrice extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-product-price-background: #eef2f7;
-      --yalo-chat-product-price-color: #111111;
-      --yalo-chat-product-price-strike-color: #7c8086;
-      --yalo-chat-product-price-per-subunit-color: #7c8086;
-      --yalo-chat-product-price-padding: 0.3125em;
-      --yalo-chat-product-price-radius: 2.0625em;
-      --yalo-chat-product-price-gap: 0.5em;
-      --yalo-chat-product-price-font-size: 0.875rem;
       display: block;
       overflow-x: auto;
     }
@@ -26,30 +18,30 @@ export class ProductMessagePrice extends LitElement {
     .row {
       display: flex;
       align-items: center;
-      gap: var(--yalo-chat-product-price-gap);
-      font-size: var(--yalo-chat-product-price-font-size);
+      gap: var(--yalo-chat-product-price-gap, 0.5em);
+      font-size: var(--yalo-chat-product-price-font-size, 0.875rem);
     }
 
     .pill {
       display: inline-flex;
       align-items: center;
       gap: 0.25em;
-      padding: var(--yalo-chat-product-price-padding)
-        calc(var(--yalo-chat-product-price-padding) * 2);
-      background: var(--yalo-chat-product-price-background);
-      color: var(--yalo-chat-product-price-color);
-      border-radius: var(--yalo-chat-product-price-radius);
+      padding: var(--yalo-chat-product-price-padding, 0.3125em)
+        calc(var(--yalo-chat-product-price-padding, 0.3125em) * 2);
+      background: var(--yalo-chat-product-price-background, #eef2f7);
+      color: var(--yalo-chat-product-price-color, #111111);
+      border-radius: var(--yalo-chat-product-price-radius, 2.0625em);
       font-weight: 600;
     }
 
     .strike {
-      color: var(--yalo-chat-product-price-strike-color);
+      color: var(--yalo-chat-product-price-strike-color, #7c8086);
       text-decoration: line-through;
       font-weight: 400;
     }
 
     .per-subunit {
-      color: var(--yalo-chat-product-price-per-subunit-color);
+      color: var(--yalo-chat-product-price-per-subunit-color, #7c8086);
     }
   `;
 

--- a/web-sdk/src/ui/chat/chat-message-list/product-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/product-message.ts
@@ -15,18 +15,12 @@ const COLLAPSED_MAX_ITEMS = 3;
 export class ProductMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-product-message-card-background: #ffffff;
-      --yalo-chat-product-message-card-border-color: #dde4ec;
-      --yalo-chat-product-message-card-radius: 1rem;
-      --yalo-chat-product-message-card-padding: 1rem;
-      --yalo-chat-product-message-gap: 1rem;
-      --yalo-chat-product-message-expand-color: #2207f1;
       display: block;
     }
 
     .list {
       display: flex;
-      gap: var(--yalo-chat-product-message-gap);
+      gap: var(--yalo-chat-product-message-gap, 1rem);
     }
 
     .list.vertical {
@@ -41,10 +35,10 @@ export class ProductMessage extends LitElement {
     }
 
     .item {
-      background: var(--yalo-chat-product-message-card-background);
-      border: 1px solid var(--yalo-chat-product-message-card-border-color);
-      border-radius: var(--yalo-chat-product-message-card-radius);
-      padding: var(--yalo-chat-product-message-card-padding);
+      background: var(--yalo-chat-product-message-card-background, #ffffff);
+      border: 1px solid var(--yalo-chat-product-message-card-border-color, #dde4ec);
+      border-radius: var(--yalo-chat-product-message-card-radius, 1rem);
+      padding: var(--yalo-chat-product-message-card-padding, 1rem);
       box-sizing: border-box;
     }
 
@@ -63,7 +57,7 @@ export class ProductMessage extends LitElement {
       border: none;
       padding: 0.5rem;
       cursor: pointer;
-      color: var(--yalo-chat-product-message-expand-color);
+      color: var(--yalo-chat-product-message-expand-color, #2207f1);
       font-size: 0.875rem;
       font-weight: 600;
     }

--- a/web-sdk/src/ui/chat/chat-message-list/user-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/user-message.ts
@@ -20,10 +20,6 @@ import './attachment-message';
 export class UserMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-user-message-error-color: #a01600;
-      --yalo-chat-user-message-error-text-color: #461a1a;
-      --yalo-chat-user-message-icon-font-size: 1.25rem;
-      --yalo-chat-bubble-padding: 0.5rem 0.75rem;
       display: flex;
       justify-content: flex-end;
       margin: 0.25rem 0.5rem;
@@ -46,7 +42,7 @@ export class UserMessage extends LitElement {
 
     .error-icon {
       flex-shrink: 0;
-      color: var(--yalo-chat-user-message-error-color);
+      color: var(--yalo-chat-user-message-error-color, #a01600);
       font-size: 1.25rem;
       display: flex;
       align-items: center;
@@ -54,14 +50,14 @@ export class UserMessage extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-user-message-icon-font-size);
+      font-size: var(--yalo-chat-user-message-icon-font-size, 1.25rem);
       font-family: 'Material Symbols Outlined';
       font-variation-settings: 'FILL' 1;
     }
 
     .error-label {
       font-size: 0.75rem;
-      color: var(--yalo-chat-user-message-error-text-color);
+      color: var(--yalo-chat-user-message-error-text-color, #461a1a);
       margin-top: 0.25rem;
       align-self: flex-end;
     }
@@ -73,7 +69,7 @@ export class UserMessage extends LitElement {
 
     .bubble {
       max-width: 80%;
-      padding: var(--yalo-chat-bubble-padding);
+      padding: var(--yalo-chat-bubble-padding, 0.5rem 0.75rem);
       border-radius: 1.125rem;
       border-bottom-right-radius: 0.25rem;
       background: var(--yalo-chat-user-message-background, #f9fafc);
@@ -88,7 +84,7 @@ export class UserMessage extends LitElement {
 
     .voice-bubble {
       width: 60%;
-      padding: var(--yalo-chat-bubble-padding);
+      padding: var(--yalo-chat-bubble-padding, 0.5rem 0.75rem);
       border-radius: 1.125rem;
       border-bottom-right-radius: 0.25rem;
       background: var(--yalo-chat-user-message-background, #f9fafc);

--- a/web-sdk/src/ui/chat/chat-message-list/voice-message.ts
+++ b/web-sdk/src/ui/chat/chat-message-list/voice-message.ts
@@ -13,7 +13,6 @@ import '@ui/chat/waveform-painter/waveform-painter';
 export class VoiceMessage extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-voice-message-icon-font-size: 1.5rem;
       display: block;
     }
 
@@ -38,7 +37,7 @@ export class VoiceMessage extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-voice-message-icon-font-size);
+      font-size: var(--yalo-chat-voice-message-icon-font-size, 1.5rem);
       font-family: 'Material Symbols Outlined';
     }
 

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
@@ -35,16 +35,9 @@ import { setLocale } from '@i18n/index';
 export class YaloChatWindow extends LitElement {
   static styles = css`
     :host {
-      --yalo-chat-background: #ffffff;
-      --yalo-chat-corner-radius: 12px;
-      --yalo-chat-font: sans-serif;
-      --yalo-chat-column-item-space: 8px;
-      --yalo-chat-row-item-space: 8px;
-      --yalo-chat-width: auto;
-      --yalo-chat-height: auto;
       display: none;
-      width: var(--yalo-chat-width);
-      height: var(--yalo-chat-height);
+      width: var(--yalo-chat-width, auto);
+      height: var(--yalo-chat-height, auto);
     }
 
     :host([open]) {
@@ -54,9 +47,9 @@ export class YaloChatWindow extends LitElement {
     .chat-window {
       width: 100%;
       height: 100%;
-      background: var(--yalo-chat-background);
-      border-radius: var(--yalo-chat-corner-radius);
-      font-family: var(--yalo-chat-font);
+      background: var(--yalo-chat-background, #ffffff);
+      border-radius: var(--yalo-chat-corner-radius, 12px);
+      font-family: var(--yalo-chat-font, sans-serif);
       display: flex;
       flex-direction: column;
       overflow: hidden;

--- a/web-sdk/src/ui/chat/waveform-painter/waveform-painter.ts
+++ b/web-sdk/src/ui/chat/waveform-painter/waveform-painter.ts
@@ -14,17 +14,10 @@ import { WaveformPainterController } from './waveform-painter-controller';
 @localized()
 export class WaveformPainter extends LitElement {
   static styles = css`
-    :host {
-      --yalo-chat-waveform-color: #2207f1;
-      --yalo-chat-waveform-close-button-color: #7c8086;
-      --yalo-chat-waveform-timer-color: #7c8086;
-      --yalo-chat-waveform-icon-font-size: 1.5em;
-    }
-
     .waveform-recorder {
       display: flex;
       flex-direction: row;
-      gap: var(--yalo-chat-row-item-space);
+      gap: var(--yalo-chat-row-item-space, 8px);
     }
 
     .waveform-canvas {
@@ -38,7 +31,7 @@ export class WaveformPainter extends LitElement {
       border: none;
       outline: none;
       background: none;
-      color: var(--yalo-chat-waveform-close-button-color);
+      color: var(--yalo-chat-waveform-close-button-color, #7c8086);
       display: flex;
       align-items: center;
       justify-content: center;
@@ -48,12 +41,12 @@ export class WaveformPainter extends LitElement {
     }
 
     .material-symbols-outlined {
-      font-size: var(--yalo-chat-waveform-icon-font-size);
+      font-size: var(--yalo-chat-waveform-icon-font-size, 1.5em);
       font-family: 'Material Symbols Outlined';
     }
 
     .recording-time {
-      color: var(--yalo-chat-waveform-timer-color);
+      color: var(--yalo-chat-waveform-timer-color, #7c8086);
       display: flex;
       align-items: center;
       margin-left: 0.5rem;


### PR DESCRIPTION
FIX: Theme variables are now overridable via :root for web-sdk so you don’t need to target web components via CSS.