### PR TITLE
feat: Multi-session hash

### DIFF
--- a/web-sdk/README.md
+++ b/web-sdk/README.md
@@ -204,6 +204,7 @@ The target element referenced by `config.target` must exist in the DOM at the ti
 | `hideAttachmentButton` | `boolean` | No      | When `true`, the file attachment button is not rendered in the footer. Users cannot send images or files from the chat. |
 | `hideVoiceButton`    | `boolean`  | No       | When `true`, the microphone affordance is removed: the action button always shows the send icon and only sends text. Users cannot record or send voice messages. |
 | `persistent`         | `boolean`  | No       | When `true` (default), the conversation is kept across sessions in the browser's local database. When `false`, the local database is cleared before the chat is initialized and again when the page is closed, so no conversation data is left behind between sessions. |
+| `differentSessionPerContext` | `boolean` | No  | When `true`, the chat is partitioned by `openContext`: two tabs opened with the same `openContext` share a conversation, while different `openContext` values start a fresh conversation. When `false` or unset (default), `openContext` has no effect on session identity. |
 
 ## Theming
 

--- a/web-sdk/src/common/hash.test.ts
+++ b/web-sdk/src/common/hash.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import { describe, expect, it } from 'vitest';
+import { xxhash32 } from '@common/hash';
+
+describe('xxhash32', () => {
+  it('returns the same hash for the same input', () => {
+    expect(xxhash32('hello world')).toBe(xxhash32('hello world'));
+  });
+
+  it('returns different hashes for different inputs', () => {
+    expect(xxhash32('hello')).not.toBe(xxhash32('world'));
+  });
+
+  it('handles the empty string', () => {
+    expect(xxhash32('')).toMatch(/^[0-9a-z]+$/);
+  });
+
+  it('handles inputs longer than one xxhash block (16 bytes)', () => {
+    expect(xxhash32('a'.repeat(1000))).toMatch(/^[0-9a-z]+$/);
+  });
+
+  it('produces distinct hashes for inputs that differ only by a trailing byte', () => {
+    expect(xxhash32('aaaa')).not.toBe(xxhash32('aaab'));
+  });
+
+  it('produces distinct hashes for keys reordered inside an object literal', () => {
+    expect(xxhash32(JSON.stringify({ a: 1, b: 2 }))).not.toBe(
+      xxhash32(JSON.stringify({ b: 2, a: 1 }))
+    );
+  });
+});

--- a/web-sdk/src/common/hash.ts
+++ b/web-sdk/src/common/hash.ts
@@ -1,0 +1,76 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+// xxhash32 over the UTF-8 bytes of `input`, base36-encoded.
+// Reference: https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md
+
+const P1 = -1640531535; // 0x9E3779B1 interpreted as int32
+const P2 = -2048144777; // 0x85EBCA77
+const P3 = -1028477379; // 0xC2B2AE3D
+const P4 = 668265263; //   0x27D4EB2F
+const P5 = 374761393; //   0x165667B1
+
+export function xxhash32(input: string): string {
+  const data = new TextEncoder().encode(input);
+  const len = data.length;
+  let i = 0;
+  let h32: number;
+
+  if (len >= 16) {
+    let v1 = (P1 + P2) | 0;
+    let v2 = P2 | 0;
+    let v3 = 0;
+    let v4 = -P1 | 0;
+    const limit = len - 16;
+    do {
+      v1 = round(v1, readU32LE(data, i));
+      v2 = round(v2, readU32LE(data, i + 4));
+      v3 = round(v3, readU32LE(data, i + 8));
+      v4 = round(v4, readU32LE(data, i + 12));
+      i += 16;
+    } while (i <= limit);
+    h32 = (rotl(v1, 1) + rotl(v2, 7) + rotl(v3, 12) + rotl(v4, 18)) | 0;
+  } else {
+    h32 = P5;
+  }
+
+  h32 = (h32 + len) | 0;
+
+  while (i + 4 <= len) {
+    h32 = (h32 + Math.imul(readU32LE(data, i), P3)) | 0;
+    h32 = Math.imul(rotl(h32, 17), P4);
+    i += 4;
+  }
+
+  while (i < len) {
+    h32 = (h32 + Math.imul(data[i], P5)) | 0;
+    h32 = Math.imul(rotl(h32, 11), P1);
+    i += 1;
+  }
+
+  h32 ^= h32 >>> 15;
+  h32 = Math.imul(h32, P2);
+  h32 ^= h32 >>> 13;
+  h32 = Math.imul(h32, P3);
+  h32 ^= h32 >>> 16;
+
+  return (h32 >>> 0).toString(36);
+}
+
+function round(acc: number, lane: number): number {
+  acc = (acc + Math.imul(lane, P2)) | 0;
+  acc = rotl(acc, 13);
+  return Math.imul(acc, P1);
+}
+
+function rotl(x: number, n: number): number {
+  return (x << n) | (x >>> (32 - n));
+}
+
+function readU32LE(data: Uint8Array, offset: number): number {
+  return (
+    data[offset] |
+    (data[offset + 1] << 8) |
+    (data[offset + 2] << 16) |
+    (data[offset + 3] << 24)
+  );
+}

