### PR TITLE
feat: Add yalo water mark

### DIFF
--- a/web-sdk/README.md
+++ b/web-sdk/README.md
@@ -261,6 +261,7 @@ Optional properties:
 - **`welcomeMessageType`** (`"none" | "verticalQuickReplies"`): Customizes how the first message in the chat renders. Defaults to `"none"`.
   - `"verticalQuickReplies"`: while the user has not sent a message yet, only the first message is shown, with its header, body and quick replies centered, and one quick reply per line. Once the user sends a message, the full conversation renders normally.
 - **`quickReplyType`** (`"modal" | "inline"`): Controls how quick replies are presented. Defaults to `"modal"`, which shows them in a modal over the chat footer. Set to `"inline"` to show them inline instead.
+- **`yaloWatermark`** (`"header-left" | "header-right" | "none"`): Controls the "by Yalo" watermark shown under the channel name in the chat header. Defaults to `"header-left"`, which left aligns it under the title. Set to `"header-right"` to right align it under the title, or `"none"` to hide it. The watermark text follows the active `locale`, and its look can be tuned with the `--yalo-chat-header-watermark-*` CSS variables.
 - **`texts`** (`object`): Overrides for built-in text strings. See [Translations](doc/translations.md).
 - **`icons`** (`object`): Replace built-in icons with your own SVGs. See [Icons](doc/icons.md).
 

