### PR TITLE
Fix remove unused tokens on ephemeral

### DIFF
--- a/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.ts
+++ b/web-sdk/src/data/repositories/chat-message/chat-message-repository-local.ts
@@ -22,6 +22,52 @@ export class ChatMessageRepositoryLocal implements ChatMessageRepository {
     }
   }
 
+  // Deletes every message belonging to the given sessions. Used to drop the
+  // messages of ephemeral sessions that were reclaimed by the token sweep.
+  static clearSessions(
+    db: IDBDatabase,
+    sessionIds: string[]
+  ): Promise<Result<boolean>> {
+    return new Promise((resolve) => {
+      if (sessionIds.length === 0) {
+        resolve(new Ok(true));
+        return;
+      }
+      try {
+        const tx = db.transaction(
+          ChatMessageRepositoryLocal._STORE_NAME,
+          'readwrite'
+        );
+        const store = tx.objectStore(ChatMessageRepositoryLocal._STORE_NAME);
+        const index = store.index('sessionId');
+        let pending = sessionIds.length;
+
+        for (const sessionId of sessionIds) {
+          const request = index.openCursor(IDBKeyRange.only(sessionId));
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+              pending -= 1;
+              if (pending === 0) {
+                resolve(new Ok(true));
+              }
+              return;
+            }
+            cursor.delete();
+            cursor.continue();
+          };
+          request.onerror = () => {
+            resolve(
+              new Err(request.error ?? new Error('Unable to clear sessions'))
+            );
+          };
+        }
+      } catch (e) {
+        resolve(new Err(e instanceof Error ? e : new Error(String(e))));
+      }
+    });
+  }
+
   private readonly db: IDBDatabase;
   private readonly sessionId: string;
 

--- a/web-sdk/src/data/repositories/token/token-repository-local.test.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.test.ts
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Ok, Err } from '@domain/common/result';
 import type { YaloMessageAuthService } from '@data/services/yalo-message/yalo-message-auth-service';
+import { xxhash32 } from '@common/hash';
 import { TokenRepositoryLocal } from './token-repository-local';
 
 const DB_NAME = 'YaloChatMessages';
@@ -27,6 +28,25 @@ function deleteDb(): Promise<void> {
     req.onerror = () => reject(req.error);
   });
 }
+
+// Writes a record in the shape builds before the ephemeral flag produced.
+const seedLegacyToken = (
+  db: IDBDatabase,
+  sessionId: string
+): Promise<void> =>
+  new Promise((resolve, reject) => {
+    const tx = db.transaction('session', 'readwrite');
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.objectStore('session').put(
+      {
+        accessToken: 'legacy-access',
+        refreshToken: 'legacy-refresh',
+        expiresAt: Date.now() + 3600 * 1000,
+      },
+      `token:${sessionId}`
+    );
+  });
 
 const makeAuthResponse = (overrides: Partial<{
   accessToken: string;
@@ -247,6 +267,43 @@ describe('TokenRepositoryLocal', () => {
       await new TokenRepositoryLocal(db, SESSION_ID, makeAuthService()).getToken();
 
       const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: [] });
+    });
+
+    it('lists unflagged sessions whose id carries a uuid as legacy ephemeral', async () => {
+      await seedLegacyToken(db, `${SESSION_ID}-${crypto.randomUUID()}`);
+
+      const listed = await TokenRepositoryLocal.listLegacyEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: [expect.any(String)] });
+    });
+
+    it('leaves an unflagged shared session out of the legacy listing', async () => {
+      await seedLegacyToken(db, 'org-1-channel-1-anonymous');
+
+      const listed = await TokenRepositoryLocal.listLegacyEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: [] });
+    });
+
+    it('leaves an unflagged perContext session out of the legacy listing', async () => {
+      await seedLegacyToken(db, `org-1-channel-1-anonymous-${xxhash32('ctx')}`);
+
+      const listed = await TokenRepositoryLocal.listLegacyEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: [] });
+    });
+
+    it('leaves flagged ephemeral sessions to the lock based reclamation', async () => {
+      await new TokenRepositoryLocal(
+        db,
+        `${SESSION_ID}-${crypto.randomUUID()}`,
+        makeAuthService(),
+        true
+      ).getToken();
+
+      const listed = await TokenRepositoryLocal.listLegacyEphemeralSessions(db);
 
       expect(listed).toMatchObject({ ok: true, value: [] });
     });

