### PR TITLE
feat: Better performance for big conversations

### DIFF
--- a/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.test.ts
+++ b/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.test.ts
@@ -7,7 +7,8 @@ import { ChatMessageRepositoryLocal } from './chat-message-repository-local';
 import { TokenRepositoryLocal } from '@data/repositories/token/token-repository-local';
 
 const DB_NAME = 'YaloChatMessages';
-const DB_VERSION = 2;
+const DB_VERSION = 1;
+const SESSION_ID = 'org-1-channel-1-user-1';
 
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -49,7 +50,7 @@ describe('ChatMessageRepositoryLocal', () => {
 
   beforeEach(async () => {
     db = await openDb();
-    repo = new ChatMessageRepositoryLocal(db);
+    repo = new ChatMessageRepositoryLocal(db, SESSION_ID);
   });
 
   afterEach(async () => {
@@ -199,26 +200,27 @@ describe('ChatMessageRepositoryLocal', () => {
       );
     });
 
-    it('returns messages in descending timestamp order', async () => {
-      await repo.insertChatMessage(
+    it('returns messages newest-inserted first regardless of timestamp', async () => {
+      const a = await repo.insertChatMessage(
         makeMessage({ timestamp: new Date('2024-01-01T09:00:00Z') })
       );
-      await repo.insertChatMessage(
+      const b = await repo.insertChatMessage(
         makeMessage({ timestamp: new Date('2024-01-01T11:00:00Z') })
       );
-      await repo.insertChatMessage(
+      const c = await repo.insertChatMessage(
         makeMessage({ timestamp: new Date('2024-01-01T10:00:00Z') })
       );
 
       const result = await repo.getChatMessagePageDesc(null, 10);
-      const messages = (result as Ok<{ data: ChatMessage[] }>).value.data;
+      const ids = (result as Ok<{ data: ChatMessage[] }>).value.data.map(
+        (m) => m.id
+      );
 
-      expect(messages[0].timestamp.getTime()).toBeGreaterThanOrEqual(
-        messages[1].timestamp.getTime()
-      );
-      expect(messages[1].timestamp.getTime()).toBeGreaterThanOrEqual(
-        messages[2].timestamp.getTime()
-      );
+      expect(ids).toEqual([
+        (c as Ok<ChatMessage>).value.id,
+        (b as Ok<ChatMessage>).value.id,
+        (a as Ok<ChatMessage>).value.id,
+      ]);
     });
 
     it('respects pageSize', async () => {
@@ -296,6 +298,53 @@ describe('ChatMessageRepositoryLocal', () => {
     it('returns Err when the database is closed', async () => {
       db.close();
       const result = await repo.getChatMessagePageDesc(null, 10);
+      expect(result).toBeInstanceOf(Err);
+    });
+  });
+
+  describe('session isolation', () => {
+    it('only returns messages for the configured session', async () => {
+      const other = new ChatMessageRepositoryLocal(db, 'org-2-channel-2-user-2');
+      await repo.insertChatMessage(makeMessage({ content: 'mine' }));
+      await other.insertChatMessage(makeMessage({ content: 'theirs' }));
+
+      const result = await repo.getChatMessagePageDesc(null, 10);
+      const messages = (result as Ok<{ data: ChatMessage[] }>).value.data;
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('mine');
+    });
+
+    it('treats the same wiId as distinct across sessions', async () => {
+      const other = new ChatMessageRepositoryLocal(db, 'org-2-channel-2-user-2');
+      const first = await repo.insertChatMessage(
+        makeMessage({ wiId: 'wi-1', content: 'mine' })
+      );
+      const second = await other.insertChatMessage(
+        makeMessage({ wiId: 'wi-1', content: 'theirs' })
+      );
+
+      const firstId = (first as Ok<ChatMessage>).value.id;
+      const secondId = (second as Ok<ChatMessage>).value.id;
+      expect(secondId).not.toBe(firstId);
+    });
+
+    it('clearSession removes only the configured session messages', async () => {
+      const other = new ChatMessageRepositoryLocal(db, 'org-2-channel-2-user-2');
+      await repo.insertChatMessage(makeMessage({ content: 'mine' }));
+      await other.insertChatMessage(makeMessage({ content: 'theirs' }));
+
+      await repo.clearSession();
+
+      const mine = await repo.getChatMessagePageDesc(null, 10);
+      const theirs = await other.getChatMessagePageDesc(null, 10);
+      expect((mine as Ok<{ data: ChatMessage[] }>).value.data).toHaveLength(0);
+      expect((theirs as Ok<{ data: ChatMessage[] }>).value.data).toHaveLength(1);
+    });
+
+    it('clearSession returns Err when the database is closed', async () => {
+      db.close();
+      const result = await repo.clearSession();
       expect(result).toBeInstanceOf(Err);
     });
   });

--- a/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.ts
+++ b/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.ts
@@ -6,10 +6,6 @@ import { Err, Ok } from '@domain/common/result';
 import { ChatMessage } from '@domain/models/chat-message/chat-message';
 import type { ChatMessageRepository } from './chat-message-repository';
 
-type ChatMessageData = ConstructorParameters<typeof ChatMessage>[0] & {
-  id: number;
-};
-
 export class ChatMessageRepositoryLocal implements ChatMessageRepository {
   private static readonly _STORE_NAME = 'chatMessage';
 
@@ -19,15 +15,19 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
         ChatMessageRepositoryLocal._STORE_NAME,
         { keyPath: 'id', autoIncrement: true }
       );
-      store.createIndex('wiId', 'wiId', { unique: true });
-      store.createIndex('timestamp', 'timestamp', { unique: false });
+      store.createIndex('sessionId_wiId', ['sessionId', 'wiId'], {
+        unique: true,
+      });
+      store.createIndex('sessionId', 'sessionId', { unique: false });
     }
   }
 
-  private db: IDBDatabase;
+  private readonly db: IDBDatabase;
+  private readonly sessionId: string;
 
-  constructor(db: IDBDatabase) {
+  constructor(db: IDBDatabase, sessionId: string) {
     this.db = db;
+    this.sessionId = sessionId;
   }
 
   async dispose(): Promise<void> {
@@ -39,6 +39,7 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
     pageSize: number
   ): Promise<Result<Page<ChatMessage>>> {
     try {
+      const sessionId = this.sessionId;
       const db = this.db;
       const data = await new Promise<ChatMessage[]>((resolve, reject) => {
         const tx = db.transaction(
@@ -46,11 +47,14 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
           'readonly'
         );
         const store = tx.objectStore(ChatMessageRepositoryLocal._STORE_NAME);
-        const index = store.index('timestamp');
+        const index = store.index('sessionId');
         const results: ChatMessage[] = [];
-        let skipping = cursor !== null;
+        let seeked = cursor === null;
 
-        const request = index.openCursor(null, 'prev');
+        const request = index.openCursor(
+          IDBKeyRange.only(sessionId),
+          'prev'
+        );
 
         request.onsuccess = () => {
           const idbCursor = request.result;
@@ -59,16 +63,19 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
             return;
           }
 
-          const record = idbCursor.value as ChatMessageData;
+          if (!seeked) {
+            seeked = true;
+            idbCursor.continuePrimaryKey(sessionId, cursor!);
+            return;
+          }
 
-          if (skipping) {
-            if (record.id === cursor) skipping = false;
+          if (idbCursor.primaryKey === cursor) {
             idbCursor.continue();
             return;
           }
 
           if (results.length < pageSize + 1) {
-            results.push(new ChatMessage(record));
+            results.push(idbCursor.value as ChatMessage);
             idbCursor.continue();
           } else {
             resolve(results);
@@ -93,9 +100,11 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
 
   async insertChatMessage(message: ChatMessage): Promise<Result<ChatMessage>> {
     try {
+      const sessionId = this.sessionId;
       const db = this.db;
       const { ...data } = message;
       delete data.id;
+      const record = { ...data, sessionId };
       const id = await new Promise<number>((resolve, reject) => {
         const tx = db.transaction(
           ChatMessageRepositoryLocal._STORE_NAME,
@@ -103,21 +112,23 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
         );
         const store = tx.objectStore(ChatMessageRepositoryLocal._STORE_NAME);
 
-        if (data.wiId === undefined) {
-          const addReq = store.add(data);
+        if (record.wiId === undefined) {
+          const addReq = store.add(record);
           addReq.onsuccess = () => resolve(addReq.result as number);
           addReq.onerror = () => reject(addReq.error);
           return;
         }
 
-        const existingReq = store.index('wiId').get(data.wiId);
+        const existingReq = store
+          .index('sessionId_wiId')
+          .get([sessionId, record.wiId]);
         existingReq.onsuccess = () => {
-          const existing = existingReq.result as ChatMessageData | undefined;
+          const existing = existingReq.result as ChatMessage | undefined;
           if (existing) {
-            resolve(existing.id);
+            resolve(existing.id!);
             return;
           }
-          const addReq = store.add(data);
+          const addReq = store.add(record);
           addReq.onsuccess = () => resolve(addReq.result as number);
           addReq.onerror = () => reject(addReq.error);
         };
@@ -135,6 +146,7 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
       return new Err(new Error('Message must contain an id to replace'));
     }
     try {
+      const sessionId = this.sessionId;
       const db = this.db;
       await new Promise<void>((resolve, reject) => {
         const tx = db.transaction(
@@ -142,11 +154,40 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
           'readwrite'
         );
         const store = tx.objectStore(ChatMessageRepositoryLocal._STORE_NAME);
-        const request = store.put({ ...message });
+        const request = store.put({ ...message, sessionId });
         request.onsuccess = () => resolve();
         request.onerror = () => reject(request.error);
       });
 
+      return new Ok(true);
+    } catch (e) {
+      return new Err(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
+  async clearSession(): Promise<Result<boolean>> {
+    try {
+      const sessionId = this.sessionId;
+      const db = this.db;
+      await new Promise<void>((resolve, reject) => {
+        const tx = db.transaction(
+          ChatMessageRepositoryLocal._STORE_NAME,
+          'readwrite'
+        );
+        const store = tx.objectStore(ChatMessageRepositoryLocal._STORE_NAME);
+        const index = store.index('sessionId');
+        const request = index.openCursor(IDBKeyRange.only(sessionId));
+        request.onsuccess = () => {
+          const cursor = request.result;
+          if (!cursor) {
+            resolve();
+            return;
+          }
+          cursor.delete();
+          cursor.continue();
+        };
+        request.onerror = () => reject(request.error);
+      });
       return new Ok(true);
     } catch (e) {
       return new Err(e instanceof Error ? e : new Error(String(e)));

--- a/web-sdk/src/data/repositories/chat-message/chat-message-repository.ts
+++ b/web-sdk/src/data/repositories/chat-message/chat-message-repository.ts
@@ -18,6 +18,9 @@ export interface ChatMessageRepository {
   // Replaces an existing message by id.
   replaceChatMessage(message: ChatMessage): Promise<Result<boolean>>;
 
+  // Deletes all messages belonging to the current session.
+  clearSession(): Promise<Result<boolean>>;
+
   // Releases the underlying storage resources held by the repository.
   dispose(): Promise<void>;
 }

--- a/web-sdk/src/data/repositories/token/token-repository-local.test.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.test.ts
@@ -6,7 +6,8 @@ import type { YaloMessageAuthService } from '@data/services/yalo-message/yalo-me
 import { TokenRepositoryLocal } from './token-repository-local';
 
 const DB_NAME = 'YaloChatMessages';
-const DB_VERSION = 2;
+const DB_VERSION = 1;
+const SESSION_ID = 'org-1-channel-1-user-1';
 
 function openDb(): Promise<IDBDatabase> {
   return new Promise((resolve, reject) => {
@@ -64,7 +65,7 @@ describe('TokenRepositoryLocal', () => {
   describe('getToken', () => {
     it('fetches a token when store is empty', async () => {
       const authService = makeAuthService();
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       const result = await repo.getToken();
 
@@ -75,7 +76,7 @@ describe('TokenRepositoryLocal', () => {
 
     it('returns cached token when still valid', async () => {
       const authService = makeAuthService();
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       await repo.getToken();
       const result = await repo.getToken();
@@ -86,13 +87,13 @@ describe('TokenRepositoryLocal', () => {
     });
 
     it('persists token to IndexedDB', async () => {
-      const repo = new TokenRepositoryLocal(db, makeAuthService());
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, makeAuthService());
 
       await repo.getToken();
 
       // A second repo instance with a fresh auth service reads the cached token
       const freshAuthService = makeAuthService();
-      const repo2 = new TokenRepositoryLocal(db, freshAuthService);
+      const repo2 = new TokenRepositoryLocal(db, SESSION_ID, freshAuthService);
       const result = await repo2.getToken();
 
       expect(result.ok).toBe(true);
@@ -106,7 +107,7 @@ describe('TokenRepositoryLocal', () => {
           new Ok(makeAuthResponse({ accessToken: 'refreshed-token' }))
         ),
       });
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       await repo.getToken();
       vi.advanceTimersByTime(3601 * 1000);
@@ -125,7 +126,7 @@ describe('TokenRepositoryLocal', () => {
           new Ok(makeAuthResponse({ accessToken: 'refreshed-token', refreshToken: 'new-refresh' }))
         ),
       });
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       await repo.getToken();
       vi.advanceTimersByTime(3601 * 1000);
@@ -133,7 +134,7 @@ describe('TokenRepositoryLocal', () => {
 
       // Verify updated token is persisted by reading with a new instance
       const freshAuthService = makeAuthService();
-      const result = await new TokenRepositoryLocal(db, freshAuthService).getToken();
+      const result = await new TokenRepositoryLocal(db, SESSION_ID, freshAuthService).getToken();
 
       expect(result.ok).toBe(true);
       if (result.ok) expect(result.value).toBe('refreshed-token');
@@ -145,7 +146,7 @@ describe('TokenRepositoryLocal', () => {
         refreshToken: vi.fn().mockResolvedValue(new Err(new Error('Refresh failed: 403'))),
         fetchToken: vi.fn().mockResolvedValue(new Ok(makeAuthResponse({ accessToken: 'fresh-token' }))),
       });
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       await repo.getToken();
       vi.advanceTimersByTime(3601 * 1000);
@@ -162,7 +163,7 @@ describe('TokenRepositoryLocal', () => {
       const authService = makeAuthService({
         refreshToken: vi.fn().mockResolvedValue(new Err(new Error('Refresh failed: 403'))),
       });
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       await repo.getToken();
       vi.advanceTimersByTime(3601 * 1000);
@@ -177,7 +178,7 @@ describe('TokenRepositoryLocal', () => {
           .fn()
           .mockResolvedValue(new Err(new Error('Auth failed: 401'))),
       });
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
 
       const result = await repo.getToken();
 
@@ -189,12 +190,64 @@ describe('TokenRepositoryLocal', () => {
 
     it('returns Err when the underlying IndexedDB connection is closed', async () => {
       const authService = makeAuthService();
-      const repo = new TokenRepositoryLocal(db, authService);
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, authService);
       db.close();
 
       const result = await repo.getToken();
 
       expect(result).toMatchObject({ ok: false });
+    });
+  });
+
+  describe('session isolation', () => {
+    it('does not share tokens across sessions', async () => {
+      const mineAuth = makeAuthService({
+        fetchToken: vi
+          .fn()
+          .mockResolvedValue(new Ok(makeAuthResponse({ accessToken: 'mine' }))),
+      });
+      const theirsAuth = makeAuthService({
+        fetchToken: vi
+          .fn()
+          .mockResolvedValue(new Ok(makeAuthResponse({ accessToken: 'theirs' }))),
+      });
+      const mine = new TokenRepositoryLocal(db, SESSION_ID, mineAuth);
+      const theirs = new TokenRepositoryLocal(db, 'other-session', theirsAuth);
+
+      const mineResult = await mine.getToken();
+      const theirsResult = await theirs.getToken();
+
+      expect(mineResult).toMatchObject({ ok: true, value: 'mine' });
+      expect(theirsResult).toMatchObject({ ok: true, value: 'theirs' });
+      expect(mineAuth.fetchToken).toHaveBeenCalledOnce();
+      expect(theirsAuth.fetchToken).toHaveBeenCalledOnce();
+    });
+
+    it('clearSession returns Err when the database is closed', async () => {
+      const repo = new TokenRepositoryLocal(db, SESSION_ID, makeAuthService());
+      db.close();
+      const result = await repo.clearSession();
+      expect(result).toMatchObject({ ok: false });
+    });
+
+    it('clearSession only removes the configured session token', async () => {
+      const mine = new TokenRepositoryLocal(db, SESSION_ID, makeAuthService());
+      const theirsAuth = makeAuthService();
+      const theirs = new TokenRepositoryLocal(db, 'other-session', theirsAuth);
+      await mine.getToken();
+      await theirs.getToken();
+
+      await mine.clearSession();
+
+      const freshTheirsAuth = makeAuthService();
+      const freshTheirs = new TokenRepositoryLocal(
+        db,
+        'other-session',
+        freshTheirsAuth
+      );
+      await freshTheirs.getToken();
+
+      expect(freshTheirsAuth.fetchToken).not.toHaveBeenCalled();
     });
   });
 });

--- a/web-sdk/src/data/repositories/token/token-repository-local.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.ts
@@ -4,8 +4,6 @@ import { Err, Ok, type Result } from '@domain/common/result';
 import type { YaloMessageAuthService } from '@data/services/yalo-message/yalo-message-auth-service';
 import type { TokenRepository } from './token-repository';
 
-const TOKEN_KEY = 'token';
-
 interface StoredToken {
   accessToken: string;
   refreshToken: string;
@@ -23,10 +21,16 @@ export class TokenRepositoryLocal implements TokenRepository {
 
   private readonly _db: IDBDatabase;
   private readonly _authService: YaloMessageAuthService;
+  private readonly _key: string;
 
-  constructor(db: IDBDatabase, authService: YaloMessageAuthService) {
+  constructor(
+    db: IDBDatabase,
+    sessionId: string,
+    authService: YaloMessageAuthService
+  ) {
     this._db = db;
     this._authService = authService;
+    this._key = `token:${sessionId}`;
   }
 
   async getToken(): Promise<Result<string>> {
@@ -63,11 +67,20 @@ export class TokenRepositoryLocal implements TokenRepository {
     }
   }
 
+  async clearSession(): Promise<Result<boolean>> {
+    try {
+      await this._clear();
+      return new Ok(true);
+    } catch (e) {
+      return new Err(e instanceof Error ? e : new Error(String(e)));
+    }
+  }
+
   private _read(): Promise<StoredToken | null> {
     return new Promise((resolve, reject) => {
       const tx = this._db.transaction(TokenRepositoryLocal._STORE_NAME, 'readonly');
       const store = tx.objectStore(TokenRepositoryLocal._STORE_NAME);
-      const request = store.get(TOKEN_KEY);
+      const request = store.get(this._key);
       request.onsuccess = () => resolve((request.result as StoredToken) ?? null);
       request.onerror = () => reject(request.error);
     });
@@ -82,7 +95,7 @@ export class TokenRepositoryLocal implements TokenRepository {
         refreshToken: data.refreshToken,
         expiresAt: Date.now() + data.expiresIn * 1000,
       };
-      const request = store.put(record, TOKEN_KEY);
+      const request = store.put(record, this._key);
       request.onsuccess = () => resolve();
       request.onerror = () => reject(request.error);
     });
@@ -92,7 +105,7 @@ export class TokenRepositoryLocal implements TokenRepository {
     return new Promise((resolve, reject) => {
       const tx = this._db.transaction(TokenRepositoryLocal._STORE_NAME, 'readwrite');
       const store = tx.objectStore(TokenRepositoryLocal._STORE_NAME);
-      const request = store.delete(TOKEN_KEY);
+      const request = store.delete(this._key);
       request.onsuccess = () => resolve();
       request.onerror = () => reject(request.error);
     });

--- a/web-sdk/src/data/repositories/token/token-repository.ts
+++ b/web-sdk/src/data/repositories/token/token-repository.ts
@@ -4,4 +4,7 @@ import type { Result } from '@domain/common/result';
 
 export interface TokenRepository {
   getToken(): Promise<Result<string>>;
+
+  // Deletes the stored token for the current session.
+  clearSession(): Promise<Result<boolean>>;
 }

--- a/web-sdk/src/data/services/yalo-media/yalo-media-service-remote.test.ts
+++ b/web-sdk/src/data/services/yalo-media/yalo-media-service-remote.test.ts
@@ -7,6 +7,7 @@ import type { TokenRepository } from '@data/repositories/token/token-repository'
 
 const makeTokenRepository = (token = 'test-token'): TokenRepository => ({
   getToken: vi.fn().mockResolvedValue(new Ok(token)),
+  clearSession: vi.fn().mockResolvedValue(new Ok(true)),
 });
 
 const makeUploadResponse = () => ({
@@ -111,6 +112,7 @@ describe('YaloMediaServiceRemote', () => {
         getToken: vi
           .fn()
           .mockResolvedValue(new Err(new Error('auth failed'))),
+        clearSession: vi.fn().mockResolvedValue(new Ok(true)),
       };
 
       const service = new YaloMediaServiceRemote(

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-https.test.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-https.test.ts
@@ -40,10 +40,12 @@ const makeToken = (userId: string) => {
 
 const okTokenRepository = (token: string): TokenRepository => ({
   getToken: vi.fn().mockResolvedValue(new Ok(token)),
+  clearSession: vi.fn().mockResolvedValue(new Ok(true)),
 });
 
 const failingTokenRepository = (): TokenRepository => ({
   getToken: vi.fn().mockResolvedValue(new Err(new Error('auth failed'))),
+  clearSession: vi.fn().mockResolvedValue(new Ok(true)),
 });
 
 const baseConfig = {

--- a/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
+++ b/web-sdk/src/data/services/yalo-message/yalo-message-service-websocket.test.ts
@@ -64,6 +64,7 @@ const makeTokenRepository = (
   result: Result<string> = new Ok('jwt.token.value')
 ): TokenRepository => ({
   getToken: vi.fn().mockResolvedValue(result),
+  clearSession: vi.fn().mockResolvedValue(new Ok(true)),
 });
 
 const makeTextMessage = (text: string): SdkMessage => ({

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -32,16 +32,20 @@ export default class YaloChatWindowController implements ReactiveController {
   private _guidanceCardRequested = false;
   private _messagesLoaded = false;
 
-  private readonly _DB_VERSION = 2;
+  private static readonly _DB_NAME = 'YaloChatMessages';
+  private static readonly _DB_VERSION = 1;
 
-  private get _dbName(): string {
+  private get _sessionId(): string {
     const { organizationId, channelId, userId } = this.host.config;
-    return `YaloChatMessages-${organizationId}-${channelId}-${userId ?? 'anonymous'}`;
+    return `${organizationId}-${channelId}-${userId ?? 'anonymous'}`;
   }
 
   private _openDb(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
-      const request = indexedDB.open(this._dbName, this._DB_VERSION);
+      const request = indexedDB.open(
+        YaloChatWindowController._DB_NAME,
+        YaloChatWindowController._DB_VERSION
+      );
 
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result;
@@ -54,40 +58,45 @@ export default class YaloChatWindowController implements ReactiveController {
     });
   }
 
-  private _deleteDb(): Promise<void> {
-    return new Promise((resolve, reject) => {
-      const request = indexedDB.deleteDatabase(this._dbName);
-      request.onsuccess = () => resolve();
-      request.onerror = () => reject(request.error);
-      request.onblocked = () => resolve();
-    });
-  }
-
   constructor(host: YaloChatWindow) {
     this.host = host;
     this.host.addController(this);
   }
 
   private _handleNonPersistentPageHide = () => {
-    this.host.chatMessageRepository.dispose();
+    const messageRepo = this.host.chatMessageRepository;
+    const tokenRepo = this._tokenRepository;
     this.host.yaloMessageRepository.unsubscribeMessages();
-    indexedDB.deleteDatabase(this._dbName);
+    Promise.all([messageRepo.clearSession(), tokenRepo?.clearSession()]).finally(
+      () => messageRepo.dispose()
+    );
   };
+
+  private _tokenRepository?: TokenRepositoryLocal;
 
   // Method used to create all new dependencies to be injected to all components
   async hostConnected() {
-    if (this.host.config.persistent === false) {
-      await this._deleteDb();
-      window.addEventListener('pagehide', this._handleNonPersistentPageHide);
-    }
+    const sessionId = this._sessionId;
     const db = await this._openDb();
-    this.host.chatMessageRepository = new ChatMessageRepositoryLocal(db);
+    this.host.chatMessageRepository = new ChatMessageRepositoryLocal(
+      db,
+      sessionId
+    );
 
     const authService = new YaloMessageAuthServiceRemote(
       import.meta.env.VITE_YALO_API_BASE_URL,
       this.host.config
     );
-    const tokenRepository = new TokenRepositoryLocal(db, authService);
+    const tokenRepository = new TokenRepositoryLocal(db, sessionId, authService);
+    this._tokenRepository = tokenRepository;
+
+    if (this.host.config.persistent === false) {
+      await Promise.all([
+        this.host.chatMessageRepository.clearSession(),
+        tokenRepository.clearSession(),
+      ]);
+      window.addEventListener('pagehide', this._handleNonPersistentPageHide);
+    }
     const mediaService = new YaloMediaServiceRemote(
       import.meta.env.VITE_YALO_API_BASE_URL,
       tokenRepository

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -82,7 +82,7 @@ const getSendButton = (el: YaloChatWindow): HTMLButtonElement =>
     '.chat-action-button'
   ) as unknown as HTMLButtonElement;
 
-const DB_NAME = `YaloChatMessages-${baseConfig.organizationId}-${baseConfig.channelId}-anonymous`;
+const DB_NAME = 'YaloChatMessages';
 
 const clearDb = (): Promise<void> =>
   new Promise((resolve, reject) => {
@@ -1217,65 +1217,11 @@ describe('YaloChatWindow persistent flag', () => {
     await clearDb();
   });
 
-  it('does not delete the local database when persistent is not set', async () => {
-    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
-    el.config = baseConfig;
-    document.body.appendChild(el);
-    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not delete the local database when persistent is true', async () => {
-    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
-    el.config = { ...baseConfig, persistent: true };
-    document.body.appendChild(el);
-    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-  });
-
-  it('deletes the local database before opening when persistent is false', async () => {
+  it('never deletes the shared database, even when persistent is false', async () => {
     const el = document.createElement('yalo-chat-window') as YaloChatWindow;
     el.config = { ...baseConfig, persistent: false };
     document.body.appendChild(el);
     await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-
-    expect(deleteSpy).toHaveBeenCalledWith(DB_NAME);
-  });
-
-  it('deletes the local database on pagehide when persistent is false', async () => {
-    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
-    el.config = { ...baseConfig, persistent: false };
-    document.body.appendChild(el);
-    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-    deleteSpy.mockClear();
-
-    window.dispatchEvent(new PageTransitionEvent('pagehide'));
-
-    expect(deleteSpy).toHaveBeenCalledWith(DB_NAME);
-  });
-
-  it('does not delete the local database on pagehide when persistent is true', async () => {
-    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
-    el.config = { ...baseConfig, persistent: true };
-    document.body.appendChild(el);
-    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-    deleteSpy.mockClear();
-
-    window.dispatchEvent(new PageTransitionEvent('pagehide'));
-
-    expect(deleteSpy).not.toHaveBeenCalled();
-  });
-
-  it('does not delete the local database on pagehide after the element is disconnected', async () => {
-    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
-    el.config = { ...baseConfig, persistent: false };
-    document.body.appendChild(el);
-    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
-    el.remove();
-    deleteSpy.mockClear();
-
     window.dispatchEvent(new PageTransitionEvent('pagehide'));
 
     expect(deleteSpy).not.toHaveBeenCalled();
@@ -1301,6 +1247,37 @@ describe('YaloChatWindow persistent flag', () => {
     await vi.waitUntil(() => fresh.yaloMessageRepository !== undefined);
 
     expect(getMessageList(fresh).chatMessages).toHaveLength(0);
+  });
+
+  it('keeps messages from other sessions intact when this session is non-persistent', async () => {
+    const otherConfig = { ...baseConfig, channelId: 'other-channel' };
+
+    const other = document.createElement('yalo-chat-window') as YaloChatWindow;
+    other.config = otherConfig;
+    document.body.appendChild(other);
+    await vi.waitUntil(() => other.yaloMessageRepository !== undefined);
+    await other.chatMessageRepository.insertChatMessage(
+      ChatMessage.text({
+        role: 'AGENT',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        content: 'theirs',
+      })
+    );
+    other.remove();
+
+    const mine = document.createElement('yalo-chat-window') as YaloChatWindow;
+    mine.config = { ...baseConfig, persistent: false };
+    document.body.appendChild(mine);
+    await vi.waitUntil(() => mine.yaloMessageRepository !== undefined);
+
+    const reopened = document.createElement(
+      'yalo-chat-window'
+    ) as YaloChatWindow;
+    reopened.config = otherConfig;
+    document.body.appendChild(reopened);
+    await vi.waitUntil(() => reopened.yaloMessageRepository !== undefined);
+
+    expect(getMessageList(reopened).chatMessages).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
- Moves to a single database with sessionId field + index, avoiding creating multiple databases and the overhead of it.
- Fixes slow pagination with big conversations using the autoincrement property of ids.