--- a/web-sdk/src/common/session.test.ts
+++ b/web-sdk/src/common/session.test.ts
@@ -15,30 +15,54 @@ const baseConfig: YaloChatClientConfig = {
 };
 
 describe('computeSessionId', () => {
-  it('returns the same sessionId for two configs with the same openContext', () => {
+  it('returns the same sessionId for two configs with the same openContext when differentSessionPerContext is true', () => {
     const a = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       openContext: { source: 'product-page', sku: '123' },
     });
     const b = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       openContext: { source: 'product-page', sku: '123' },
     });
 
     expect(a).toBe(b);
   });
 
-  it('returns different sessionIds when openContext differs', () => {
+  it('returns different sessionIds when openContext differs and differentSessionPerContext is true', () => {
     const a = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       openContext: { source: 'product-page', sku: '123' },
     });
     const b = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       openContext: { source: 'product-page', sku: '456' },
     });
 
     expect(a).not.toBe(b);
+  });
+
+  it('ignores openContext when differentSessionPerContext is unset', () => {
+    const withContext = computeSessionId({
+      ...baseConfig,
+      openContext: { sku: '123' },
+    });
+    const withoutContext = computeSessionId(baseConfig);
+
+    expect(withContext).toBe(withoutContext);
+  });
+
+  it('ignores openContext when differentSessionPerContext is explicitly false', () => {
+    expect(
+      computeSessionId({
+        ...baseConfig,
+        differentSessionPerContext: false,
+        openContext: { sku: '123' },
+      })
+    ).toBe('org-1-ch-1-anonymous');
   });
 
   it('keeps the legacy sessionId shape when no openContext is provided', () => {
@@ -51,10 +75,11 @@ describe('computeSessionId', () => {
     );
   });
 
-  it('appends the openContext hash to the userId-keyed base when both are provided', () => {
+  it('appends the openContext hash to the userId-keyed base when both are provided and the flag is on', () => {
     expect(
       computeSessionId({
         ...baseConfig,
+        differentSessionPerContext: true,
         userId: 'user-9',
         openContext: { sku: '123' },
       })
@@ -64,11 +89,13 @@ describe('computeSessionId', () => {
   it('does not collapse two different users to the same sessionId when their openContext is identical', () => {
     const a = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       userId: 'user-9',
       openContext: { sku: '123' },
     });
     const b = computeSessionId({
       ...baseConfig,
+      differentSessionPerContext: true,
       userId: 'user-10',
       openContext: { sku: '123' },
     });
@@ -78,10 +105,11 @@ describe('computeSessionId', () => {
 });
 
 describe('computeEffectiveAuthUserId', () => {
-  it('returns undefined when no userId is provided, even with openContext', () => {
+  it('returns undefined when no userId is provided, even with openContext and the flag on', () => {
     expect(
       computeEffectiveAuthUserId({
         ...baseConfig,
+        differentSessionPerContext: true,
         openContext: { sku: 'A' },
       })
     ).toBeUndefined();
@@ -93,10 +121,21 @@ describe('computeEffectiveAuthUserId', () => {
     ).toBe('u1');
   });
 
-  it('appends the openContext hash to the userId when both are provided', () => {
+  it('returns the original userId unchanged when differentSessionPerContext is unset', () => {
     expect(
       computeEffectiveAuthUserId({
         ...baseConfig,
+        userId: 'u1',
+        openContext: { sku: 'A' },
+      })
+    ).toBe('u1');
+  });
+
+  it('appends the openContext hash to the userId when both are provided and the flag is on', () => {
+    expect(
+      computeEffectiveAuthUserId({
+        ...baseConfig,
+        differentSessionPerContext: true,
         userId: 'u1',
         openContext: { sku: 'A' },
       })
@@ -104,7 +143,11 @@ describe('computeEffectiveAuthUserId', () => {
   });
 
   it('returns the same effective userId for two identical openContexts', () => {
-    const config = { ...baseConfig, userId: 'u1' };
+    const config = {
+      ...baseConfig,
+      differentSessionPerContext: true,
+      userId: 'u1',
+    };
     const a = computeEffectiveAuthUserId({
       ...config,
       openContext: { sku: 'A' },
@@ -118,7 +161,11 @@ describe('computeEffectiveAuthUserId', () => {
   });
 
   it('returns different effective userIds when openContext differs', () => {
-    const config = { ...baseConfig, userId: 'u1' };
+    const config = {
+      ...baseConfig,
+      differentSessionPerContext: true,
+      userId: 'u1',
+    };
     const a = computeEffectiveAuthUserId({
       ...config,
       openContext: { sku: 'A' },

--- a/web-sdk/src/common/session.test.ts
+++ b/web-sdk/src/common/session.test.ts
@@ -1,0 +1,133 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import { describe, expect, it } from 'vitest';
+import type { YaloChatClientConfig } from '@domain/config/chat-config';
+import {
+  computeEffectiveAuthUserId,
+  computeSessionId,
+} from '@common/session';
+
+const baseConfig: YaloChatClientConfig = {
+  channelId: 'ch-1',
+  organizationId: 'org-1',
+  channelName: 'Test',
+  target: 'target',
+};
+
+describe('computeSessionId', () => {
+  it('returns the same sessionId for two configs with the same openContext', () => {
+    const a = computeSessionId({
+      ...baseConfig,
+      openContext: { source: 'product-page', sku: '123' },
+    });
+    const b = computeSessionId({
+      ...baseConfig,
+      openContext: { source: 'product-page', sku: '123' },
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it('returns different sessionIds when openContext differs', () => {
+    const a = computeSessionId({
+      ...baseConfig,
+      openContext: { source: 'product-page', sku: '123' },
+    });
+    const b = computeSessionId({
+      ...baseConfig,
+      openContext: { source: 'product-page', sku: '456' },
+    });
+
+    expect(a).not.toBe(b);
+  });
+
+  it('keeps the legacy sessionId shape when no openContext is provided', () => {
+    expect(computeSessionId(baseConfig)).toBe('org-1-ch-1-anonymous');
+  });
+
+  it('includes the userId when provided and no openContext is set', () => {
+    expect(computeSessionId({ ...baseConfig, userId: 'user-9' })).toBe(
+      'org-1-ch-1-user-9'
+    );
+  });
+
+  it('appends the openContext hash to the userId-keyed base when both are provided', () => {
+    expect(
+      computeSessionId({
+        ...baseConfig,
+        userId: 'user-9',
+        openContext: { sku: '123' },
+      })
+    ).toMatch(/^org-1-ch-1-user-9-[0-9a-z]+$/);
+  });
+
+  it('does not collapse two different users to the same sessionId when their openContext is identical', () => {
+    const a = computeSessionId({
+      ...baseConfig,
+      userId: 'user-9',
+      openContext: { sku: '123' },
+    });
+    const b = computeSessionId({
+      ...baseConfig,
+      userId: 'user-10',
+      openContext: { sku: '123' },
+    });
+
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('computeEffectiveAuthUserId', () => {
+  it('returns undefined when no userId is provided, even with openContext', () => {
+    expect(
+      computeEffectiveAuthUserId({
+        ...baseConfig,
+        openContext: { sku: 'A' },
+      })
+    ).toBeUndefined();
+  });
+
+  it('returns the original userId unchanged when no openContext is provided', () => {
+    expect(
+      computeEffectiveAuthUserId({ ...baseConfig, userId: 'u1' })
+    ).toBe('u1');
+  });
+
+  it('appends the openContext hash to the userId when both are provided', () => {
+    expect(
+      computeEffectiveAuthUserId({
+        ...baseConfig,
+        userId: 'u1',
+        openContext: { sku: 'A' },
+      })
+    ).toMatch(/^u1-[0-9a-z]+$/);
+  });
+
+  it('returns the same effective userId for two identical openContexts', () => {
+    const config = { ...baseConfig, userId: 'u1' };
+    const a = computeEffectiveAuthUserId({
+      ...config,
+      openContext: { sku: 'A' },
+    });
+    const b = computeEffectiveAuthUserId({
+      ...config,
+      openContext: { sku: 'A' },
+    });
+
+    expect(a).toBe(b);
+  });
+
+  it('returns different effective userIds when openContext differs', () => {
+    const config = { ...baseConfig, userId: 'u1' };
+    const a = computeEffectiveAuthUserId({
+      ...config,
+      openContext: { sku: 'A' },
+    });
+    const b = computeEffectiveAuthUserId({
+      ...config,
+      openContext: { sku: 'B' },
+    });
+
+    expect(a).not.toBe(b);
+  });
+});

--- a/web-sdk/src/common/session.ts
+++ b/web-sdk/src/common/session.ts
@@ -4,26 +4,27 @@ import type { YaloChatClientConfig } from '@domain/config/chat-config';
 import { xxhash32 } from '@common/hash';
 
 function computeOpenContextHash(
-  openContext: YaloChatClientConfig['openContext']
+  config: YaloChatClientConfig
 ): string | undefined {
-  if (openContext === undefined) {
+  const { openContext, differentSessionPerContext } = config;
+  if (differentSessionPerContext !== true || openContext === undefined) {
     return undefined;
   }
   return xxhash32(JSON.stringify(openContext));
 }
 
 export function computeSessionId(config: YaloChatClientConfig): string {
-  const { organizationId, channelId, userId, openContext } = config;
+  const { organizationId, channelId, userId } = config;
   const base = `${organizationId}-${channelId}-${userId ?? 'anonymous'}`;
-  const hash = computeOpenContextHash(openContext);
+  const hash = computeOpenContextHash(config);
   return hash === undefined ? base : `${base}-${hash}`;
 }
 
 export function computeEffectiveAuthUserId(
   config: YaloChatClientConfig
 ): string | undefined {
-  const { userId, openContext } = config;
-  const hash = computeOpenContextHash(openContext);
+  const { userId } = config;
+  const hash = computeOpenContextHash(config);
   if (userId === undefined || hash === undefined) {
     return userId;
   }

--- a/web-sdk/src/common/session.ts
+++ b/web-sdk/src/common/session.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Yalochat, Inc. All rights reserved.
+
+import type { YaloChatClientConfig } from '@domain/config/chat-config';
+import { xxhash32 } from '@common/hash';
+
+function computeOpenContextHash(
+  openContext: YaloChatClientConfig['openContext']
+): string | undefined {
+  if (openContext === undefined) {
+    return undefined;
+  }
+  return xxhash32(JSON.stringify(openContext));
+}
+
+export function computeSessionId(config: YaloChatClientConfig): string {
+  const { organizationId, channelId, userId, openContext } = config;
+  const base = `${organizationId}-${channelId}-${userId ?? 'anonymous'}`;
+  const hash = computeOpenContextHash(openContext);
+  return hash === undefined ? base : `${base}-${hash}`;
+}
+
+export function computeEffectiveAuthUserId(
+  config: YaloChatClientConfig
+): string | undefined {
+  const { userId, openContext } = config;
+  const hash = computeOpenContextHash(openContext);
+  if (userId === undefined || hash === undefined) {
+    return userId;
+  }
+  return `${userId}-${hash}`;
+}

--- a/web-sdk/src/domain/config/chat-config.ts
+++ b/web-sdk/src/domain/config/chat-config.ts
@@ -15,4 +15,5 @@ export interface YaloChatClientConfig {
   hideAttachmentButton?: boolean;
   hideVoiceButton?: boolean;
   persistent?: boolean;
+  differentSessionPerContext?: boolean;
 }

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -5,6 +5,10 @@ import type { YaloChatWindow } from './yalo-chat-window';
 import { ChatMessage } from '@domain/models/chat-message/chat-message';
 import type { ChangeQuantity } from '@domain/models/chat-events/change-quantity';
 import type { PageInfo } from '@domain/common/page';
+import {
+  computeEffectiveAuthUserId,
+  computeSessionId,
+} from '@common/session';
 import { ChatMessageRepositoryLocal } from '@data/repositories/chat-message/chat-message-repository-local';
 import { YaloMessageRepositoryRemote } from '@data/repositories/yalo-message/yalo-message-repository-remote';
 import { YaloMessageAuthServiceRemote } from '@data/services/yalo-message/yalo-message-auth-service-remote';
@@ -34,11 +38,6 @@ export default class YaloChatWindowController implements ReactiveController {
 
   private static readonly _DB_NAME = 'YaloChatMessages';
   private static readonly _DB_VERSION = 1;
-
-  private get _sessionId(): string {
-    const { organizationId, channelId, userId } = this.host.config;
-    return `${organizationId}-${channelId}-${userId ?? 'anonymous'}`;
-  }
 
   private _openDb(): Promise<IDBDatabase> {
     return new Promise((resolve, reject) => {
@@ -76,7 +75,7 @@ export default class YaloChatWindowController implements ReactiveController {
 
   // Method used to create all new dependencies to be injected to all components
   async hostConnected() {
-    const sessionId = this._sessionId;
+    const sessionId = computeSessionId(this.host.config);
     const db = await this._openDb();
     this.host.chatMessageRepository = new ChatMessageRepositoryLocal(
       db,
@@ -85,7 +84,10 @@ export default class YaloChatWindowController implements ReactiveController {
 
     const authService = new YaloMessageAuthServiceRemote(
       import.meta.env.VITE_YALO_API_BASE_URL,
-      this.host.config
+      {
+        ...this.host.config,
+        userId: computeEffectiveAuthUserId(this.host.config),
+      }
     );
     const tokenRepository = new TokenRepositoryLocal(db, sessionId, authService);
     this._tokenRepository = tokenRepository;


### PR DESCRIPTION
- Added a hash (xxhash32) to open context and appended to the sessionId and user ids to partition the sessions. So a user does not need to setup the userid per product manually.