### PR TITLE
feat: Add client.sendTextMessage

### DIFF
--- a/web-sdk/README.md
+++ b/web-sdk/README.md
@@ -211,6 +211,25 @@ Each pushed configuration also accepts the `onOpen` and `onClose` callbacks that
 
 Each pushed configuration also accepts `registerCommands` so you can register commands without a direct `YaloChatClient` reference (see [Commands](doc/commands.md)).
 
+To drive the chat imperatively later (for example to call `client.sendTextMessage(...)`), you need the `YaloChatClient` the queue creates. Use the `onReady` callback to receive it. It runs once the client is created and works the same whether you push before or after the SDK script loads, so it is the reliable way to get the reference from the queue:
+
+```html
+<script>
+  window.yaloOpen = window.yaloOpen || [];
+  window.yaloOpen.push({
+    channelId: 'your-channel-id',
+    organizationId: 'your-organization-id',
+    channelName: 'Support',
+    target: 'yalo-chat',
+    onReady: (client) => {
+      window.myChat = client;
+      // later, from anywhere on your page:
+      // window.myChat.sendTextMessage('I want to reorder');
+    },
+  });
+</script>
+```
+
 The target element referenced by `config.target` must exist in the DOM at the time the configuration is processed. Place the script after the target element or wrap the push in your own `DOMContentLoaded` handler if needed.
 
 ## Configuration