--- a/web-sdk/doc/theming.md
+++ b/web-sdk/doc/theming.md
@@ -156,6 +156,20 @@ To replace an icon with your own SVG image instead of a font glyph, use the `ico
   /* Font weight of the channel name (header title). */
   --yalo-chat-header-title-font-weight: 600;
 
+  /* Font size of the "by Yalo" watermark shown in the header.
+     Rendered when the `yaloWatermark` config property is `header-left`
+     or `header-right`. */
+  --yalo-chat-header-watermark-font-size: 0.7rem;
+
+  /* Font weight of the "by" text in the watermark. */
+  --yalo-chat-header-watermark-font-weight: 400;
+
+  /* Font weight of the bold "Yalo" brand name in the watermark. */
+  --yalo-chat-header-watermark-brand-font-weight: 700;
+
+  /* Text color of the "by Yalo" watermark. */
+  --yalo-chat-header-watermark-color: #747474;
+
   /* Display of the chat header bar. Set to `none` to hide the header.
      This is the CSS equivalent of the `hideHeader` config property. */
   --yalo-chat-header-display: flex;

--- a/web-sdk/src/domain/config/chat-config.ts
+++ b/web-sdk/src/domain/config/chat-config.ts
@@ -11,6 +11,13 @@ export type WelcomeMessageType = (typeof WELCOME_MESSAGE_TYPES)[number];
 export const QUICK_REPLY_TYPES = ['modal', 'inline'] as const;
 export type QuickReplyType = (typeof QUICK_REPLY_TYPES)[number];
 
+export const YALO_WATERMARK_POSITIONS = [
+  'none',
+  'header-left',
+  'header-right',
+] as const;
+export type YaloWatermarkPosition = (typeof YALO_WATERMARK_POSITIONS)[number];
+
 export interface YaloChatTexts {
   inputPlaceholder?: string;
 }
@@ -41,6 +48,7 @@ export interface YaloChatClientConfig {
   openContext?: Record<string, unknown>;
   hideCloseButton?: boolean;
   hideHeader?: boolean;
+  yaloWatermark?: YaloWatermarkPosition;
   hideAttachmentButton?: boolean;
   hideVoiceButton?: boolean;
   sessionMode?: SessionMode;

--- a/web-sdk/src/i18n/locales/ar.ts
+++ b/web-sdk/src/i18n/locales/ar.ts
@@ -2,21 +2,28 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `تحديث السلة`,
-'s2c8189544e3ea679': `إعادة المحاولة`,
-'s317b6c4a03e34c5d': `في السلة`,
-'s32bad8884f0b1be7': `إغلاق المحادثة`,
-'sa50a6326530d8a0d': `عرض أقل`,
-'sb2c57b2d347203dd': `عرض المزيد`,
-'sc876da507d6d97c4': `لم يتم التسليم.`,
-'sf5d501d58546bff9': `أضف إلى السلة`,
-'sf900fe612519e672': `اكتب رسالة...`,
+      'h6d222a138907d6d6': html`من <b>Yalo</b>`,
+'s20dfc2658b5ed207': `ØªØ­Ø¯ÙØ« Ø§ÙØ³ÙØ©`,
+'s2c8189544e3ea679': `Ø¥Ø¹Ø§Ø¯Ø© Ø§ÙÙ
+Ø­Ø§ÙÙØ©`,
+'s317b6c4a03e34c5d': `ÙÙ Ø§ÙØ³ÙØ©`,
+'s32bad8884f0b1be7': `Ø¥ØºÙØ§Ù Ø§ÙÙ
+Ø­Ø§Ø¯Ø«Ø©`,
+'sa50a6326530d8a0d': `Ø¹Ø±Ø¶ Ø£ÙÙ`,
+'sb2c57b2d347203dd': `Ø¹Ø±Ø¶ Ø§ÙÙ
+Ø²ÙØ¯`,
+'sc876da507d6d97c4': `ÙÙ
+ ÙØªÙ
+ Ø§ÙØªØ³ÙÙÙ
+.`,
+'sf5d501d58546bff9': `Ø£Ø¶Ù Ø¥ÙÙ Ø§ÙØ³ÙØ©`,
+'sf900fe612519e672': `Ø§ÙØªØ¨ Ø±Ø³Ø§ÙØ©...`,
     };
   

--- a/web-sdk/src/i18n/locales/es-MX.ts
+++ b/web-sdk/src/i18n/locales/es-MX.ts
@@ -2,14 +2,15 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `Actualizar el carrito`,
+      'h6d222a138907d6d6': html`Por <b>Yalo</b>`,
+'s20dfc2658b5ed207': `Actualizar el carrito`,
 's2c8189544e3ea679': `Reintentar`,
 's317b6c4a03e34c5d': `En el carrito`,
 's32bad8884f0b1be7': `Cerrar chat`,

--- a/web-sdk/src/i18n/locales/es.ts
+++ b/web-sdk/src/i18n/locales/es.ts
@@ -2,14 +2,15 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `Actualizar el carrito`,
+      'h6d222a138907d6d6': html`Por <b>Yalo</b>`,
+'s20dfc2658b5ed207': `Actualizar el carrito`,
 's2c8189544e3ea679': `Reintentar`,
 's317b6c4a03e34c5d': `En el carrito`,
 's32bad8884f0b1be7': `Cerrar chat`,

--- a/web-sdk/src/i18n/locales/pt-BR.ts
+++ b/web-sdk/src/i18n/locales/pt-BR.ts
@@ -2,14 +2,15 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `Atualizar o carrinho`,
+      'h6d222a138907d6d6': html`Por <b>Yalo</b>`,
+'s20dfc2658b5ed207': `Atualizar o carrinho`,
 's2c8189544e3ea679': `Tentar novamente`,
 's317b6c4a03e34c5d': `No carrinho`,
 's32bad8884f0b1be7': `Fechar chat`,

--- a/web-sdk/src/i18n/locales/pt.ts
+++ b/web-sdk/src/i18n/locales/pt.ts
@@ -2,14 +2,15 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `Atualizar o carrinho`,
+      'h6d222a138907d6d6': html`Por <b>Yalo</b>`,
+'s20dfc2658b5ed207': `Atualizar o carrinho`,
 's2c8189544e3ea679': `Tentar novamente`,
 's317b6c4a03e34c5d': `No carrinho`,
 's32bad8884f0b1be7': `Fechar chat`,

--- a/web-sdk/src/i18n/locales/zh-CN.ts
+++ b/web-sdk/src/i18n/locales/zh-CN.ts
@@ -2,21 +2,24 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `更新购物车`,
-'s2c8189544e3ea679': `重试`,
-'s317b6c4a03e34c5d': `已在购物车中`,
-'s32bad8884f0b1be7': `关闭聊天`,
-'sa50a6326530d8a0d': `显示更少`,
-'sb2c57b2d347203dd': `显示更多`,
-'sc876da507d6d97c4': `未送达。`,
-'sf5d501d58546bff9': `加入购物车`,
-'sf900fe612519e672': `写下一条消息...`,
+      'h6d222a138907d6d6': html`由 <b>Yalo</b> 提供`,
+'s20dfc2658b5ed207': `æ´æ°è´­ç©è½¦`,
+'s2c8189544e3ea679': `éè¯`,
+'s317b6c4a03e34c5d': `å·²å¨è´­ç©è½¦ä¸­`,
+'s32bad8884f0b1be7': `å
+³é­èå¤©`,
+'sa50a6326530d8a0d': `æ¾ç¤ºæ´å°`,
+'sb2c57b2d347203dd': `æ¾ç¤ºæ´å¤`,
+'sc876da507d6d97c4': `æªéè¾¾ã`,
+'sf5d501d58546bff9': `å å
+¥è´­ç©è½¦`,
+'sf900fe612519e672': `åä¸ä¸æ¡æ¶æ¯...`,
     };
   

--- a/web-sdk/src/i18n/locales/zh.ts
+++ b/web-sdk/src/i18n/locales/zh.ts
@@ -2,21 +2,24 @@
     // Do not modify this file by hand!
     // Re-generate this file by running lit-localize
 
-    
+    import {html} from 'lit';
     
 
     /* eslint-disable no-irregular-whitespace */
     /* eslint-disable @typescript-eslint/no-explicit-any */
 
     export const templates = {
-      's20dfc2658b5ed207': `更新购物车`,
-'s2c8189544e3ea679': `重试`,
-'s317b6c4a03e34c5d': `已在购物车中`,
-'s32bad8884f0b1be7': `关闭聊天`,
-'sa50a6326530d8a0d': `显示更少`,
-'sb2c57b2d347203dd': `显示更多`,
-'sc876da507d6d97c4': `未送达。`,
-'sf5d501d58546bff9': `加入购物车`,
-'sf900fe612519e672': `写下一条消息...`,
+      'h6d222a138907d6d6': html`由 <b>Yalo</b> 提供`,
+'s20dfc2658b5ed207': `æ´æ°è´­ç©è½¦`,
+'s2c8189544e3ea679': `éè¯`,
+'s317b6c4a03e34c5d': `å·²å¨è´­ç©è½¦ä¸­`,
+'s32bad8884f0b1be7': `å
+³é­èå¤©`,
+'sa50a6326530d8a0d': `æ¾ç¤ºæ´å°`,
+'sb2c57b2d347203dd': `æ¾ç¤ºæ´å¤`,
+'sc876da507d6d97c4': `æªéè¾¾ã`,
+'sf5d501d58546bff9': `å å
+¥è´­ç©è½¦`,
+'sf900fe612519e672': `åä¸ä¸æ¡æ¶æ¯...`,
     };
   

--- a/web-sdk/src/ui/chat/chat-header/chat-header.ts
+++ b/web-sdk/src/ui/chat/chat-header/chat-header.ts
@@ -5,10 +5,11 @@ import {
   yaloChatClientConfigContext,
 } from '@domain/config/chat-config-context';
 import { consume } from '@lit/context';
-import { msg } from '@lit/localize';
+import { localized, msg } from '@lit/localize';
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+@localized()
 @customElement('yalo-chat-header')
 export class ChatHeader extends LitElement {
   static styles = css`