--- a/web-sdk/src/data/repositories/token/token-repository-local.test.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.test.ts
@@ -230,6 +230,80 @@ describe('TokenRepositoryLocal', () => {
       expect(result).toMatchObject({ ok: false });
     });
 
+    it('lists the sessions that stored an ephemeral token', async () => {
+      await new TokenRepositoryLocal(
+        db,
+        'ephemeral-session',
+        makeAuthService(),
+        true
+      ).getToken();
+
+      const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: ['ephemeral-session'] });
+    });
+
+    it('leaves sessions of any other mode out of the listing', async () => {
+      await new TokenRepositoryLocal(db, SESSION_ID, makeAuthService()).getToken();
+
+      const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: true, value: [] });
+    });
+
+    it('listEphemeralSessions returns Err when the database is closed', async () => {
+      db.close();
+
+      const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+
+      expect(listed).toMatchObject({ ok: false });
+    });
+
+    it('a reclaimed session has to authenticate again', async () => {
+      await new TokenRepositoryLocal(
+        db,
+        'abandoned-session',
+        makeAuthService(),
+        true
+      ).getToken();
+
+      await TokenRepositoryLocal.clearSessions(db, ['abandoned-session']);
+
+      const laterAuth = makeAuthService();
+      await new TokenRepositoryLocal(
+        db,
+        'abandoned-session',
+        laterAuth,
+        true
+      ).getToken();
+
+      expect(laterAuth.fetchToken).toHaveBeenCalledOnce();
+    });
+
+    it('clearSessions leaves sessions it was not given alone', async () => {
+      const keptAuth = makeAuthService();
+      await new TokenRepositoryLocal(db, SESSION_ID, keptAuth, true).getToken();
+      await new TokenRepositoryLocal(
+        db,
+        'abandoned-session',
+        makeAuthService(),
+        true
+      ).getToken();
+
+      await TokenRepositoryLocal.clearSessions(db, ['abandoned-session']);
+
+      const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+      expect(listed).toMatchObject({ ok: true, value: [SESSION_ID] });
+    });
+
+    it('clearSessions returns Err when the database is closed', async () => {
+      db.close();
+
+      const cleared = await TokenRepositoryLocal.clearSessions(db, ['gone']);
+
+      expect(cleared).toMatchObject({ ok: false });
+    });
+
     it('clearSession only removes the configured session token', async () => {
       const mine = new TokenRepositoryLocal(db, SESSION_ID, makeAuthService());
       const theirsAuth = makeAuthService();

--- a/web-sdk/src/data/repositories/token/token-repository-local.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.ts
@@ -21,11 +21,40 @@ export class TokenRepositoryLocal implements TokenRepository {
     }
   }
 
+  // Only crypto.randomUUID ever produced a suffix of this shape, so a record
+  // written before the ephemeral flag existed that carries one came from an
+  // ephemeral session. A perContext suffix is a base36 hash and never has
+  // dashes, and a shared session has no suffix at all, so neither can match.
+  private static readonly _LEGACY_EPHEMERAL_SUFFIX =
+    /-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
   // Lists the sessions that stored an ephemeral token, so the caller can work
   // out which of them no document owns any more. Sessions of any other mode are
   // never reported: an anonymous shared session would lose its identity along
   // with its token, so its record has to survive.
   static listEphemeralSessions(db: IDBDatabase): Promise<Result<string[]>> {
+    return TokenRepositoryLocal._listSessions(
+      db,
+      (stored) => stored.ephemeral === true
+    );
+  }
+
+  // Lists ephemeral sessions left by builds that predate the flag. Their
+  // records are invisible to listEphemeralSessions, so without this pass they
+  // would sit in storage forever holding a usable refresh token.
+  static listLegacyEphemeralSessions(db: IDBDatabase): Promise<Result<string[]>> {
+    return TokenRepositoryLocal._listSessions(
+      db,
+      (stored, sessionId) =>
+        stored.ephemeral === undefined &&
+        TokenRepositoryLocal._LEGACY_EPHEMERAL_SUFFIX.test(sessionId)
+    );
+  }
+
+  private static _listSessions(
+    db: IDBDatabase,
+    matches: (stored: StoredToken, sessionId: string) => boolean
+  ): Promise<Result<string[]>> {
     return new Promise((resolve) => {
       try {
         const sessionIds: string[] = [];
@@ -39,19 +68,18 @@ export class TokenRepositoryLocal implements TokenRepository {
             resolve(new Ok(sessionIds));
             return;
           }
-          if ((cursor.value as StoredToken).ephemeral === true) {
-            sessionIds.push(
-              String(cursor.key).slice(TokenRepositoryLocal._KEY_PREFIX.length)
-            );
+          const sessionId = String(cursor.key).slice(
+            TokenRepositoryLocal._KEY_PREFIX.length
+          );
+          if (matches(cursor.value as StoredToken, sessionId)) {
+            sessionIds.push(sessionId);
           }
           cursor.continue();
         };
 
         request.onerror = () => {
           resolve(
-            new Err(
-              request.error ?? new Error('Unable to list ephemeral sessions')
-            )
+            new Err(request.error ?? new Error('Unable to list sessions'))
           );
         };
       } catch (e) {

--- a/web-sdk/src/data/repositories/token/token-repository-local.ts
+++ b/web-sdk/src/data/repositories/token/token-repository-local.ts
@@ -8,10 +8,12 @@ interface StoredToken {
   accessToken: string;
   refreshToken: string;
   expiresAt: number;
+  ephemeral?: boolean;
 }
 
 export class TokenRepositoryLocal implements TokenRepository {
   private static readonly _STORE_NAME = 'session';
+  private static readonly _KEY_PREFIX = 'token:';
 
   static upgrade(db: IDBDatabase): void {
     if (!db.objectStoreNames.contains(TokenRepositoryLocal._STORE_NAME)) {
@@ -19,18 +21,87 @@ export class TokenRepositoryLocal implements TokenRepository {
     }
   }
 
+  // Lists the sessions that stored an ephemeral token, so the caller can work
+  // out which of them no document owns any more. Sessions of any other mode are
+  // never reported: an anonymous shared session would lose its identity along
+  // with its token, so its record has to survive.
+  static listEphemeralSessions(db: IDBDatabase): Promise<Result<string[]>> {
+    return new Promise((resolve) => {
+      try {
+        const sessionIds: string[] = [];
+        const tx = db.transaction(TokenRepositoryLocal._STORE_NAME, 'readonly');
+        const store = tx.objectStore(TokenRepositoryLocal._STORE_NAME);
+        const request = store.openCursor();
+
+        request.onsuccess = () => {
+          const cursor = request.result;
+          if (!cursor) {
+            resolve(new Ok(sessionIds));
+            return;
+          }
+          if ((cursor.value as StoredToken).ephemeral === true) {
+            sessionIds.push(
+              String(cursor.key).slice(TokenRepositoryLocal._KEY_PREFIX.length)
+            );
+          }
+          cursor.continue();
+        };
+
+        request.onerror = () => {
+          resolve(
+            new Err(
+              request.error ?? new Error('Unable to list ephemeral sessions')
+            )
+          );
+        };
+      } catch (e) {
+        resolve(new Err(e instanceof Error ? e : new Error(String(e))));
+      }
+    });
+  }
+
+  // Deletes the tokens of the given sessions. Deleting a key that is already
+  // gone succeeds, so callers can pass sessions the sweep may have taken.
+  static clearSessions(
+    db: IDBDatabase,
+    sessionIds: string[]
+  ): Promise<Result<boolean>> {
+    return new Promise((resolve) => {
+      if (sessionIds.length === 0) {
+        resolve(new Ok(true));
+        return;
+      }
+      try {
+        const tx = db.transaction(TokenRepositoryLocal._STORE_NAME, 'readwrite');
+        const store = tx.objectStore(TokenRepositoryLocal._STORE_NAME);
+        tx.oncomplete = () => resolve(new Ok(true));
+        tx.onerror = () => {
+          resolve(new Err(tx.error ?? new Error('Unable to clear sessions')));
+        };
+        for (const sessionId of sessionIds) {
+          store.delete(`${TokenRepositoryLocal._KEY_PREFIX}${sessionId}`);
+        }
+      } catch (e) {
+        resolve(new Err(e instanceof Error ? e : new Error(String(e))));
+      }
+    });
+  }
+
   private readonly _db: IDBDatabase;
   private readonly _authService: YaloMessageAuthService;
   private readonly _key: string;
+  private readonly _ephemeral: boolean;
 
   constructor(
     db: IDBDatabase,
     sessionId: string,
-    authService: YaloMessageAuthService
+    authService: YaloMessageAuthService,
+    ephemeral: boolean = false
   ) {
     this._db = db;
     this._authService = authService;
-    this._key = `token:${sessionId}`;
+    this._key = `${TokenRepositoryLocal._KEY_PREFIX}${sessionId}`;
+    this._ephemeral = ephemeral;
   }
 
   async getToken(): Promise<Result<string>> {
@@ -94,6 +165,7 @@ export class TokenRepositoryLocal implements TokenRepository {
         accessToken: data.accessToken,
         refreshToken: data.refreshToken,
         expiresAt: Date.now() + data.expiresIn * 1000,
+        ephemeral: this._ephemeral,
       };
       const request = store.put(record, this._key);
       request.onsuccess = () => resolve();

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -150,16 +150,40 @@ export default class YaloChatWindowController implements ReactiveController {
         ),
       }))
     );
-    const abandoned = ownership
-      .filter((entry) => entry.abandoned)
-      .map((entry) => entry.sessionId);
-    if (abandoned.length === 0) {
+    await this._clearSessions(
+      db,
+      ownership.filter((entry) => entry.abandoned).map((entry) => entry.sessionId)
+    );
+  }
+
+  // Reclaims ephemeral sessions left by builds that shipped before the flag
+  // existed. Runs in every session mode, since a customer may have moved off
+  // ephemeral since, and nothing else would ever reach those records. No lock
+  // is probed because those builds took none, and an ephemeral token is
+  // disposable by design, so the worst case is one re-authentication.
+  private async _reclaimLegacyEphemeralSessions(
+    db: IDBDatabase
+  ): Promise<void> {
+    const listed = await TokenRepositoryLocal.listLegacyEphemeralSessions(db);
+    if (!listed.ok) {
+      this.host.logger.error('Unable to list legacy ephemeral sessions', {
+        error: listed.error,
+      });
       return;
     }
+    await this._clearSessions(db, listed.value);
+  }
 
+  private async _clearSessions(
+    db: IDBDatabase,
+    sessionIds: string[]
+  ): Promise<void> {
+    if (sessionIds.length === 0) {
+      return;
+    }
     const [tokens, messages] = await Promise.all([
-      TokenRepositoryLocal.clearSessions(db, abandoned),
-      ChatMessageRepositoryLocal.clearSessions(db, abandoned),
+      TokenRepositoryLocal.clearSessions(db, sessionIds),
+      ChatMessageRepositoryLocal.clearSessions(db, sessionIds),
     ]);
     if (!tokens.ok || !messages.ok) {
       this.host.logger.error('Unable to reclaim ephemeral sessions', {
@@ -167,8 +191,8 @@ export default class YaloChatWindowController implements ReactiveController {
       });
       return;
     }
-    this.host.logger.debug('Reclaimed abandoned ephemeral sessions', {
-      count: abandoned.length,
+    this.host.logger.debug('Reclaimed ephemeral sessions', {
+      count: sessionIds.length,
     });
   }
 
@@ -252,6 +276,7 @@ export default class YaloChatWindowController implements ReactiveController {
     );
     this._tokenRepository = tokenRepository;
 
+    await this._reclaimLegacyEphemeralSessions(db);
     if (isEphemeral) {
       await this._holdEphemeralLock(sessionId);
       await this._reclaimAbandonedEphemeralSessions(db);

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window-controller.ts
@@ -82,13 +82,110 @@ export default class YaloChatWindowController implements ReactiveController {
   }
 
   private _handleEphemeralPageHide = () => {
+    this.host.yaloMessageRepository.unsubscribeMessages();
+    this._disposeEphemeralSession();
+  };
+
+  private _releaseEphemeralLock?: () => void;
+
+  private static _ephemeralLockName(sessionId: string): string {
+    return `yalo-chat:ephemeral:${sessionId}`;
+  }
+
+  // Claims a lock for as long as this document lives. The browser releases it
+  // on unload, on a crash and on a tab close alike, which makes "nobody holds
+  // this lock" the signal that a session is abandoned.
+  private _holdEphemeralLock(sessionId: string): Promise<void> {
+    return new Promise((resolve) => {
+      if (navigator.locks === undefined) {
+        resolve();
+        return;
+      }
+      navigator.locks
+        .request(
+          YaloChatWindowController._ephemeralLockName(sessionId),
+          { ifAvailable: true },
+          (lock) => {
+            resolve();
+            if (lock === null) {
+              return;
+            }
+            return new Promise<void>((release) => {
+              this._releaseEphemeralLock = release;
+            });
+          }
+        )
+        .catch(() => resolve());
+    });
+  }
+
+  // Reclaims every ephemeral session no document holds a lock for. Covers the
+  // reload, the crash and the tab close in one pass, since all three release
+  // the lock while a session live in another tab keeps holding it.
+  private async _reclaimAbandonedEphemeralSessions(
+    db: IDBDatabase
+  ): Promise<void> {
+    // Without locks there is no way to tell an abandoned session apart from one
+    // a second tab is using, and guessing wrong would cut that tab off.
+    if (navigator.locks === undefined) {
+      this.host.logger.debug('Web Locks unavailable, skipping reclamation');
+      return;
+    }
+
+    const listed = await TokenRepositoryLocal.listEphemeralSessions(db);
+    if (!listed.ok) {
+      this.host.logger.error('Unable to list ephemeral sessions', {
+        error: listed.error,
+      });
+      return;
+    }
+
+    const ownership = await Promise.all(
+      listed.value.map(async (sessionId) => ({
+        sessionId,
+        abandoned: await navigator.locks.request(
+          YaloChatWindowController._ephemeralLockName(sessionId),
+          { ifAvailable: true },
+          (lock) => lock !== null
+        ),
+      }))
+    );
+    const abandoned = ownership
+      .filter((entry) => entry.abandoned)
+      .map((entry) => entry.sessionId);
+    if (abandoned.length === 0) {
+      return;
+    }
+
+    const [tokens, messages] = await Promise.all([
+      TokenRepositoryLocal.clearSessions(db, abandoned),
+      ChatMessageRepositoryLocal.clearSessions(db, abandoned),
+    ]);
+    if (!tokens.ok || !messages.ok) {
+      this.host.logger.error('Unable to reclaim ephemeral sessions', {
+        error: tokens.ok ? messages : tokens,
+      });
+      return;
+    }
+    this.host.logger.debug('Reclaimed abandoned ephemeral sessions', {
+      count: abandoned.length,
+    });
+  }
+
+  // Drops this session's messages and token before releasing the connection.
+  // Runs on every teardown path we control, since an ephemeral session must
+  // never outlive the window that created it.
+  private _disposeEphemeralSession(): void {
     const messageRepo = this.host.chatMessageRepository;
     const tokenRepo = this._tokenRepository;
-    this.host.yaloMessageRepository.unsubscribeMessages();
+    // Unmounting leaves the document alive, so the lock has to be handed back
+    // explicitly. Whatever this teardown fails to delete becomes reclaimable.
+    this._releaseEphemeralLock?.();
+    this._releaseEphemeralLock = undefined;
     Promise.all([messageRepo.clearSession(), tokenRepo?.clearSession()]).finally(
       () => messageRepo.dispose()
     );
-  };
+  }
 
   private _handleVisibilityChange = () => {
     if (document.visibilityState !== 'visible') {
@@ -146,14 +243,18 @@ export default class YaloChatWindowController implements ReactiveController {
         userId: computeEffectiveAuthUserId(this.host.config, ephemeralToken),
       }
     );
-    const tokenRepository = new TokenRepositoryLocal(db, sessionId, authService);
+    const isEphemeral = this.host.config.sessionMode === 'ephemeral';
+    const tokenRepository = new TokenRepositoryLocal(
+      db,
+      sessionId,
+      authService,
+      isEphemeral
+    );
     this._tokenRepository = tokenRepository;
 
-    if (this.host.config.sessionMode === 'ephemeral') {
-      await Promise.all([
-        this.host.chatMessageRepository.clearSession(),
-        tokenRepository.clearSession(),
-      ]);
+    if (isEphemeral) {
+      await this._holdEphemeralLock(sessionId);
+      await this._reclaimAbandonedEphemeralSessions(db);
       window.addEventListener('pagehide', this._handleEphemeralPageHide);
     }
     document.addEventListener('visibilitychange', this._handleVisibilityChange);
@@ -927,6 +1028,10 @@ export default class YaloChatWindowController implements ReactiveController {
       this._handleVisibilityChange
     );
     this.host.yaloMessageRepository.unsubscribeMessages();
+    if (this.host.config.sessionMode === 'ephemeral') {
+      this._disposeEphemeralSession();
+      return;
+    }
     this.host.chatMessageRepository.dispose();
   }
 }

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -8,6 +8,7 @@ import { ChatMessage } from '@domain/models/chat-message/chat-message';
 import { Product } from '@domain/models/product/product';
 import { Err, Ok } from '@domain/common/result';
 import { ChatMessageRepositoryLocal } from '@data/repositories/chat-message/chat-message-repository-local';
+import { TokenRepositoryLocal } from '@data/repositories/token/token-repository-local';
 import { YaloMessageRepositoryRemote } from '@data/repositories/yalo-message/yalo-message-repository-remote';
 import type { PollCallback } from '@data/repositories/yalo-message/yalo-message-repository';
 import {
@@ -115,6 +116,79 @@ const clearDb = (): Promise<void> =>
       }
     };
   });
+
+const openDb = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, 1);
+    request.onupgradeneeded = () => {
+      ChatMessageRepositoryLocal.upgrade(request.result);
+      TokenRepositoryLocal.upgrade(request.result);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const readAll = async <T>(
+  storeName: string,
+  read: (store: IDBObjectStore) => IDBRequest<T>
+): Promise<T> => {
+  const db = await openDb();
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const request = read(db.transaction(storeName).objectStore(storeName));
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+  } finally {
+    db.close();
+  }
+};
+
+// Stands in for another tab running that session. The controller reads the very
+// same lock name to decide whether a session still has an owner.
+const holdEphemeralLock = (sessionId: string): Promise<() => void> =>
+  new Promise((resolve) => {
+    navigator.locks.request(
+      `yalo-chat:ephemeral:${sessionId}`,
+      () => new Promise<void>((release) => resolve(release))
+    );
+  });
+
+const countStoredMessages = (): Promise<number> =>
+  readAll('chatMessage', (store) => store.count());
+
+const readStoredTokenKeys = (): Promise<IDBValidKey[]> =>
+  readAll('session', (store) => store.getAllKeys());
+
+// Writes what a session that went away without any teardown would leave behind:
+// an ephemeral token plus the messages it never got to clear.
+const seedEphemeralSession = async (sessionId: string): Promise<void> => {
+  const db = await openDb();
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction(['session', 'chatMessage'], 'readwrite');
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+      tx.objectStore('session').put(
+        {
+          accessToken: 'stale-access',
+          refreshToken: 'stale-refresh',
+          expiresAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
+          ephemeral: true,
+        },
+        `token:${sessionId}`
+      );
+      tx.objectStore('chatMessage').add({
+        sessionId,
+        role: 'AGENT',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        content: 'abandoned',
+      });
+    });
+  } finally {
+    db.close();
+  }
+};
 
 describe('YaloChatWindow', () => {
   let el: YaloChatWindow;
@@ -1560,6 +1634,72 @@ describe('YaloChatWindow ephemeral session mode', () => {
     await vi.waitUntil(() => fresh.yaloMessageRepository !== undefined);
 
     expect(getMessageList(fresh).chatMessages).toHaveLength(0);
+  });
+
+  it('clears the ephemeral session when the window is removed without a pagehide', async () => {
+    const clearToken = vi.spyOn(TokenRepositoryLocal.prototype, 'clearSession');
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = { ...baseConfig, sessionMode: 'ephemeral' };
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+    await el.chatMessageRepository.insertChatMessage(
+      ChatMessage.text({
+        role: 'AGENT',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        content: 'ephemeral',
+      })
+    );
+
+    el.remove();
+
+    await vi.waitUntil(() => clearToken.mock.calls.length > 0);
+    expect(await countStoredMessages()).toBe(0);
+  });
+
+  it('keeps the session when a window of any other mode is removed', async () => {
+    const clearToken = vi.spyOn(TokenRepositoryLocal.prototype, 'clearSession');
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = baseConfig;
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+    await el.chatMessageRepository.insertChatMessage(
+      ChatMessage.text({
+        role: 'AGENT',
+        timestamp: new Date('2026-01-01T00:00:00Z'),
+        content: 'persistent',
+      })
+    );
+
+    el.remove();
+
+    expect(clearToken).not.toHaveBeenCalled();
+    expect(await countStoredMessages()).toBe(1);
+  });
+
+  it('reclaims ephemeral sessions no document holds any more', async () => {
+    await seedEphemeralSession('abandoned-session');
+
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = { ...baseConfig, sessionMode: 'ephemeral' };
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+
+    expect(await readStoredTokenKeys()).not.toContain('token:abandoned-session');
+    expect(await countStoredMessages()).toBe(0);
+  });
+
+  it('keeps ephemeral sessions another document is still holding', async () => {
+    await seedEphemeralSession('live-session');
+    const release = await holdEphemeralLock('live-session');
+
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = { ...baseConfig, sessionMode: 'ephemeral' };
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+
+    expect(await readStoredTokenKeys()).toContain('token:live-session');
+    expect(await countStoredMessages()).toBe(1);
+    release();
   });
 
   it('keeps messages from other sessions intact when this session is ephemeral', async () => {

--- a/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
+++ b/web-sdk/src/ui/chat/chat-window/yalo-chat-window.test.ts
@@ -161,8 +161,12 @@ const readStoredTokenKeys = (): Promise<IDBValidKey[]> =>
   readAll('session', (store) => store.getAllKeys());
 
 // Writes what a session that went away without any teardown would leave behind:
-// an ephemeral token plus the messages it never got to clear.
-const seedEphemeralSession = async (sessionId: string): Promise<void> => {
+// a token plus the messages it never got to clear. A legacy record is one from
+// a build that predates the ephemeral flag, so it carries no flag at all.
+const seedEphemeralSession = async (
+  sessionId: string,
+  options: { legacy?: boolean } = {}
+): Promise<void> => {
   const db = await openDb();
   try {
     await new Promise<void>((resolve, reject) => {
@@ -174,7 +178,7 @@ const seedEphemeralSession = async (sessionId: string): Promise<void> => {
           accessToken: 'stale-access',
           refreshToken: 'stale-refresh',
           expiresAt: Date.now() - 30 * 24 * 60 * 60 * 1000,
-          ephemeral: true,
+          ...(options.legacy === true ? {} : { ephemeral: true }),
         },
         `token:${sessionId}`
       );
@@ -1700,6 +1704,33 @@ describe('YaloChatWindow ephemeral session mode', () => {
     expect(await readStoredTokenKeys()).toContain('token:live-session');
     expect(await countStoredMessages()).toBe(1);
     release();
+  });
+
+  it('reclaims legacy ephemeral sessions even when the mode is no longer ephemeral', async () => {
+    const legacyId = `org-1-channel-1-anonymous-${crypto.randomUUID()}`;
+    await seedEphemeralSession(legacyId, { legacy: true });
+
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = baseConfig;
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+
+    expect(await readStoredTokenKeys()).not.toContain(`token:${legacyId}`);
+    expect(await countStoredMessages()).toBe(0);
+  });
+
+  it('keeps legacy sessions that were never ephemeral', async () => {
+    await seedEphemeralSession('org-2-channel-9-anonymous', { legacy: true });
+
+    const el = document.createElement('yalo-chat-window') as YaloChatWindow;
+    el.config = baseConfig;
+    document.body.appendChild(el);
+    await vi.waitUntil(() => el.yaloMessageRepository !== undefined);
+
+    expect(await readStoredTokenKeys()).toContain(
+      'token:org-2-channel-9-anonymous'
+    );
+    expect(await countStoredMessages()).toBe(1);
   });
 
   it('keeps messages from other sessions intact when this session is ephemeral', async () => {


### PR DESCRIPTION
- Clears the messages and session tokens of orphaned previous ephemeral sessions.
- Clears legacy ephemeral sessions.