@@ -253,4 +272,5 @@ The widget can be fully customized with CSS custom properties. See the [Theming 
 - **`client.open()`**: Shows the chat window. Uses the `openContext` from the config.
 - **`client.close()`**: Hides the chat window.
 - **`client.registerCommand(command, handler)`**: Registers a handler the chat can invoke on your page, keyed by command id. Built-in command ids run your callback instead of the built-in remote call. Any other id answers custom command requests from the channel: the handler runs with the request payload and its return value is sent back as the response (see [Commands](doc/commands.md)).
+- **`client.sendTextMessage(text)`**: Sends a text message on the user's behalf, as if they had typed it in the footer. Empty or whitespace-only text is ignored. You can call it any time after `init()`. Sends requested before the chat has finished loading are queued and delivered once it is ready.
 - **`client.dispose()`**: Removes the chat widget from the page and releases its resources. Call this before navigating away in single page apps. The client can be re-initialized with `init()` after disposal.

--- a/web-sdk/src/data/services/client/yalo-chat-client.test.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.test.ts
@@ -4,6 +4,9 @@ import type { YaloChatWindow } from '@ui/chat/chat-window/yalo-chat-window';
 import type { ChatCommand } from '@domain/models/command/chat-command';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import YaloChatClient from './yalo-chat-client';
+import { YaloMessageRepositoryRemote } from '@data/repositories/yalo-message/yalo-message-repository-remote';
+import { Ok } from '@domain/common/result';
+import type { ChatMessage } from '@domain/models/chat-message/chat-message';
 
 const baseConfig = {
   channelId: 'channel-1',
@@ -257,6 +260,51 @@ describe('YaloChatClient', () => {
         () => client.chatWindowEl?.yaloMessageRepository != null
       );
       expect(getChatWindow().commands.get('getCart')).toBe(handler);
+    });
+  });
+
+  describe('sendTextMessage', () => {
+    const spyInsertMessage = () =>
+      vi
+        .spyOn(YaloMessageRepositoryRemote.prototype, 'insertMessage')
+        .mockImplementation((message: ChatMessage) =>
+          Promise.resolve(new Ok(message))
+        );
+
+    it('warns and does not throw when called before init', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const client = new YaloChatClient(baseConfig);
+      expect(() => client.sendTextMessage('hello')).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        'sendTextMessage called before init(). Call init() first.'
+      );
+    });
+
+    it('delivers the text to the channel as a user message', async () => {
+      const insertMessage = spyInsertMessage();
+      const client = new YaloChatClient(baseConfig);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      client.sendTextMessage('hello');
+      await vi.waitUntil(() => insertMessage.mock.calls.length > 0);
+      expect(insertMessage.mock.calls[0][0]).toMatchObject({
+        role: 'USER',
+        type: 'text',
+        content: 'hello',
+      });
+    });
+
+    it('ignores empty or whitespace-only text', async () => {
+      const insertMessage = spyInsertMessage();
+      const client = new YaloChatClient(baseConfig);
+      client.init();
+      await vi.waitUntil(
+        () => client.chatWindowEl?.yaloMessageRepository != null
+      );
+      client.sendTextMessage('   ');
+      expect(insertMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/web-sdk/src/data/services/client/yalo-chat-client.ts
+++ b/web-sdk/src/data/services/client/yalo-chat-client.ts
@@ -71,6 +71,17 @@ export default class YaloChatClient {
     this._onClose?.();
   }
 
+  // Sends a text message on the user's behalf, as if they had typed it in the
+  // chat footer. It renders as a user bubble and is delivered to the channel.
+  // Empty or whitespace-only text is ignored.
+  sendTextMessage(text: string): void {
+    if (!this.chatWindowEl) {
+      console.warn('sendTextMessage called before init(). Call init() first.');
+      return;
+    }
+    this.chatWindowEl.sendTextMessage(text);
+  }
+
   // Registers a handler the chat can invoke on the host, keyed by command id.
   // Client -> channel command ids (ChatCommands) run instead of the built-in
   // remote call. Any other id answers the matching channel command request and

--- a/web-sdk/src/queue-open.test.ts
+++ b/web-sdk/src/queue-open.test.ts
@@ -3,6 +3,10 @@
 import type { YaloChatWindow } from '@ui/chat/chat-window/yalo-chat-window';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { installYaloOpenQueue } from './queue-open';
+import YaloChatClient from '@data/services/client/yalo-chat-client';
+import { YaloMessageRepositoryRemote } from '@data/repositories/yalo-message/yalo-message-repository-remote';
+import { Ok } from '@domain/common/result';
+import type { ChatMessage } from '@domain/models/chat-message/chat-message';
 
 const baseConfig = {
   channelId: 'channel-1',
@@ -146,5 +150,32 @@ describe('installYaloOpenQueue', () => {
     installYaloOpenQueue();
     expect(getChatWindow()).toBeNull();
     expect(typeof (window.yaloOpen as { push: unknown }).push).toBe('function');
+  });
+
+  it('invokes onReady with the created client', async () => {
+    const onReady = vi.fn();
+    window.yaloOpen = [{ ...baseConfig, onReady }];
+    installYaloOpenQueue();
+    await waitForChatWindow();
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady.mock.calls[0][0]).toBeInstanceOf(YaloChatClient);
+  });
+
+  it('lets onReady send a text message through the client', async () => {
+    const insertMessage = vi
+      .spyOn(YaloMessageRepositoryRemote.prototype, 'insertMessage')
+      .mockImplementation((message: ChatMessage) =>
+        Promise.resolve(new Ok(message))
+      );
+    const onReady = (client: YaloChatClient) =>
+      client.sendTextMessage('from host');
+    window.yaloOpen = [{ ...baseConfig, onReady }];
+    installYaloOpenQueue();
+    await vi.waitUntil(() => insertMessage.mock.calls.length > 0);
+    expect(insertMessage.mock.calls[0][0]).toMatchObject({
+      role: 'USER',
+      type: 'text',
+      content: 'from host',
+    });
   });
 });

--- a/web-sdk/src/queue-open.ts
+++ b/web-sdk/src/queue-open.ts
@@ -18,9 +18,20 @@ export interface YaloOpenCommandOptions {
   registerCommands?: RegisteredCommandsMap;
 }
 
+// Lifecycle callbacks specific to the queue path. `onReady` hands back the
+// created client once it is initialized, so hosts that open through the queue
+// (and never hold a client reference) can still drive it imperatively, for
+// example to call `client.sendTextMessage(...)` later. It is the reliable way
+// to get the client from the queue: it fires whether you push before or after
+// the SDK script loads.
+export interface YaloOpenLifecycleOptions {
+  onReady?: (client: YaloChatClient) => void;
+}
+
 export type YaloOpenConfig = YaloChatClientConfig &
   YaloChatClientInitOptions &
-  YaloOpenCommandOptions;
+  YaloOpenCommandOptions &
+  YaloOpenLifecycleOptions;
 
 export interface YaloOpenQueue {
   push(config: YaloOpenConfig): void;
@@ -33,7 +44,7 @@ declare global {
 }
 
 function openClient(config: YaloOpenConfig): YaloChatClient {
-  const { onOpen, onClose, registerCommands, ...clientConfig } = config;
+  const { onOpen, onClose, onReady, registerCommands, ...clientConfig } = config;
   const client = new YaloChatClient(clientConfig);
   if (registerCommands) {
     for (const [command, handler] of Object.entries(registerCommands)) {
@@ -47,6 +58,7 @@ function openClient(config: YaloOpenConfig): YaloChatClient {
   }
   client.init({ onOpen, onClose });
   client.open();
+  onReady?.(client);
   return client;
 }
 

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -51,6 +51,8 @@ export default class YaloChatWindowController implements ReactiveController {
   private _writingTimeout?: ReturnType<typeof setTimeout>;
   private _guidanceCardRequested = false;
   private _messagesLoaded = false;
+  private _isReady = false;
+  private _pendingUserTexts: string[] = [];
   private _pendingAckTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   private static readonly _DB_NAME = 'YaloChatMessages';
@@ -190,6 +192,15 @@ export default class YaloChatWindowController implements ReactiveController {
     // Subscribe to incoming message stream
     this.host.yaloMessageRepository.subscribeToMessages(this.onMessageReceived);
 
+    // The repositories are set, so programmatic sends are safe now. Flush any
+    // text that was requested before the window finished connecting.
+    this._isReady = true;
+    const pending = this._pendingUserTexts;
+    this._pendingUserTexts = [];
+    for (const text of pending) {
+      await this.sendUserText(text);
+    }
+
     if (this.host.open) {
       await this.requestGuidanceCardIfEmpty();
     }
@@ -234,8 +245,30 @@ export default class YaloChatWindowController implements ReactiveController {
   }
 
   async sendTextMessage(e: CustomEvent) {
-    const textMessage = e.detail as ChatMessage;
+    await this._deliverUserMessage(e.detail as ChatMessage);
+  }
 
+  // Sends a text message on the user's behalf, as if they had typed it in the
+  // footer. Empty or whitespace-only text is ignored. Calls that arrive before
+  // the window has finished connecting are buffered and flushed once ready.
+  async sendUserText(content: string): Promise<void> {
+    const text = content.trim();
+    if (!text) {
+      return;
+    }
+    if (!this._isReady) {
+      this._pendingUserTexts.push(text);
+      return;
+    }
+    const message = ChatMessage.text({
+      role: 'USER',
+      timestamp: new Date(),
+      content: text,
+    });
+    await this._deliverUserMessage(message);
+  }
+
+  private async _deliverUserMessage(textMessage: ChatMessage): Promise<void> {
     const localResult =
       await this.host.chatMessageRepository.insertChatMessage(textMessage);
 
@@ -881,6 +914,8 @@ export default class YaloChatWindowController implements ReactiveController {
   }
 
   hostDisconnected() {
+    this._isReady = false;
+    this._pendingUserTexts = [];
     clearTimeout(this._writingTimeout);
     for (const timer of this._pendingAckTimers.values()) {
       clearTimeout(timer);

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -355,6 +355,73 @@ describe('YaloChatWindow', () => {
     });
   });
 
+  describe('host-triggered text messages', () => {
+    it('renders a user bubble and delivers the text through the window API', async () => {
+      vi.spyOn(el.yaloMessageRepository, 'insertMessage').mockResolvedValue(
+        new Ok(
+          ChatMessage.text({
+            role: 'USER',
+            timestamp: new Date(),
+            content: 'programmatic',
+          })
+        )
+      );
+
+      el.sendTextMessage('programmatic');
+
+      await vi.waitUntil(() => getMessageList(el).chatMessages.length > 0);
+      expect(getMessageList(el).chatMessages[0]).toMatchObject({
+        role: 'USER',
+        type: 'text',
+        content: 'programmatic',
+      });
+    });
+
+    it('ignores whitespace-only text on the window API', async () => {
+      const insert = vi.spyOn(el.yaloMessageRepository, 'insertMessage');
+
+      el.sendTextMessage('   ');
+
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      expect(insert).not.toHaveBeenCalled();
+      expect(getMessageList(el).chatMessages).toHaveLength(0);
+    });
+
+    it('buffers a text message sent before the window is ready and delivers it once ready', async () => {
+      const insertMessage = vi
+        .spyOn(YaloMessageRepositoryRemote.prototype, 'insertMessage')
+        .mockImplementation((message: ChatMessage) =>
+          Promise.resolve(new Ok(message))
+        );
+
+      const fresh = document.createElement(
+        'yalo-chat-window'
+      ) as YaloChatWindow;
+      fresh.config = baseConfig;
+      document.body.appendChild(fresh);
+      // Send immediately, before hostConnected finishes wiring the repositories.
+      fresh.sendTextMessage('buffered hello');
+
+      await vi.waitUntil(() =>
+        insertMessage.mock.calls.some((c) => c[0].content === 'buffered hello')
+      );
+      const delivered = insertMessage.mock.calls.find(
+        (c) => c[0].content === 'buffered hello'
+      );
+      expect(delivered?.[0]).toMatchObject({
+        role: 'USER',
+        type: 'text',
+        content: 'buffered hello',
+      });
+
+      // This spy is on the shared prototype, so restore it here to avoid
+      // leaking into other tests in this file (its afterEach does not restore
+      // mocks, since every other test spies on instances that are discarded).
+      fresh.remove();
+      insertMessage.mockRestore();
+    });
+  });
+
   describe('error display', () => {
     it('marks message as ERROR when remote insert fails', async () => {
       vi.spyOn(el.yaloMessageRepository, 'insertMessage').mockResolvedValue(

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.ts
@@ -100,6 +100,12 @@ export class YaloChatWindow extends LitElement {
     }
   }
 
+  // Sends a text message on the user's behalf. Delegates to the controller so
+  // it follows the same path as a message typed in the footer.
+  sendTextMessage(text: string): void {
+    this._chatWindowController.sendUserText(text);
+  }
+
   private _handleClose = () => {
     this.open = false;
     this.dispatchEvent(


### PR DESCRIPTION
- In order to enable the host app to send text message, sendTextMessage was added to the client object and yaloOpen.