@@ -59,6 +60,25 @@ export class ChatHeader extends LitElement {
     .chat-status {
       margin: 0;
       font-size: 0.8rem;
+    }
+
+    .yalo-watermark {
+      margin: 0;
+      font-size: var(--yalo-chat-header-watermark-font-size, 0.7rem);
+      font-weight: var(--yalo-chat-header-watermark-font-weight, 400);
+      color: var(--yalo-chat-header-watermark-color, #747474);
+    }
+
+    .yalo-watermark[data-position='header-left'] {
+      text-align: left;
+    }
+
+    .yalo-watermark[data-position='header-right'] {
+      text-align: right;
+    }
+
+    .yalo-watermark b {
+      font-weight: var(--yalo-chat-header-watermark-brand-font-weight, 700);
     }
 
     .chat-close-btn {
@@ -113,6 +133,7 @@ export class ChatHeader extends LitElement {
   };
 
   render() {
+    const watermarkPosition = this.config.yaloWatermark ?? 'header-left';
     return html`
       <header class="chat-header">
         ${this.config.image != null
@@ -123,6 +144,11 @@ export class ChatHeader extends LitElement {
           ${this.statusMessage !== ''
             ? html`<p class="chat-status">${this.statusMessage}</p>`
             : nothing}
+          ${watermarkPosition === 'none'
+            ? nothing
+            : html`<p class="yalo-watermark" data-position=${watermarkPosition}>
+                ${msg(html`By <b>Yalo</b>`)}
+              </p>`}
         </hgroup>
         ${this.config.hideCloseButton
           ? nothing

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -209,6 +209,70 @@ describe('YaloChatWindow', () => {
 
       expect(hidden.shadowRoot?.querySelector('yalo-chat-header')).toBeNull();
     });
+
+    const renderHeaderWith = async (
+      yaloWatermark: 'none' | 'header-left' | 'header-right'
+    ): Promise<LitElement> => {
+      document.body.innerHTML = '';
+      const window = document.createElement(
+        'yalo-chat-window'
+      ) as YaloChatWindow;
+      window.config = { ...baseConfig, yaloWatermark };
+      document.body.appendChild(window);
+      await vi.waitUntil(() => window.yaloMessageRepository !== undefined);
+      const header = window.shadowRoot?.querySelector(
+        'yalo-chat-header'
+      ) as LitElement;
+      await header.updateComplete;
+      return header;
+    };
+
+    const getWatermark = (header: LitElement): HTMLElement | null =>
+      header.shadowRoot?.querySelector('.yalo-watermark') ?? null;
+
+    it('shows the by Yalo watermark under the title on the left by default', async () => {
+      const header = el.shadowRoot?.querySelector(
+        'yalo-chat-header'
+      ) as LitElement;
+      await header.updateComplete;
+
+      const watermark = getWatermark(header);
+      const titleGroup = header.shadowRoot?.querySelector(
+        '.chat-header-title-group'
+      );
+      expect(watermark?.textContent?.trim()).toBe('By Yalo');
+      expect(titleGroup?.contains(watermark)).toBe(true);
+      expect(getComputedStyle(watermark!).textAlign).toBe('left');
+    });
+
+    it('renders the watermark under the title when header-left', async () => {
+      const header = await renderHeaderWith('header-left');
+
+      const watermark = getWatermark(header);
+      const titleGroup = header.shadowRoot?.querySelector(
+        '.chat-header-title-group'
+      );
+      expect(titleGroup?.contains(watermark)).toBe(true);
+      expect(getComputedStyle(watermark!).textAlign).toBe('left');
+    });
+
+    it('right aligns the watermark under the title when header-right', async () => {
+      const header = await renderHeaderWith('header-right');
+
+      const watermark = getWatermark(header);
+      const titleGroup = header.shadowRoot?.querySelector(
+        '.chat-header-title-group'
+      );
+      expect(watermark?.textContent?.trim()).toBe('By Yalo');
+      expect(titleGroup?.contains(watermark)).toBe(true);
+      expect(getComputedStyle(watermark!).textAlign).toBe('right');
+    });
+
+    it('hides the watermark when config.yaloWatermark is none', async () => {
+      const header = await renderHeaderWith('none');
+
+      expect(getWatermark(header)).toBeNull();
+    });
   });
 
   describe('sending messages', () => {

--- a/web-sdk/xliff/ar.xlf
+++ b/web-sdk/xliff/ar.xlf
@@ -4,39 +4,49 @@
 <body>
 <trans-unit id="sf900fe612519e672">
   <source>Write a message...</source>
-  <target>اكتب رسالة...</target>
+  <target>Ø§ÙØªØ¨ Ø±Ø³Ø§ÙØ©...</target>
 </trans-unit>
 <trans-unit id="s32bad8884f0b1be7">
   <source>Close Chat</source>
-  <target>إغلاق المحادثة</target>
+  <target>Ø¥ØºÙØ§Ù Ø§ÙÙ
+Ø­Ø§Ø¯Ø«Ø©</target>
 </trans-unit>
 <trans-unit id="sa50a6326530d8a0d">
   <source>Show less</source>
-  <target>عرض أقل</target>
+  <target>Ø¹Ø±Ø¶ Ø£ÙÙ</target>
 </trans-unit>
 <trans-unit id="sb2c57b2d347203dd">
   <source>Show more</source>
-  <target>عرض المزيد</target>
+  <target>Ø¹Ø±Ø¶ Ø§ÙÙ
+Ø²ÙØ¯</target>
 </trans-unit>
 <trans-unit id="s317b6c4a03e34c5d">
   <source>In the cart</source>
-  <target>في السلة</target>
+  <target>ÙÙ Ø§ÙØ³ÙØ©</target>
 </trans-unit>
 <trans-unit id="s20dfc2658b5ed207">
   <source>Update the cart</source>
-  <target>تحديث السلة</target>
+  <target>ØªØ­Ø¯ÙØ« Ø§ÙØ³ÙØ©</target>
 </trans-unit>
 <trans-unit id="sf5d501d58546bff9">
   <source>Add to cart</source>
-  <target>أضف إلى السلة</target>
+  <target>Ø£Ø¶Ù Ø¥ÙÙ Ø§ÙØ³ÙØ©</target>
 </trans-unit>
 <trans-unit id="sc876da507d6d97c4">
   <source>Not delivered.</source>
-  <target>لم يتم التسليم.</target>
+  <target>ÙÙ
+ ÙØªÙ
+ Ø§ÙØªØ³ÙÙÙ
+.</target>
 </trans-unit>
 <trans-unit id="s2c8189544e3ea679">
   <source>Retry</source>
-  <target>إعادة المحاولة</target>
+  <target>Ø¥Ø¹Ø§Ø¯Ø© Ø§ÙÙ
+Ø­Ø§ÙÙØ©</target>
+</trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>من <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></target>
 </trans-unit>
 </body>
 </file>

--- a/web-sdk/xliff/es-MX.xlf
+++ b/web-sdk/xliff/es-MX.xlf
@@ -38,6 +38,10 @@
   <source>Retry</source>
   <target>Reintentar</target>
 </trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>Por <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-sdk/xliff/es.xlf
+++ b/web-sdk/xliff/es.xlf
@@ -38,6 +38,10 @@
   <source>Retry</source>
   <target>Reintentar</target>
 </trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>Por <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-sdk/xliff/pt-BR.xlf
+++ b/web-sdk/xliff/pt-BR.xlf
@@ -38,6 +38,10 @@
   <source>Retry</source>
   <target>Tentar novamente</target>
 </trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>Por <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-sdk/xliff/pt.xlf
+++ b/web-sdk/xliff/pt.xlf
@@ -38,6 +38,10 @@
   <source>Retry</source>
   <target>Tentar novamente</target>
 </trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>Por <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></target>
+</trans-unit>
 </body>
 </file>
 </xliff>

--- a/web-sdk/xliff/zh-CN.xlf
+++ b/web-sdk/xliff/zh-CN.xlf
@@ -4,39 +4,45 @@
 <body>
 <trans-unit id="sf900fe612519e672">
   <source>Write a message...</source>
-  <target>写下一条消息...</target>
+  <target>åä¸ä¸æ¡æ¶æ¯...</target>
 </trans-unit>
 <trans-unit id="s32bad8884f0b1be7">
   <source>Close Chat</source>
-  <target>关闭聊天</target>
+  <target>å
+³é­èå¤©</target>
 </trans-unit>
 <trans-unit id="sa50a6326530d8a0d">
   <source>Show less</source>
-  <target>显示更少</target>
+  <target>æ¾ç¤ºæ´å°</target>
 </trans-unit>
 <trans-unit id="sb2c57b2d347203dd">
   <source>Show more</source>
-  <target>显示更多</target>
+  <target>æ¾ç¤ºæ´å¤</target>
 </trans-unit>
 <trans-unit id="s317b6c4a03e34c5d">
   <source>In the cart</source>
-  <target>已在购物车中</target>
+  <target>å·²å¨è´­ç©è½¦ä¸­</target>
 </trans-unit>
 <trans-unit id="s20dfc2658b5ed207">
   <source>Update the cart</source>
-  <target>更新购物车</target>
+  <target>æ´æ°è´­ç©è½¦</target>
 </trans-unit>
 <trans-unit id="sf5d501d58546bff9">
   <source>Add to cart</source>
-  <target>加入购物车</target>
+  <target>å å
+¥è´­ç©è½¦</target>
 </trans-unit>
 <trans-unit id="sc876da507d6d97c4">
   <source>Not delivered.</source>
-  <target>未送达。</target>
+  <target>æªéè¾¾ã</target>
 </trans-unit>
 <trans-unit id="s2c8189544e3ea679">
   <source>Retry</source>
-  <target>重试</target>
+  <target>éè¯</target>
+</trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>由 <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/> 提供</target>
 </trans-unit>
 </body>
 </file>

--- a/web-sdk/xliff/zh.xlf
+++ b/web-sdk/xliff/zh.xlf
@@ -4,39 +4,45 @@
 <body>
 <trans-unit id="sf900fe612519e672">
   <source>Write a message...</source>
-  <target>写下一条消息...</target>
+  <target>åä¸ä¸æ¡æ¶æ¯...</target>
 </trans-unit>
 <trans-unit id="s32bad8884f0b1be7">
   <source>Close Chat</source>
-  <target>关闭聊天</target>
+  <target>å
+³é­èå¤©</target>
 </trans-unit>
 <trans-unit id="sa50a6326530d8a0d">
   <source>Show less</source>
-  <target>显示更少</target>
+  <target>æ¾ç¤ºæ´å°</target>
 </trans-unit>
 <trans-unit id="sb2c57b2d347203dd">
   <source>Show more</source>
-  <target>显示更多</target>
+  <target>æ¾ç¤ºæ´å¤</target>
 </trans-unit>
 <trans-unit id="s317b6c4a03e34c5d">
   <source>In the cart</source>
-  <target>已在购物车中</target>
+  <target>å·²å¨è´­ç©è½¦ä¸­</target>
 </trans-unit>
 <trans-unit id="s20dfc2658b5ed207">
   <source>Update the cart</source>
-  <target>更新购物车</target>
+  <target>æ´æ°è´­ç©è½¦</target>
 </trans-unit>
 <trans-unit id="sf5d501d58546bff9">
   <source>Add to cart</source>
-  <target>加入购物车</target>
+  <target>å å
+¥è´­ç©è½¦</target>
 </trans-unit>
 <trans-unit id="sc876da507d6d97c4">
   <source>Not delivered.</source>
-  <target>未送达。</target>
+  <target>æªéè¾¾ã</target>
 </trans-unit>
 <trans-unit id="s2c8189544e3ea679">
   <source>Retry</source>
-  <target>重试</target>
+  <target>éè¯</target>
+</trans-unit>
+<trans-unit id="h6d222a138907d6d6">
+  <source>By <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/></source>
+  <target>由 <x id="0" equiv-text="&lt;b&gt;"/>Yalo<x id="1" equiv-text="&lt;/b&gt;"/> 提供</target>
 </trans-unit>
 </body>
 </file>


### PR DESCRIPTION
- Adds yalo water mark under the chat header, enabled by default. With three render options 'none', 'header-left' and 'header-right'.